### PR TITLE
svg_loader: fix vector memory leaks.

### DIFF
--- a/src/loaders/svg/tvgSvgLoaderCommon.h
+++ b/src/loaders/svg/tvgSvgLoaderCommon.h
@@ -119,6 +119,35 @@ enum class SvgParserLengthType
 struct SvgNode;
 struct SvgStyleGradient;
 
+template<class T>
+struct SvgVector
+{
+    T* list;
+    uint32_t cnt;
+    uint32_t reserved;
+
+    void push(T element)
+    {
+        if (cnt + 1 > reserved) {
+            reserved = (cnt + 1) * 2;
+            list = static_cast<T*>(realloc(list, sizeof(T) * reserved));
+        }
+        list[cnt++] = element;
+    }
+
+    void pop()
+    {
+        if (cnt > 0) --cnt;
+    }
+
+    void clear()
+    {
+        if (list) free(list);
+        list = nullptr;
+        cnt = reserved = 0;
+    }
+};
+
 struct SvgDocNode
 {
     float w;
@@ -137,7 +166,7 @@ struct SvgGNode
 
 struct SvgDefsNode
 {
-    vector<SvgStyleGradient *> gradients;
+    SvgVector<SvgStyleGradient*> gradients;
 };
 
 struct SvgArcNode
@@ -240,7 +269,7 @@ struct SvgStyleGradient
     SvgRadialGradient* radial;
     SvgLinearGradient* linear;
     Matrix* transform;
-    vector<Fill::ColorStop *> stops;
+    SvgVector<Fill::ColorStop *> stops;
     bool userSpace;
     bool usePercentage;
 };
@@ -281,7 +310,7 @@ struct SvgNode
 {
     SvgNodeType type;
     SvgNode* parent;
-    vector<SvgNode*> child;
+    SvgVector<SvgNode*> child;
     string *id;
     SvgStyleProperty *style;
     Matrix* transform;
@@ -320,10 +349,10 @@ struct SvgParser
 
 struct SvgLoaderData
 {
-    vector<SvgNode *> stack;
+    SvgVector<SvgNode *> stack = {nullptr, 0, 0};
     SvgNode* doc = nullptr;
     SvgNode* def = nullptr;
-    vector<SvgStyleGradient*> gradients;
+    SvgVector<SvgStyleGradient*> gradients;
     SvgStyleGradient* latestGradient = nullptr; //For stops
     SvgParser* svgParse = nullptr;
     int level = 0;

--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -93,13 +93,13 @@ unique_ptr<LinearGradient> _applyLinearGradientProperty(SvgStyleGradient* g, Sha
     fillGrad->spread(g->spread);
 
     //Update the stops
-    stopCount = g->stops.size();
+    stopCount = g->stops.cnt;
     if (stopCount > 0) {
         float opacity;
         float fopacity = fillOpacity / 255.0f; //fill opacity if any exists.
-        int i = 0;
         stops = (Fill::ColorStop*)calloc(stopCount, sizeof(Fill::ColorStop));
-        for (auto colorStop : g->stops) {
+        for (uint32_t i = 0; i < g->stops.cnt; ++i) {
+            auto colorStop = g->stops.list[i];
             //Use premultiplied color
             opacity = ((float)colorStop->a / 255.0f) * fopacity;
             stops[i].r = colorStop->r * opacity;
@@ -107,7 +107,6 @@ unique_ptr<LinearGradient> _applyLinearGradientProperty(SvgStyleGradient* g, Sha
             stops[i].b = colorStop->b * opacity;
             stops[i].a = colorStop->a * fopacity;
             stops[i].offset = colorStop->offset;
-            i++;
         }
         fillGrad->colorStops(stops, stopCount);
         free(stops);
@@ -179,13 +178,13 @@ unique_ptr<RadialGradient> _applyRadialGradientProperty(SvgStyleGradient* g, Sha
     fillGrad->spread(g->spread);
 
     //Update the stops
-    stopCount = g->stops.size();
+    stopCount = g->stops.cnt;
     if (stopCount > 0) {
         float opacity;
         float fopacity = fillOpacity / 255.0f; //fill opacity if any exists.
-        int i = 0;
         stops = (Fill::ColorStop*)calloc(stopCount, sizeof(Fill::ColorStop));
-        for (auto colorStop : g->stops) {
+        for (uint32_t i = 0; i < g->stops.cnt; ++i) {
+            auto colorStop = g->stops.list[i];
             //Use premultiplied color
             opacity = ((float)colorStop->a / 255.0f) * fopacity;
             stops[i].r = colorStop->r * opacity;
@@ -193,7 +192,6 @@ unique_ptr<RadialGradient> _applyRadialGradientProperty(SvgStyleGradient* g, Sha
             stops[i].b = colorStop->b * opacity;
             stops[i].a = colorStop->a * fopacity;
             stops[i].offset = colorStop->offset;
-            i++;
         }
         fillGrad->colorStops(stops, stopCount);
         free(stops);
@@ -335,7 +333,8 @@ unique_ptr<Scene> _sceneBuildHelper(SvgNode* node, float vx, float vy, float vw,
         if (node->transform) scene->transform(*node->transform);
         node->style->opacity = (node->style->opacity * parentOpacity) / 255.0f;
         if (node->display) {
-            for (auto child : node->child) {
+            for (uint32_t i = 0; i < node->child.cnt; ++i) {
+                auto child = node->child.list[i];
                 if (child->type == SvgNodeType::Doc || child->type == SvgNodeType::G) scene->push(_sceneBuildHelper(child, vx, vy, vw, vh, node->style->opacity));
                 else {
                     child->style->opacity = (child->style->opacity * node->style->opacity) / 255.0f;


### PR DESCRIPTION
vector is designed for c++ syntaxes,
it works properly when c++ memory allocator is applied,

Here svg_loader uses c style structures which allocated using malloc()/calloc().
That brings the memory broken of stl vectors.

So, we replaced it with our customized SvgVector to easily fix it.