### PR TITLE
SvgLoader: Defs type nodes are not saved in loader's node list.

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -1963,7 +1963,8 @@ static void _svgLoaderParserXmlOpen(SvgLoaderData* loader, const char* content, 
             loader->stack.push(node);
         }
     } else if ((method = _findGraphicsFactory(tagName))) {
-        parent = loader->stack.list[loader->stack.cnt - 1];
+        if (loader->stack.cnt > 0) parent = loader->stack.list[loader->stack.cnt - 1];
+        else parent = loader->doc;
         node = method(loader, parent, attrs, attrsLength);
     } else if ((gradientMethod = _findGradientFactory(tagName))) {
         SvgStyleGradient* gradient;

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -1955,11 +1955,12 @@ static void _svgLoaderParserXmlOpen(SvgLoaderData* loader, const char* content, 
             if (loader->stack.cnt > 0) parent = loader->stack.list[loader->stack.cnt - 1];
             node = method(loader, parent, attrs, attrsLength);
         }
-        loader->stack.push(node);
 
         if (node->type == SvgNodeType::Defs) {
             loader->doc->node.doc.defs = node;
             loader->def = node;
+        } else {
+            loader->stack.push(node);
         }
     } else if ((method = _findGraphicsFactory(tagName))) {
         parent = loader->stack.list[loader->stack.cnt - 1];


### PR DESCRIPTION
If there is an empty (unused) <defs /> inside the svg file, this can cause problems.
<defs> node is managed separately in loader->def.
So it doesn't have to be added to loader's list.