### PR TITLE
Fix svg loader's segfualt

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -1458,8 +1458,6 @@ static void _cloneNode(SvgNode* from, SvgNode* parent)
     for (uint32_t i = 0; i < from->child.cnt; ++i, ++child) {
         _cloneNode(*child, newNode);
     }
-
-    _freeNode(newNode);
 }
 
 

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -30,7 +30,6 @@
 
 typedef SvgNode* (*FactoryMethod)(SvgLoaderData* loader, SvgNode* parent, const char* buf, unsigned bufLength);
 typedef SvgStyleGradient* (*GradientFactoryMethod)(SvgLoaderData* loader, const char* buf, unsigned bufLength);
-static void _freeNode(SvgNode* node);
 
 
 static char* _skipSpace(const char* str, const char* end)

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -1917,7 +1917,7 @@ static void _svgLoaderParerXmlClose(SvgLoaderData* loader, const char* content)
 }
 
 
-static void _svgLoaderParserXmlOpen(SvgLoaderData* loader, const char* content, unsigned int length)
+static void _svgLoaderParserXmlOpen(SvgLoaderData* loader, const char* content, unsigned int length, bool empty)
 {
     const char* attrs = nullptr;
     int attrsLength = 0;
@@ -1953,12 +1953,14 @@ static void _svgLoaderParserXmlOpen(SvgLoaderData* loader, const char* content, 
         } else {
             if (!strcmp(tagName, "svg")) return; //Already loadded <svg>(SvgNodeType::Doc) tag
             if (loader->stack.cnt > 0) parent = loader->stack.list[loader->stack.cnt - 1];
+            else parent = loader->doc;
             node = method(loader, parent, attrs, attrsLength);
         }
 
         if (node->type == SvgNodeType::Defs) {
             loader->doc->node.doc.defs = node;
             loader->def = node;
+            if (!empty) loader->stack.push(node);
         } else {
             loader->stack.push(node);
         }
@@ -2000,11 +2002,11 @@ static bool _svgLoaderParser(void* data, SimpleXMLType type, const char* content
 
     switch (type) {
         case SimpleXMLType::Open: {
-            _svgLoaderParserXmlOpen(loader, content, length);
+            _svgLoaderParserXmlOpen(loader, content, length, false);
             break;
         }
         case SimpleXMLType::OpenEmpty: {
-            _svgLoaderParserXmlOpen(loader, content, length);
+            _svgLoaderParserXmlOpen(loader, content, length, true);
             break;
         }
         case SimpleXMLType::Close: {


### PR DESCRIPTION
In several cases of svg loaders, segfaults have occurred.
most cases, it refers to wrong node.
These two commits are fixed to refer to the correct node.