### PR TITLE
SvgLoader: Support DashArray attribute for stroke

### DIFF
--- a/src/loaders/svg/tvgSvgLoaderCommon.h
+++ b/src/loaders/svg/tvgSvgLoaderCommon.h
@@ -256,8 +256,7 @@ struct SvgPaint
 
 struct SvgDash
 {
-    float length;
-    float gap;
+    SvgVector<float> array;
 };
 
 struct SvgStyleGradient
@@ -292,7 +291,7 @@ struct SvgStyleStroke
     float centered;
     StrokeCap cap;
     StrokeJoin join;
-    SvgDash* dash;
+    SvgDash dash;
     int dashCount;
 };
 

--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -235,7 +235,8 @@ void _applyProperty(SvgNode* node, Shape* vg, float vx, float vy, float vw, floa
     vg->stroke(style->stroke.width);
     vg->stroke(style->stroke.cap);
     vg->stroke(style->stroke.join);
-
+    if (style->stroke.dash.array.cnt > 0)
+        vg->stroke(style->stroke.dash.array.list, style->stroke.dash.array.cnt);
 
     //If stroke property is nullptr then do nothing
     if (style->stroke.paint.none) {


### PR DESCRIPTION
It supports stroke-dasharray, one of the stroke properties of svg.
https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-dasharray