### PR TITLE
sw_engine: the check if the stroke width > 0 after conversion its val…

### DIFF
--- a/src/lib/sw_engine/tvgSwRenderer.cpp
+++ b/src/lib/sw_engine/tvgSwRenderer.cpp
@@ -41,7 +41,7 @@ struct SwTask : Task
         //Valid Stroking?
         uint8_t strokeAlpha = 0;
         auto strokeWidth = sdata->strokeWidth();
-        if (strokeWidth > FLT_EPSILON) {
+        if (TO_SWCOORD(strokeWidth * 0.5) > 0) {
             sdata->strokeColor(nullptr, nullptr, nullptr, &strokeAlpha);
         }
 


### PR DESCRIPTION
the check if the stroke width > 0 after conversion its value from float to long

If the width value after conversion to long was 0, the bbox size was undefined.