### PR TITLE
sw_engine: fix shape rendering skip issue.

### DIFF
--- a/src/lib/sw_engine/tvgSwRenderer.cpp
+++ b/src/lib/sw_engine/tvgSwRenderer.cpp
@@ -138,23 +138,32 @@ bool SwRenderer::target(uint32_t* buffer, uint32_t stride, uint32_t w, uint32_t 
 
 bool SwRenderer::preRender()
 {
-    rasterClear(surface);
+    return rasterClear(surface);
+}
 
-    //before we start rendering, we should finish all preparing tasks
-    for (auto task : tasks) {
-        task->get();
 
-        uint8_t r, g, b, a;
-        if (auto fill = task->sdata->fill()) {
-            rasterGradientShape(surface, &task->shape, fill->id());
-        } else{
-            task->sdata->fill(&r, &g, &b, &a);
-            if (a > 0) rasterSolidShape(surface, &task->shape, r, g, b, a);
-        }
-        task->sdata->strokeColor(&r, &g, &b, &a);
-        if (a > 0) rasterStroke(surface, &task->shape, r, g, b, a);
-    }
+bool SwRenderer::postRender()
+{
     tasks.clear();
+
+    return true;
+}
+
+
+bool SwRenderer::render(const Shape& shape, void *data)
+{
+    auto task = static_cast<SwTask*>(data);
+    task->get();
+
+    uint8_t r, g, b, a;
+    if (auto fill = task->sdata->fill()) {
+        rasterGradientShape(surface, &task->shape, fill->id());
+    } else{
+        task->sdata->fill(&r, &g, &b, &a);
+        if (a > 0) rasterSolidShape(surface, &task->shape, r, g, b, a);
+    }
+    task->sdata->strokeColor(&r, &g, &b, &a);
+    if (a > 0) rasterStroke(surface, &task->shape, r, g, b, a);
 
     return true;
 }

--- a/src/lib/sw_engine/tvgSwRenderer.h
+++ b/src/lib/sw_engine/tvgSwRenderer.h
@@ -34,8 +34,10 @@ public:
     void* prepare(const Shape& shape, void* data, const RenderTransform* transform, RenderUpdateFlag flags) override;
     bool dispose(const Shape& shape, void *data) override;
     bool preRender() override;
+    bool postRender() override;
     bool target(uint32_t* buffer, uint32_t stride, uint32_t w, uint32_t h, uint32_t cs);
     bool clear() override;
+    bool render(const Shape& shape, void *data) override;
 
     static SwRenderer* gen();
     static bool init();

--- a/test/testDirectUpdate.cpp
+++ b/test/testDirectUpdate.cpp
@@ -9,6 +9,15 @@ void tvgDrawCmds(tvg::Canvas* canvas)
 {
     if (!canvas) return;
 
+    //Shape (for BG)
+    auto bg = tvg::Shape::gen();
+    bg->appendRect(0, 0, WIDTH, HEIGHT, 0, 0);
+
+    //fill property will be retained
+    bg->fill(255, 255, 255, 255);
+
+    if (canvas->push(move(bg)) != tvg::Result::Success) return;
+
     //Shape
     auto shape = tvg::Shape::gen();
 


### PR DESCRIPTION
tvg canvas must draw retained shapes for every draw call
even though user missed call update() for shapes.

that case canvs must draw shapes without update,
it means drawing them within previous condition.