### PR TITLE
SvgLoader: Supports case when only rx or ry is declared

### DIFF
--- a/src/loaders/svg/tvgSvgLoaderCommon.h
+++ b/src/loaders/svg/tvgSvgLoaderCommon.h
@@ -196,6 +196,8 @@ struct SvgRectNode
     float h;
     float rx;
     float ry;
+    bool hasRx;
+    bool hasRy;
 };
 
 struct SvgLineNode


### PR DESCRIPTION
In relation to the declaration of rx and ry attribute of rect, the following three cases occur.
rx="10" (or ry="10")
rx="10" ry = "0" (or rx="0" ry = "10")
rx="10" ry = "10"
To cover these case, we check the rx and ry declarations.