### PR TITLE
svg_loader: fixing issues with a A/a command

### DIFF
--- a/src/loaders/svg/tvgSvgPath.cpp
+++ b/src/loaders/svg/tvgSvgPath.cpp
@@ -44,12 +44,14 @@ static bool _parseNumber(char** content, float* number)
 }
 
 
-static bool _parseLong(char** content, int* number)
+static bool _parseFlag(char** content, int* number)
 {
     char* end = NULL;
-    *number = strtol(*content, &end, 10) ? 1 : 0;
-    //If the start of string is not number
-    if ((*content) == end) return false;
+    *number = strtol(*content, &end, 10);
+    //If the start of string is not number or a number was a float
+    if ((*content) == end || *end == '.') return false;
+    //If a flag has a different value than 0 or 1
+    if (*number != 0 && *number != 1) return false;
     *content = _skipComma(end);
     return true;
 }
@@ -463,8 +465,8 @@ static char* _nextCommand(char* path, char* cmd, float* arr, int* count)
         if (_parseNumber(&path, &arr[0])) {
             if (_parseNumber(&path, &arr[1])) {
                 if (_parseNumber(&path, &arr[2])) {
-                    if (_parseLong(&path, &large)) {
-                        if (_parseLong(&path, &sweep)) {
+                    if (_parseFlag(&path, &large)) {
+                        if (_parseFlag(&path, &sweep)) {
                             if (_parseNumber(&path, &arr[5])) {
                                 if (_parseNumber(&path, &arr[6])) {
                                     arr[3] = large;


### PR DESCRIPTION
1. Cmd 'A' from an svg path should not be connected with any other commands via the control points. -> changes moved to #42

2. When the sweep flag is given as a float it draws an elliptic arc different from what the user intended.

Right now if large_arc is given as a float, the 'A' command won't be plotted at all (and nothing after it). _parseLong function called for the first time will read only the part of a float until the dot character. The second call of this function will return 'false', since the strtol function finds a dot as the first char in a given string. This is the desired behavior.

If sweep is given as a float, the svg path will be plotted until a new cmd will occur (a new letter in an svg path). It's because after the second _parseLong call there is a _parseNumber call, which knows how to deal with a number starting with a point. 
So for example:
A 3 3 3 0 1.0 4 4
will be interpreted as: 
A 3 3 3 0 1 0 4 
with one number (4) still left for further interpretation.
So, the whole 'A' command will be plotted, but not in a way, that was intended. 