### PR TITLE
Fixing issues with a A/a command

### DIFF
--- a/src/loaders/svg/tvgSvgPath.cpp
+++ b/src/loaders/svg/tvgSvgPath.cpp
@@ -435,7 +435,8 @@ static void _processCommand(vector<PathCommand>* cmds, vector<Point>* pts, char 
         case 'a':
         case 'A': {
             _pathAppendArcTo(cmds, pts, cur, curCtl, arr[5], arr[6], arr[0], arr[1], arr[2], arr[3], arr[4]);
-            *cur = {arr[5] ,arr[6]};
+            *cur = *curCtl = {arr[5] ,arr[6]};
+            *isQuadratic = false;
             break;
         }
         default: {


### PR DESCRIPTION
Cmd 'A' from an svg path should not be connected with any other commands via the control points.

This change will be excluded from #25 