### PR TITLE
shape: added duplicate api.

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -210,6 +210,8 @@ class TVG_EXPORT Shape final : public Paint
 public:
     ~Shape();
 
+    Result duplicate(std::unique_ptr<tvg::Shape>& shape);
+    Result duplicate(Shape* from); //For CAPI binding
     Result reset() noexcept;
 
     //Path

--- a/inc/thorvg_capi.h
+++ b/inc/thorvg_capi.h
@@ -127,6 +127,7 @@ TVG_EXPORT Tvg_Result tvg_paint_transform(Tvg_Paint* paint, const Tvg_Matrix* m)
 /************************************************************************/
 TVG_EXPORT Tvg_Paint* tvg_shape_new();
 TVG_EXPORT Tvg_Result tvg_shape_reset(Tvg_Paint* paint);
+TVG_EXPORT Tvg_Result tvg_shape_duplicate(Tvg_Paint* paint, Tvg_Paint* from);
 TVG_EXPORT Tvg_Result tvg_shape_move_to(Tvg_Paint* paint, float x, float y);
 TVG_EXPORT Tvg_Result tvg_shape_line_to(Tvg_Paint* paint, float x, float y);
 TVG_EXPORT Tvg_Result tvg_shape_cubic_to(Tvg_Paint* paint, float cx1, float cy1, float cx2, float cy2, float x, float y);

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -195,6 +195,12 @@ TVG_EXPORT Tvg_Paint* tvg_shape_new()
 }
 
 
+TVG_EXPORT Tvg_Result tvg_shape_duplicate(Tvg_Paint* paint, Tvg_Paint* from)
+{
+    if (!paint || !from) return TVG_RESULT_INVALID_ARGUMENT;
+    return (Tvg_Result) reinterpret_cast<Shape*>(paint)->duplicate(reinterpret_cast<Shape*>(from));
+}
+
 TVG_EXPORT Tvg_Result tvg_shape_reset(Tvg_Paint* paint)
 {
     if (!paint) return TVG_RESULT_INVALID_ARGUMENT;

--- a/src/lib/tvgShape.cpp
+++ b/src/lib/tvgShape.cpp
@@ -48,6 +48,17 @@ unique_ptr<Shape> Shape::gen() noexcept
     return unique_ptr<Shape>(new Shape);
 }
 
+Result Shape::duplicate(unique_ptr<Shape>& shape)
+{
+    IMPL->duplicate(shape.get());
+    return Result::Success;
+}
+
+Result Shape::duplicate(Shape* from)
+{
+    IMPL->duplicate(from);
+    return Result::Success;
+}
 
 Result Shape::reset() noexcept
 {

--- a/test/makefile
+++ b/test/makefile
@@ -21,4 +21,5 @@ all:
 	gcc -o testAsync testAsync.cpp -g -lstdc++ `pkg-config --cflags --libs elementary thorvg`
 	gcc -o testArc testArc.cpp -g -lstdc++ `pkg-config --cflags --libs elementary thorvg`
 	gcc -o testMultiCanvas testMultiCanvas.cpp -g -lstdc++ `pkg-config --cflags --libs elementary thorvg`
+	gcc -o testDuplicate testDuplicate.cpp -g -lstdc++ `pkg-config --cflags --libs elementary thorvg`
 	gcc -o testCapi testCapi.c -g `pkg-config --cflags --libs elementary thorvg`

--- a/test/testCapi.c
+++ b/test/testCapi.c
@@ -119,6 +119,18 @@ void testCapi()
     tvg_shape_set_stroke_color(shape, 125, 0, 125, 255);
     tvg_canvas_update_paint(canvas, shape);
 
+    //Origin paint for duplicated
+    Tvg_Paint* org = tvg_shape_new();
+    tvg_shape_append_rect(org, 550, 10, 100, 100, 0, 0);
+    tvg_shape_set_stroke_width(org, 3);
+    tvg_shape_set_stroke_color(org, 255, 0, 0, 255);
+    tvg_shape_fill_color(org, 0, 255, 0, 255);
+
+    //Duplicated paint test - should copy rectangle parameters from origin
+    Tvg_Paint* dup = tvg_shape_new();
+    tvg_shape_duplicate(dup, org);
+    tvg_canvas_push(canvas, dup);
+
     tvg_canvas_draw(canvas);
     tvg_canvas_sync(canvas);
 

--- a/test/testDuplicate.cpp
+++ b/test/testDuplicate.cpp
@@ -1,0 +1,150 @@
+#include "testCommon.h"
+
+/************************************************************************/
+/* Drawing Commands                                                     */
+/************************************************************************/
+
+void tvgDrawCmds(tvg::Canvas* canvas)
+{
+    if (!canvas) return;
+
+    //Prepare first shape, which will not be drawn
+    auto shape1 = tvg::Shape::gen();
+    shape1->appendRect(10, 10, 200, 200, 0, 0);
+    shape1->appendRect(220, 10, 100, 100, 0, 0);
+    
+    shape1->stroke(3); 
+    shape1->stroke(0, 255, 0, 255);
+
+    float dashPattern[2] = {4, 4};
+    shape1->stroke(dashPattern, 2);
+
+    shape1->fill(255, 0, 0, 255);
+
+    //Create second shape and duplicate parameters
+    auto shape2 = tvg::Shape::gen();
+    shape2->duplicate(shape1);
+
+    //Create third shape, duplicate from first and add some new parameters
+    auto shape3 = tvg::Shape::gen(); 
+    shape3->duplicate(shape1);
+
+
+    //move shape3 to new postion to don't cover second shape
+    shape3->translate(0, 220);
+
+    //append new paths 
+    shape3->appendRect(340, 10, 100, 100, 0, 0);
+    shape3->fill(0, 0, 255, 255);
+
+    //TODO: test gradient
+
+    canvas->push(move(shape2));
+    canvas->push(move(shape3));
+}
+
+
+/************************************************************************/
+/* Sw Engine Test Code                                                  */
+/************************************************************************/
+
+static unique_ptr<tvg::SwCanvas> swCanvas;
+
+void tvgSwTest(uint32_t* buffer)
+{
+    //Create a Canvas
+    swCanvas = tvg::SwCanvas::gen();
+    swCanvas->target(buffer, WIDTH, WIDTH, HEIGHT, tvg::SwCanvas::ARGB8888);
+
+    /* Push the shape into the Canvas drawing list
+       When this shape is into the canvas list, the shape could update & prepare
+       internal data asynchronously for coming rendering.
+       Canvas keeps this shape node unless user call canvas->clear() */
+    tvgDrawCmds(swCanvas.get());
+}
+
+void drawSwView(void* data, Eo* obj)
+{
+    if (swCanvas->draw() == tvg::Result::Success) {
+        swCanvas->sync();
+    }
+}
+
+
+/************************************************************************/
+/* GL Engine Test Code                                                  */
+/************************************************************************/
+
+static unique_ptr<tvg::GlCanvas> glCanvas;
+
+void initGLview(Evas_Object *obj)
+{
+    static constexpr auto BPP = 4;
+
+    //Create a Canvas
+    glCanvas = tvg::GlCanvas::gen();
+    glCanvas->target(nullptr, WIDTH * BPP, WIDTH, HEIGHT);
+
+    /* Push the shape into the Canvas drawing list
+       When this shape is into the canvas list, the shape could update & prepare
+       internal data asynchronously for coming rendering.
+       Canvas keeps this shape node unless user call canvas->clear() */
+    tvgDrawCmds(glCanvas.get());
+}
+
+void drawGLview(Evas_Object *obj)
+{
+    auto gl = elm_glview_gl_api_get(obj);
+    gl->glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+    gl->glClear(GL_COLOR_BUFFER_BIT);
+
+    if (glCanvas->draw() == tvg::Result::Success) {
+        glCanvas->sync();
+    }
+}
+
+
+/************************************************************************/
+/* Main Code                                                            */
+/************************************************************************/
+
+int main(int argc, char **argv)
+{
+    tvg::CanvasEngine tvgEngine = tvg::CanvasEngine::Sw;
+
+    if (argc > 1) {
+        if (!strcmp(argv[1], "gl")) tvgEngine = tvg::CanvasEngine::Gl;
+    }
+
+    //Initialize ThorVG Engine
+    if (tvgEngine == tvg::CanvasEngine::Sw) {
+        cout << "tvg engine: software" << endl;
+    } else {
+        cout << "tvg engine: opengl" << endl;
+    }
+
+    //Threads Count
+    auto threads = std::thread::hardware_concurrency();
+
+    //Initialize ThorVG Engine
+    if (tvg::Initializer::init(tvgEngine, threads) == tvg::Result::Success) {
+
+        elm_init(argc, argv);
+
+        if (tvgEngine == tvg::CanvasEngine::Sw) {
+            createSwView();
+        } else {
+            createGlView();
+        }
+
+        elm_run();
+        elm_shutdown();
+
+        //Terminate ThorVG Engine
+        tvg::Initializer::term(tvgEngine);
+
+    } else {
+        cout << "engine is not supported" << endl;
+    }
+    return 0;
+}


### PR DESCRIPTION
Changes:
1. New shape->duplicate(Shape *from) api.
2. New example: testDuplicate
3. Added capi binding for duploicate api
4. Added capi duplication test in testCapi.c

Description:
Added implementation of duplicate api. Duplicate copies content of Shape *from object to newly created shape. Parameters (stroke, path etc) stored so far in origin object will be replaced by new values. 

TODO:
Implement gradient properties duplication