### PR TITLE
SvgLoader: Fix wrong display when dasharray size is 1

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -233,13 +233,14 @@ _parseDashArray(const char *str, SvgDash* dash)
 {
    char *end = nullptr;
 
-   while (*str)
-     {
+   while (*str) {
         // skip white space, comma
         str = _skipComma(str);
         (*dash).array.push(strtof(str, &end));
         str = _skipComma(end);
-     }
+   }
+   //If dash array size is 1, it means that dash and gap size are the same.
+   if ((*dash).array.cnt == 1) (*dash).array.push((*dash).array.list[0]);
 }
 
 static string* _idFromUrl(const char* url)


### PR DESCRIPTION
If dash array size is 1, it means that dash and gap size are the same.

#47 