### PR TITLE
sw_engine: fix build warning

### DIFF
--- a/src/lib/sw_engine/tvgSwFill.cpp
+++ b/src/lib/sw_engine/tvgSwFill.cpp
@@ -151,7 +151,7 @@ bool _prepareRadial(SwFill* fill, const RadialGradient* radial, const Matrix* tr
         //FIXME; Scale + Rotation is not working properly
         radius *= sx;
 
-        if (fabsf(sx - sy) > FLT_EPSILON) {
+        if (abs(sx - sy) > FLT_EPSILON) {
             fill->sx = sx;
             fill->sy = sy;
         }
@@ -240,7 +240,7 @@ void fillFetchLinear(const SwFill* fill, uint32_t* dst, uint32_t y, uint32_t x, 
     float t = (fill->linear.dx * rx + fill->linear.dy * ry + fill->linear.offset) * (GRADIENT_STOP_SIZE - 1);
     float inc = (fill->linear.dx) * (GRADIENT_STOP_SIZE - 1);
 
-    if (fabsf(inc) < FLT_EPSILON) {
+    if (abs(inc) < FLT_EPSILON) {
         auto color = _fixedPixel(fill, static_cast<int32_t>(t * FIXPT_SIZE));
         rasterRGBA32(dst, color, offset, len);
         return;


### PR DESCRIPTION
warning: absolute value function 'fabsf' given an argument of type 'double' but has parameter of type 'float' which may cause truncation of value [-Wabsolute-value]