### PR TITLE
capi: code refactoring 

### DIFF
--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -54,13 +54,13 @@ struct _Tvg_Gradient
 
 TVG_EXPORT Tvg_Result tvg_engine_init(unsigned engine_method, unsigned threads)
 {
-    return (Tvg_Result) tvg::Initializer::init(tvg::CanvasEngine(engine_method), threads);
+    return (Tvg_Result) Initializer::init(CanvasEngine(engine_method), threads);
 }
 
 
 TVG_EXPORT Tvg_Result tvg_engine_term(unsigned engine_method)
 {
-    return (Tvg_Result) tvg::Initializer::term(tvg::CanvasEngine(engine_method));
+    return (Tvg_Result) Initializer::term(CanvasEngine(engine_method));
 }
 
 /************************************************************************/

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -52,25 +52,15 @@ struct _Tvg_Gradient
 /* Engine API                                                           */
 /************************************************************************/
 
-TVG_EXPORT Tvg_Result tvg_engine_init(unsigned engine_method, unsigned threads) {
-    Result ret = Result::Success;
-
-    if (engine_method & TVG_ENGINE_SW) ret = tvg::Initializer::init(tvg::CanvasEngine::Sw, threads);
-    if (ret != Result::Success) return (Tvg_Result) ret;
-
-    if (engine_method & TVG_ENGINE_GL) ret = tvg::Initializer::init(tvg::CanvasEngine::Gl, threads);
-    return (Tvg_Result) ret;
+TVG_EXPORT Tvg_Result tvg_engine_init(unsigned engine_method, unsigned threads)
+{
+    return (Tvg_Result) tvg::Initializer::init(tvg::CanvasEngine(engine_method), threads);
 }
 
 
-TVG_EXPORT Tvg_Result tvg_engine_term(unsigned engine_method) {
-    Result ret = Result::Success;
-
-    if (engine_method & TVG_ENGINE_SW) ret = tvg::Initializer::term(tvg::CanvasEngine::Sw);
-    if (ret != Result::Success) return (Tvg_Result) ret;
-
-    if (engine_method & TVG_ENGINE_GL) ret = tvg::Initializer::term(tvg::CanvasEngine::Gl);
-    return (Tvg_Result) ret;
+TVG_EXPORT Tvg_Result tvg_engine_term(unsigned engine_method)
+{
+    return (Tvg_Result) tvg::Initializer::term(tvg::CanvasEngine(engine_method));
 }
 
 /************************************************************************/


### PR DESCRIPTION
init/term method allows mixing enum values,
we don't need to call them separatetly.