### PR TITLE
SwRender & tvgPaint: Implement ClipPath feature

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -56,6 +56,7 @@ enum class TVG_EXPORT PathCommand { Close = 0, MoveTo, LineTo, CubicTo };
 enum class TVG_EXPORT StrokeCap { Square = 0, Round, Butt };
 enum class TVG_EXPORT StrokeJoin { Bevel = 0, Round, Miter };
 enum class TVG_EXPORT FillSpread { Pad = 0, Reflect, Repeat };
+enum class TVG_EXPORT CompMethod { None = 0, ClipPath };
 enum class TVG_EXPORT CanvasEngine { Sw = (1 << 1), Gl = (1 << 2)};
 
 
@@ -90,8 +91,13 @@ public:
     Result scale(float factor) noexcept;
     Result translate(float x, float y) noexcept;
     Result transform(const Matrix& m) noexcept;
+    Matrix transform() noexcept;
     Result bounds(float* x, float* y, float* w, float* h) const noexcept;
     Paint* duplicate() const noexcept;
+
+    Result composite(std::unique_ptr<Paint> comp, CompMethod methd) const noexcept;
+    Paint* composite() const noexcept;
+    CompMethod compositeMethod() const noexcept;
 
     _TVG_DECLARE_ACCESSOR();
     _TVG_DECLARE_PRIVATE(Paint);

--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -91,13 +91,10 @@ public:
     Result scale(float factor) noexcept;
     Result translate(float x, float y) noexcept;
     Result transform(const Matrix& m) noexcept;
-    Matrix transform() noexcept;
     Result bounds(float* x, float* y, float* w, float* h) const noexcept;
     Paint* duplicate() const noexcept;
 
     Result composite(std::unique_ptr<Paint> comp, CompMethod methd) const noexcept;
-    Paint* composite() const noexcept;
-    CompMethod compositeMethod() const noexcept;
 
     _TVG_DECLARE_ACCESSOR();
     _TVG_DECLARE_PRIVATE(Paint);

--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -94,7 +94,7 @@ public:
     Result bounds(float* x, float* y, float* w, float* h) const noexcept;
     Paint* duplicate() const noexcept;
 
-    Result composite(std::unique_ptr<Paint> target, CompMethod methd) const noexcept;
+    Result composite(std::unique_ptr<Paint> target, CompMethod method) const noexcept;
 
     _TVG_DECLARE_ACCESSOR();
     _TVG_DECLARE_PRIVATE(Paint);

--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -94,7 +94,7 @@ public:
     Result bounds(float* x, float* y, float* w, float* h) const noexcept;
     Paint* duplicate() const noexcept;
 
-    Result composite(std::unique_ptr<Paint> comp, CompMethod methd) const noexcept;
+    Result composite(std::unique_ptr<Paint> target, CompMethod methd) const noexcept;
 
     _TVG_DECLARE_ACCESSOR();
     _TVG_DECLARE_PRIVATE(Paint);

--- a/src/examples/meson.build
+++ b/src/examples/meson.build
@@ -26,6 +26,7 @@ source_file = [
     'testSvg.cpp',
     'testTransform.cpp',
     'testUpdate.cpp',
+    'testClipPath.cpp',
 ]
 
 foreach current_file : source_file

--- a/src/examples/testClipPath.cpp
+++ b/src/examples/testClipPath.cpp
@@ -41,6 +41,13 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     //Move Star1
     star1->translate(-10, -10);
 
+    auto clipStar = tvg::Shape::gen();
+    clipStar->appendCircle(200, 230, 110, 110);
+    clipStar->fill(255, 255, 255, 255); // clip object must have alpha.
+    clipStar->translate(10, 10);
+
+    star1->composite(move(clipStar), tvg::CompMethod::ClipPath);
+
     auto star2 = tvg::Shape::gen();
     tvgDrawStar(star2.get());
     star2->fill(0, 255, 255, 64);
@@ -52,6 +59,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
 
     auto clip = tvg::Shape::gen();
     clip->appendCircle(200, 230, 130, 130);
+    clip->fill(255, 255, 255, 255); // clip object must have alpha.
     clip->translate(10, 10);
 
     scene->push(move(star1));
@@ -72,7 +80,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
 
     auto clipRect = tvg::Shape::gen();
     clipRect->appendRect(480, 110, 200, 200, 0, 0);          //x, y, w, h, rx, ry
-    clipRect->fill(255, 0, 255, 255);                    //r, g, b, a
+    clipRect->fill(255, 255, 255, 255); // clip object must have alpha.
     clipRect->translate(20, 20);
 
     //Clipping scene to rect(shape)
@@ -95,7 +103,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     auto clipPath = tvg::Shape::gen();
     clipPath->appendCircle(350, 510, 110, 110);          //x, y, w, h, rx, ry
     clipPath->appendCircle(350, 650, 50, 50);          //x, y, w, h, rx, ry
-    clipPath->fill(255, 0, 255, 255);                    //r, g, b, a
+    clipPath->fill(255, 255, 255, 255); // clip object must have alpha.
     clipPath->translate(20, 20);
 
     //Clipping picture to path

--- a/src/examples/testClipPath.cpp
+++ b/src/examples/testClipPath.cpp
@@ -1,0 +1,214 @@
+#include "testCommon.h"
+
+/************************************************************************/
+/* Drawing Commands                                                     */
+/************************************************************************/
+
+void tvgDrawStar(tvg::Shape* star)
+{
+    star->moveTo(199, 34);
+    star->lineTo(253, 143);
+    star->lineTo(374, 160);
+    star->lineTo(287, 244);
+    star->lineTo(307, 365);
+    star->lineTo(199, 309);
+    star->lineTo(97, 365);
+    star->lineTo(112, 245);
+    star->lineTo(26, 161);
+    star->lineTo(146, 143);
+    star->close();
+}
+
+void tvgDrawCmds(tvg::Canvas* canvas)
+{
+    if (!canvas) return;
+    //Background
+    auto shape = tvg::Shape::gen();
+    shape->appendRect(0, 0, WIDTH, HEIGHT, 0, 0);
+    shape->fill(255, 255, 255, 255);
+    if (canvas->push(move(shape)) != tvg::Result::Success) return;
+
+    //////////////////////////////////////////////
+    auto scene = tvg::Scene::gen();
+    scene->reserve(2);
+
+    auto star1 = tvg::Shape::gen();
+    tvgDrawStar(star1.get());
+    star1->fill(255, 255, 0, 255);
+    star1->stroke(255 ,0, 0, 128);
+    star1->stroke(10);
+
+    //Move Star1
+    star1->translate(-10, -10);
+
+    auto star2 = tvg::Shape::gen();
+    tvgDrawStar(star2.get());
+    star2->fill(0, 255, 255, 64);
+    star2->stroke(0 ,255, 0, 128);
+    star2->stroke(10);
+
+    //Move Star2
+    star2->translate(10, 40);
+
+    auto clip = tvg::Shape::gen();
+    clip->appendCircle(200, 230, 130, 130);
+    clip->translate(10, 10);
+
+    scene->push(move(star1));
+    scene->push(move(star2));
+
+    //Clipping scene to shape
+    scene->composite(move(clip), tvg::CompMethod::ClipPath);
+
+    canvas->push(move(scene));
+
+    //////////////////////////////////////////////
+    auto star3 = tvg::Shape::gen();
+    tvgDrawStar(star3.get());
+    star3->translate(400, 0);
+    star3->fill(255, 255, 0, 255);                    //r, g, b, a
+    star3->stroke(255 ,0, 0, 128);
+    star3->stroke(10);
+
+    auto clipRect = tvg::Shape::gen();
+    clipRect->appendRect(480, 110, 200, 200, 0, 0);          //x, y, w, h, rx, ry
+    clipRect->fill(255, 0, 255, 255);                    //r, g, b, a
+    clipRect->translate(20, 20);
+
+    //Clipping scene to rect(shape)
+    star3->composite(move(clipRect), tvg::CompMethod::ClipPath);
+
+    canvas->push(move(star3));
+
+
+
+    //////////////////////////////////////////////
+    auto picture = tvg::Picture::gen();
+    char buf[PATH_MAX];
+    sprintf(buf,"%s/cartman.svg", EXAMPLE_DIR);
+
+    if (picture->load(buf) != tvg::Result::Success) return;
+
+    picture->scale(3);
+    picture->translate(200, 400);
+
+    auto clipPath = tvg::Shape::gen();
+    clipPath->appendCircle(350, 510, 110, 110);          //x, y, w, h, rx, ry
+    clipPath->appendCircle(350, 650, 50, 50);          //x, y, w, h, rx, ry
+    clipPath->fill(255, 0, 255, 255);                    //r, g, b, a
+    clipPath->translate(20, 20);
+
+    //Clipping picture to path
+    picture->composite(move(clipPath), tvg::CompMethod::ClipPath);
+
+    canvas->push(move(picture));
+
+
+    //canvas->push(move(shape2));
+}
+
+
+/************************************************************************/
+/* Sw Engine Test Code                                                  */
+/************************************************************************/
+
+unique_ptr<tvg::SwCanvas> swCanvas;
+
+void tvgSwTest(uint32_t* buffer)
+{
+    //Create a Canvas
+    swCanvas = tvg::SwCanvas::gen();
+    swCanvas->target(buffer, WIDTH, WIDTH, HEIGHT, tvg::SwCanvas::ARGB8888);
+
+    /* Push the shape into the Canvas drawing list
+       When this shape is into the canvas list, the shape could update & prepare
+       internal data asynchronously for coming rendering.
+       Canvas keeps this shape node unless user call canvas->clear() */
+    tvgDrawCmds(swCanvas.get());
+}
+
+void drawSwView(void* data, Eo* obj)
+{
+    if (swCanvas->draw() == tvg::Result::Success) {
+        swCanvas->sync();
+    }
+}
+
+
+/************************************************************************/
+/* GL Engine Test Code                                                  */
+/************************************************************************/
+
+static unique_ptr<tvg::GlCanvas> glCanvas;
+
+void initGLview(Evas_Object *obj)
+{
+    static constexpr auto BPP = 4;
+
+    //Create a Canvas
+    glCanvas = tvg::GlCanvas::gen();
+    glCanvas->target(nullptr, WIDTH * BPP, WIDTH, HEIGHT);
+
+    /* Push the shape into the Canvas drawing list
+       When this shape is into the canvas list, the shape could update & prepare
+       internal data asynchronously for coming rendering.
+       Canvas keeps this shape node unless user call canvas->clear() */
+    tvgDrawCmds(glCanvas.get());
+}
+
+void drawGLview(Evas_Object *obj)
+{
+    auto gl = elm_glview_gl_api_get(obj);
+    gl->glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+    gl->glClear(GL_COLOR_BUFFER_BIT);
+
+    if (glCanvas->draw() == tvg::Result::Success) {
+        glCanvas->sync();
+    }
+}
+
+
+/************************************************************************/
+/* Main Code                                                            */
+/************************************************************************/
+
+int main(int argc, char **argv)
+{
+    tvg::CanvasEngine tvgEngine = tvg::CanvasEngine::Sw;
+
+    if (argc > 1) {
+        if (!strcmp(argv[1], "gl")) tvgEngine = tvg::CanvasEngine::Gl;
+    }
+
+    //Initialize ThorVG Engine
+    if (tvgEngine == tvg::CanvasEngine::Sw) {
+        cout << "tvg engine: software" << endl;
+    } else {
+        cout << "tvg engine: opengl" << endl;
+    }
+
+    //Threads Count
+    auto threads = std::thread::hardware_concurrency();
+
+    //Initialize ThorVG Engine
+    if (tvg::Initializer::init(tvgEngine, threads) == tvg::Result::Success) {
+
+        elm_init(argc, argv);
+
+        if (tvgEngine == tvg::CanvasEngine::Sw) {
+            createSwView();
+        } else {
+            createGlView();
+        }
+
+        elm_run();
+        elm_shutdown();
+
+        //Terminate ThorVG Engine
+        tvg::Initializer::term(tvgEngine);
+
+    } else {
+        cout << "engine is not supported" << endl;
+    }
+    return 0;
+}

--- a/src/examples/testClipPath.cpp
+++ b/src/examples/testClipPath.cpp
@@ -88,8 +88,6 @@ void tvgDrawCmds(tvg::Canvas* canvas)
 
     canvas->push(move(star3));
 
-
-
     //////////////////////////////////////////////
     auto picture = tvg::Picture::gen();
     char buf[PATH_MAX];
@@ -110,9 +108,6 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     picture->composite(move(clipPath), tvg::CompMethod::ClipPath);
 
     canvas->push(move(picture));
-
-
-    //canvas->push(move(shape2));
 }
 
 

--- a/src/lib/gl_engine/tvgGlRenderer.cpp
+++ b/src/lib/gl_engine/tvgGlRenderer.cpp
@@ -140,7 +140,7 @@ bool GlRenderer::dispose(TVG_UNUSED const Shape& shape, void *data)
 }
 
 
-void* GlRenderer::prepare(const Shape& shape, void* data, TVG_UNUSED const RenderTransform* transform, RenderUpdateFlag flags)
+void* GlRenderer::prepare(const Shape& shape, void* data, TVG_UNUSED const RenderTransform* transform, vector<Composite>& compList, RenderUpdateFlag flags)
 {
     //prepare shape data
     GlShape* sdata = static_cast<GlShape*>(data);

--- a/src/lib/gl_engine/tvgGlRenderer.h
+++ b/src/lib/gl_engine/tvgGlRenderer.h
@@ -30,7 +30,7 @@ class GlRenderer : public RenderMethod
 public:
     Surface surface = {nullptr, 0, 0, 0};
 
-    void* prepare(const Shape& shape, void* data, const RenderTransform* transform, RenderUpdateFlag flags) override;
+    void* prepare(const Shape& shape, void* data, const RenderTransform* transform, vector<Composite>& compList, RenderUpdateFlag flags) override;
     bool dispose(const Shape& shape, void *data) override;
     bool preRender() override;
     bool render(const Shape& shape, void *data) override;

--- a/src/lib/sw_engine/tvgSwCommon.h
+++ b/src/lib/sw_engine/tvgSwCommon.h
@@ -293,6 +293,9 @@ void fillFetchRadial(const SwFill* fill, uint32_t* dst, uint32_t y, uint32_t x, 
 
 SwRleData* rleRender(const SwOutline* outline, const SwBBox& bbox, const SwSize& clip, bool antiAlias);
 void rleFree(SwRleData* rle);
+void rleClipPath(SwRleData *rle, const SwRleData *compRle);
+void rleClipRect(SwRleData *rle, const SwBBox* compBBox);
+
 
 bool rasterCompositor(SwSurface* surface);
 bool rasterGradientShape(SwSurface* surface, SwShape* shape, unsigned id);

--- a/src/lib/sw_engine/tvgSwCommon.h
+++ b/src/lib/sw_engine/tvgSwCommon.h
@@ -270,7 +270,7 @@ SwFixed mathMean(SwFixed angle1, SwFixed angle2);
 void shapeReset(SwShape* shape);
 bool shapeGenOutline(SwShape* shape, const Shape* sdata, const Matrix* transform);
 bool shapePrepare(SwShape* shape, const Shape* sdata, const SwSize& clip, const Matrix* transform);
-bool shapeGenRle(SwShape* shape, const Shape* sdata, const SwSize& clip, bool antiAlias);
+bool shapeGenRle(SwShape* shape, const Shape* sdata, const SwSize& clip, bool antiAlias, bool hasComposite);
 void shapeDelOutline(SwShape* shape);
 void shapeResetStroke(SwShape* shape, const Shape* sdata, const Matrix* transform);
 bool shapeGenStrokeRle(SwShape* shape, const Shape* sdata, const Matrix* transform, const SwSize& clip);
@@ -293,8 +293,8 @@ void fillFetchRadial(const SwFill* fill, uint32_t* dst, uint32_t y, uint32_t x, 
 
 SwRleData* rleRender(const SwOutline* outline, const SwBBox& bbox, const SwSize& clip, bool antiAlias);
 void rleFree(SwRleData* rle);
-void rleClipPath(SwRleData *rle, const SwRleData *compRle);
-void rleClipRect(SwRleData *rle, const SwBBox* compBBox);
+void rleClipPath(SwRleData *rle, const SwRleData *clip);
+void rleClipRect(SwRleData *rle, const SwBBox* clip);
 
 
 bool rasterCompositor(SwSurface* surface);

--- a/src/lib/sw_engine/tvgSwRenderer.cpp
+++ b/src/lib/sw_engine/tvgSwRenderer.cpp
@@ -39,6 +39,7 @@ struct SwTask : Task
     Matrix* compTransform = nullptr;
     SwSurface* surface = nullptr;
     RenderUpdateFlag flags = RenderUpdateFlag::None;
+    vector<Composite> compList;
 
     void run() override
     {
@@ -88,23 +89,17 @@ struct SwTask : Task
         }
 
         //Composite clip-path
-        if(compData && compMethod == CompMethod::ClipPath) {
-            SwShape compShape;
-            if (flags & (RenderUpdateFlag::Path | RenderUpdateFlag::Transform)) {
-                shapeReset(&compShape);
+        for (auto comp : compList) {
+             SwShape *compShape = &static_cast<SwTask*>(comp.compEData)->shape;
+             if(comp.method == CompMethod::ClipPath) {
+                  //Clip to fill(path) rle
+                  if (shape.rle && compShape->rect) rleClipRect(shape.rle, &compShape->bbox);
+                  else if (shape.rle && compShape->rle) rleClipPath(shape.rle, compShape->rle);
 
-                //Make composite rle
-                if (!shapePrepare(&compShape, compData, clip, compTransform)) return;
-                if (!shapeGenRle(&compShape, compData, clip, true)) return;
-
-                //Clip to fill(path) rle
-                if (shape.rle && compShape.rect) rleClipRect(shape.rle, &compShape.bbox);
-                else if (shape.rle && compShape.rle) rleClipPath(shape.rle, compShape.rle);
-
-                //Clip to stroke rle
-                if (shape.strokeRle && compShape.rect) rleClipRect(shape.strokeRle, &compShape.bbox);
-                else if (shape.strokeRle && compShape.rle) rleClipPath(shape.strokeRle, compShape.rle);
-            }
+                  //Clip to stroke rle
+                  if (shape.strokeRle && compShape->rect) rleClipRect(shape.strokeRle, &compShape->bbox);
+                  else if (shape.strokeRle && compShape->rle) rleClipPath(shape.strokeRle, compShape->rle);
+             }
         }
         shapeDelOutline(&shape);
     }
@@ -209,7 +204,7 @@ bool SwRenderer::dispose(TVG_UNUSED const Shape& sdata, void *data)
 }
 
 
-void* SwRenderer::prepare(const Shape& sdata, void* data, const RenderTransform* transform, RenderUpdateFlag flags)
+void* SwRenderer::prepare(const Shape& sdata, void* data, const RenderTransform* transform, vector<Composite>& compList, RenderUpdateFlag flags)
 {
     //prepare task
     auto task = static_cast<SwTask*>(data);
@@ -221,8 +216,10 @@ void* SwRenderer::prepare(const Shape& sdata, void* data, const RenderTransform*
     if (flags == RenderUpdateFlag::None || task->valid()) return task;
 
     task->sdata = &sdata;
-    task->compData = static_cast<Shape*>(task->sdata->composite());
-    task->compMethod = task->sdata->compositeMethod();
+    if (compList.size() > 0) {
+        for (auto comp : compList)  static_cast<SwTask*>(comp.compEData)->get();
+        task->compList.assign(compList.begin(), compList.end());
+    }
 
     if (transform) {
         if (!task->transform) task->transform = static_cast<Matrix*>(malloc(sizeof(Matrix)));
@@ -230,14 +227,6 @@ void* SwRenderer::prepare(const Shape& sdata, void* data, const RenderTransform*
     } else {
         if (task->transform) free(task->transform);
         task->transform = nullptr;
-    }
-
-    if (task->compData) {
-        if (!task->compTransform) task->compTransform = static_cast<Matrix*>(malloc(sizeof(Matrix)));
-        *task->compTransform = ((Shape*)task->compData)->transform();
-    } else {
-        if (task->compTransform) free(task->compTransform);
-        task->compTransform = nullptr;
     }
 
     task->surface = surface;

--- a/src/lib/sw_engine/tvgSwRenderer.cpp
+++ b/src/lib/sw_engine/tvgSwRenderer.cpp
@@ -33,7 +33,10 @@ struct SwTask : Task
 {
     SwShape shape;
     const Shape* sdata = nullptr;
+    const Shape* compData = nullptr;
+    CompMethod compMethod = CompMethod::None;
     Matrix* transform = nullptr;
+    Matrix* compTransform = nullptr;
     SwSurface* surface = nullptr;
     RenderUpdateFlag flags = RenderUpdateFlag::None;
 
@@ -62,6 +65,7 @@ struct SwTask : Task
                 }
             }
         }
+
         //Fill
         if (flags & (RenderUpdateFlag::Gradient | RenderUpdateFlag::Transform)) {
             auto fill = sdata->fill();
@@ -80,6 +84,26 @@ struct SwTask : Task
                 if (!shapeGenStrokeRle(&shape, sdata, transform, clip)) return;
             } else {
                 shapeDelStroke(&shape);
+            }
+        }
+
+        //Composite clip-path
+        if(compData && compMethod == CompMethod::ClipPath) {
+            SwShape compShape;
+            if (flags & (RenderUpdateFlag::Path | RenderUpdateFlag::Transform)) {
+                shapeReset(&compShape);
+
+                //Make composite rle
+                if (!shapePrepare(&compShape, compData, clip, compTransform)) return;
+                if (!shapeGenRle(&compShape, compData, clip, true)) return;
+
+                //Clip to fill(path) rle
+                if (shape.rle && compShape.rect) rleClipRect(shape.rle, &compShape.bbox);
+                else if (shape.rle && compShape.rle) rleClipPath(shape.rle, compShape.rle);
+
+                //Clip to stroke rle
+                if (shape.strokeRle && compShape.rect) rleClipRect(shape.strokeRle, &compShape.bbox);
+                else if (shape.strokeRle && compShape.rle) rleClipPath(shape.strokeRle, compShape.rle);
             }
         }
         shapeDelOutline(&shape);
@@ -178,6 +202,7 @@ bool SwRenderer::dispose(TVG_UNUSED const Shape& sdata, void *data)
     task->get();
     shapeFree(&task->shape);
     if (task->transform) free(task->transform);
+    if (task->compTransform) free(task->compTransform);
     delete(task);
 
     return true;
@@ -196,6 +221,8 @@ void* SwRenderer::prepare(const Shape& sdata, void* data, const RenderTransform*
     if (flags == RenderUpdateFlag::None || task->valid()) return task;
 
     task->sdata = &sdata;
+    task->compData = static_cast<Shape*>(task->sdata->composite());
+    task->compMethod = task->sdata->compositeMethod();
 
     if (transform) {
         if (!task->transform) task->transform = static_cast<Matrix*>(malloc(sizeof(Matrix)));
@@ -203,6 +230,14 @@ void* SwRenderer::prepare(const Shape& sdata, void* data, const RenderTransform*
     } else {
         if (task->transform) free(task->transform);
         task->transform = nullptr;
+    }
+
+    if (task->compData) {
+        if (!task->compTransform) task->compTransform = static_cast<Matrix*>(malloc(sizeof(Matrix)));
+        *task->compTransform = ((Shape*)task->compData)->transform();
+    } else {
+        if (task->compTransform) free(task->compTransform);
+        task->compTransform = nullptr;
     }
 
     task->surface = surface;

--- a/src/lib/sw_engine/tvgSwRenderer.cpp
+++ b/src/lib/sw_engine/tvgSwRenderer.cpp
@@ -88,7 +88,7 @@ struct SwTask : Task
         //Composite clip-path
         for (auto comp : compList) {
              SwShape *compShape = &static_cast<SwTask*>(comp.edata)->shape;
-             if(comp.method == CompMethod::ClipPath) {
+             if (comp.method == CompMethod::ClipPath) {
                   //Clip to fill(path) rle
                   if (shape.rle && compShape->rect) rleClipRect(shape.rle, &compShape->bbox);
                   else if (shape.rle && compShape->rle) rleClipPath(shape.rle, compShape->rle);

--- a/src/lib/sw_engine/tvgSwRenderer.h
+++ b/src/lib/sw_engine/tvgSwRenderer.h
@@ -34,7 +34,7 @@ namespace tvg
 class SwRenderer : public RenderMethod
 {
 public:
-    void* prepare(const Shape& shape, void* data, const RenderTransform* transform, RenderUpdateFlag flags) override;
+    void* prepare(const Shape& shape, void* data, const RenderTransform* transform, vector<Composite>& compList, RenderUpdateFlag flags) override;
     bool dispose(const Shape& shape, void *data) override;
     bool preRender() override;
     bool postRender() override;

--- a/src/lib/sw_engine/tvgSwShape.cpp
+++ b/src/lib/sw_engine/tvgSwShape.cpp
@@ -466,7 +466,7 @@ bool shapeGenRle(SwShape* shape, TVG_UNUSED const Shape* sdata, const SwSize& cl
     //if (shape.outline->opened) return true;
 
     //Case A: Fast Track Rectangle Drawing
-    if (sdata->compositeMethod() != CompMethod::ClipPath && (shape->rect = _fastTrack(shape->outline))) return true;
+    //if (sdata->pImpl->compMethod != CompMethod::ClipPath && (shape->rect = _fastTrack(shape->outline))) return true;
     //Case B: Normale Shape RLE Drawing
     if ((shape->rle = rleRender(shape->outline, shape->bbox, clip, antiAlias))) return true;
 

--- a/src/lib/sw_engine/tvgSwShape.cpp
+++ b/src/lib/sw_engine/tvgSwShape.cpp
@@ -466,7 +466,7 @@ bool shapeGenRle(SwShape* shape, TVG_UNUSED const Shape* sdata, const SwSize& cl
     //if (shape.outline->opened) return true;
 
     //Case A: Fast Track Rectangle Drawing
-    if ((shape->rect = _fastTrack(shape->outline))) return true;
+    if (sdata->compositeMethod() != CompMethod::ClipPath && (shape->rect = _fastTrack(shape->outline))) return true;
     //Case B: Normale Shape RLE Drawing
     if ((shape->rle = rleRender(shape->outline, shape->bbox, clip, antiAlias))) return true;
 

--- a/src/lib/sw_engine/tvgSwShape.cpp
+++ b/src/lib/sw_engine/tvgSwShape.cpp
@@ -459,14 +459,14 @@ bool shapePrepare(SwShape* shape, const Shape* sdata, const SwSize& clip, const 
 }
 
 
-bool shapeGenRle(SwShape* shape, TVG_UNUSED const Shape* sdata, const SwSize& clip, bool antiAlias)
+bool shapeGenRle(SwShape* shape, TVG_UNUSED const Shape* sdata, const SwSize& clip, bool antiAlias, bool hasComposite)
 {
     //FIXME: Should we draw it?
     //Case: Stroke Line
     //if (shape.outline->opened) return true;
 
     //Case A: Fast Track Rectangle Drawing
-    //if (sdata->pImpl->compMethod != CompMethod::ClipPath && (shape->rect = _fastTrack(shape->outline))) return true;
+    if (!hasComposite && (shape->rect = _fastTrack(shape->outline))) return true;
     //Case B: Normale Shape RLE Drawing
     if ((shape->rle = rleRender(shape->outline, shape->bbox, clip, antiAlias))) return true;
 

--- a/src/lib/tvgCanvasImpl.h
+++ b/src/lib/tvgCanvasImpl.h
@@ -33,6 +33,7 @@ struct Canvas::Impl
 {
     vector<Paint*> paints;
     RenderMethod*  renderer;
+    vector<Composite> compList;
 
     Impl(RenderMethod* pRenderer):renderer(pRenderer)
     {
@@ -64,6 +65,9 @@ struct Canvas::Impl
             paint->pImpl->dispose(*renderer);
             delete(paint);
         }
+
+        compList.clear();
+
         paints.clear();
 
         return Result::Success;
@@ -73,15 +77,17 @@ struct Canvas::Impl
     {
         if (!renderer) return Result::InsufficientCondition;
 
+        compList.clear();
+
         //Update single paint node
         if (paint) {
-            if (!paint->pImpl->update(*renderer, nullptr, RenderUpdateFlag::None)) {
+            if (!paint->pImpl->update(*renderer, nullptr, compList, RenderUpdateFlag::None)) {
                 return Result::InsufficientCondition;
             }
         //Update retained all paint nodes
         } else {
             for(auto paint: paints) {
-                if (!paint->pImpl->update(*renderer, nullptr, RenderUpdateFlag::None)) {
+                if (!paint->pImpl->update(*renderer, nullptr, compList, RenderUpdateFlag::None)) {
                     return Result::InsufficientCondition;
                 }
             }

--- a/src/lib/tvgCanvasImpl.h
+++ b/src/lib/tvgCanvasImpl.h
@@ -33,7 +33,6 @@ struct Canvas::Impl
 {
     vector<Paint*> paints;
     RenderMethod*  renderer;
-    vector<Composite> compList;
 
     Impl(RenderMethod* pRenderer):renderer(pRenderer)
     {
@@ -66,8 +65,6 @@ struct Canvas::Impl
             delete(paint);
         }
 
-        compList.clear();
-
         paints.clear();
 
         return Result::Success;
@@ -77,7 +74,7 @@ struct Canvas::Impl
     {
         if (!renderer) return Result::InsufficientCondition;
 
-        compList.clear();
+        vector<Composite> compList;
 
         //Update single paint node
         if (paint) {

--- a/src/lib/tvgCanvasImpl.h
+++ b/src/lib/tvgCanvasImpl.h
@@ -78,13 +78,13 @@ struct Canvas::Impl
 
         //Update single paint node
         if (paint) {
-            if (!paint->pImpl->update(*renderer, nullptr, compList, RenderUpdateFlag::None)) {
+            if (!paint->pImpl->update(*renderer, nullptr, compList, nullptr, RenderUpdateFlag::None)) {
                 return Result::InsufficientCondition;
             }
         //Update retained all paint nodes
         } else {
-            for(auto paint: paints) {
-                if (!paint->pImpl->update(*renderer, nullptr, compList, RenderUpdateFlag::None)) {
+            for (auto paint: paints) {
+                if (!paint->pImpl->update(*renderer, nullptr, compList, nullptr, RenderUpdateFlag::None)) {
                     return Result::InsufficientCondition;
                 }
             }

--- a/src/lib/tvgPaint.cpp
+++ b/src/lib/tvgPaint.cpp
@@ -67,6 +67,10 @@ Result Paint::transform(const Matrix& m) noexcept
     return Result::FailedAllocation;
 }
 
+Matrix Paint::transform() noexcept
+{
+    return pImpl->transform();
+}
 
 Result Paint::bounds(float* x, float* y, float* w, float* h) const noexcept
 {
@@ -78,3 +82,20 @@ Paint* Paint::duplicate() const noexcept
 {
     return pImpl->duplicate();
 }
+
+Result Paint::composite(std::unique_ptr<Paint> comp, CompMethod method) const noexcept
+{
+    if (pImpl->composite(move(comp), method)) return Result::Success;
+    return Result::InsufficientCondition;
+}
+
+Paint* Paint::composite() const noexcept
+{
+    return pImpl->composite();
+}
+
+CompMethod Paint::compositeMethod() const noexcept
+{
+    return pImpl->compositeMethod();
+}
+

--- a/src/lib/tvgPaint.cpp
+++ b/src/lib/tvgPaint.cpp
@@ -67,11 +67,6 @@ Result Paint::transform(const Matrix& m) noexcept
     return Result::FailedAllocation;
 }
 
-Matrix Paint::transform() noexcept
-{
-    return pImpl->transform();
-}
-
 Result Paint::bounds(float* x, float* y, float* w, float* h) const noexcept
 {
     if (pImpl->bounds(x, y, w, h)) return Result::Success;
@@ -87,15 +82,5 @@ Result Paint::composite(std::unique_ptr<Paint> comp, CompMethod method) const no
 {
     if (pImpl->composite(move(comp), method)) return Result::Success;
     return Result::InsufficientCondition;
-}
-
-Paint* Paint::composite() const noexcept
-{
-    return pImpl->composite();
-}
-
-CompMethod Paint::compositeMethod() const noexcept
-{
-    return pImpl->compositeMethod();
 }
 

--- a/src/lib/tvgPaint.cpp
+++ b/src/lib/tvgPaint.cpp
@@ -80,7 +80,7 @@ Paint* Paint::duplicate() const noexcept
 
 Result Paint::composite(std::unique_ptr<Paint> target, CompMethod method) const noexcept
 {
-    if (pImpl->composite(move(target), method)) return Result::Success;
+    if (pImpl->composite(target.release(), method)) return Result::Success;
     return Result::InsufficientCondition;
 }
 

--- a/src/lib/tvgPaint.cpp
+++ b/src/lib/tvgPaint.cpp
@@ -78,9 +78,9 @@ Paint* Paint::duplicate() const noexcept
     return pImpl->duplicate();
 }
 
-Result Paint::composite(std::unique_ptr<Paint> comp, CompMethod method) const noexcept
+Result Paint::composite(std::unique_ptr<Paint> target, CompMethod method) const noexcept
 {
-    if (pImpl->composite(move(comp), method)) return Result::Success;
+    if (pImpl->composite(move(target), method)) return Result::Success;
     return Result::InsufficientCondition;
 }
 

--- a/src/lib/tvgPaint.h
+++ b/src/lib/tvgPaint.h
@@ -37,6 +37,10 @@ namespace tvg
         virtual bool render(RenderMethod& renderer) = 0;
         virtual bool bounds(float* x, float* y, float* w, float* h) const = 0;
         virtual Paint* duplicate() = 0;
+        virtual bool composite(unique_ptr<Paint> comp, CompMethod method) = 0;
+        virtual bool composite(Paint* comp, CompMethod method) = 0;
+        virtual Paint* composite() = 0;
+        virtual CompMethod compositeMethod() = 0;
     };
 
     struct Paint::Impl
@@ -113,6 +117,15 @@ namespace tvg
             return true;
         }
 
+        Matrix transform()
+        {
+            if (rTransform) {
+                rTransform->update();
+                return rTransform->m;
+            }
+            return {1, 0, 0, 0, 1, 0, 0, 0, 1};
+        }
+
         bool bounds(float* x, float* y, float* w, float* h) const
         {
             return smethod->bounds(x, y, w, h);
@@ -165,6 +178,26 @@ namespace tvg
 
             return ret;
         }
+
+        bool composite(unique_ptr<Paint> comp, CompMethod method) const
+        {
+            return smethod->composite(move(comp), method);
+        }
+
+        bool composite(Paint* comp, CompMethod method) const
+        {
+            return smethod->composite(comp, method);
+        }
+
+        Paint* composite() const
+        {
+            return smethod->composite();
+        }
+
+        CompMethod compositeMethod() const
+        {
+            return smethod->compositeMethod();
+        }
     };
 
 
@@ -199,6 +232,26 @@ namespace tvg
         Paint* duplicate() override
         {
             return inst->duplicate();
+        }
+
+        bool composite(unique_ptr<Paint> comp, CompMethod method) override
+        {
+            return inst->composite(move(comp), method);
+        }
+
+        bool composite(Paint* comp, CompMethod method) override
+        {
+            return inst->composite(comp, method);
+        }
+
+        Paint* composite() override
+        {
+            return inst->composite();
+        }
+
+        CompMethod compositeMethod() override
+        {
+            return inst->compositeMethod();
         }
     };
 }

--- a/src/lib/tvgPaint.h
+++ b/src/lib/tvgPaint.h
@@ -45,7 +45,7 @@ namespace tvg
         RenderTransform *rTransform = nullptr;
         uint32_t flag = RenderUpdateFlag::None;
 
-        Paint* comp = nullptr;
+        Paint* compTarget = nullptr;
         CompMethod compMethod = CompMethod::None;
 
         ~Impl() {
@@ -148,13 +148,13 @@ namespace tvg
             auto newFlag = static_cast<RenderUpdateFlag>(pFlag | flag);
             flag = RenderUpdateFlag::None;
             void *edata = nullptr;
-            void *compEData = nullptr;
+            void *compEngineData = nullptr; //composite target paint's engine data.
 
-            if (this->comp && compMethod == CompMethod::ClipPath) {
-                compEData = this->comp->pImpl->update(renderer, pTransform, compList, static_cast<RenderUpdateFlag>(pFlag | flag));
-                if (compEData) {
+            if (this->compTarget && compMethod == CompMethod::ClipPath) {
+                compEngineData = this->compTarget->pImpl->update(renderer, pTransform, compList, static_cast<RenderUpdateFlag>(pFlag | flag));
+                if (compEngineData) {
                     Composite comp;
-                    comp.compEData = compEData;
+                    comp.edata = compEngineData;
                     comp.method = this->compMethod;
                     compList.push_back(comp);
                 }
@@ -168,7 +168,7 @@ namespace tvg
                 edata = smethod->update(renderer, outTransform, compList, newFlag);
             }
 
-            if (compEData) {
+            if (compEngineData) {
                 compList.pop_back();
             }
             return edata;
@@ -195,11 +195,11 @@ namespace tvg
             return ret;
         }
 
-        bool composite(unique_ptr<Paint> comp, CompMethod compMethod)
+        bool composite(unique_ptr<Paint> target, CompMethod compMethod)
         {
-            this->comp = static_cast<Paint*>(comp.release());
+            this->compTarget = static_cast<Paint*>(target.release());
             this->compMethod = compMethod;
-            if (this->comp) return true;
+            if (this->compTarget) return true;
             return false;
         }
     };

--- a/src/lib/tvgPictureImpl.h
+++ b/src/lib/tvgPictureImpl.h
@@ -124,6 +124,36 @@ struct Picture::Impl
 
         return ret.release();
     }
+
+    bool composite(unique_ptr<Paint> comp, CompMethod method)
+    {
+        if (loader) {
+            auto scene = loader->data();
+            if (scene) {
+                this->paint = scene.release();
+                if (!this->paint) return false;
+                loader->close();
+            }
+        }
+        if (!paint) return false;
+        auto c = comp.release();
+        return paint->pImpl->composite(c, method);
+    }
+
+    bool composite(Paint* comp, CompMethod method)
+    {
+        return paint->pImpl->composite(comp, method);
+    }
+
+    Paint* composite()
+    {
+        return nullptr;//paint->pImpl->composite();
+    }
+
+    CompMethod compositeMethod()
+    {
+        return CompMethod::None;
+    }
 };
 
 #endif //_TVG_PICTURE_IMPL_H_

--- a/src/lib/tvgPictureImpl.h
+++ b/src/lib/tvgPictureImpl.h
@@ -57,13 +57,13 @@ struct Picture::Impl
     }
 
 
-    bool update(RenderMethod &renderer, const RenderTransform* transform, RenderUpdateFlag flag)
+    void* update(RenderMethod &renderer, const RenderTransform* transform, vector<Composite>& compList, RenderUpdateFlag flag)
     {
         reload();
 
-        if (!paint) return false;
+        if (!paint) return nullptr;
 
-        return paint->pImpl->update(renderer, transform, flag);
+        return paint->pImpl->update(renderer, transform, compList, flag);
     }
 
     bool render(RenderMethod &renderer)
@@ -123,36 +123,6 @@ struct Picture::Impl
         dup->paint = paint->duplicate();
 
         return ret.release();
-    }
-
-    bool composite(unique_ptr<Paint> comp, CompMethod method)
-    {
-        if (loader) {
-            auto scene = loader->data();
-            if (scene) {
-                this->paint = scene.release();
-                if (!this->paint) return false;
-                loader->close();
-            }
-        }
-        if (!paint) return false;
-        auto c = comp.release();
-        return paint->pImpl->composite(c, method);
-    }
-
-    bool composite(Paint* comp, CompMethod method)
-    {
-        return paint->pImpl->composite(comp, method);
-    }
-
-    Paint* composite()
-    {
-        return nullptr;//paint->pImpl->composite();
-    }
-
-    CompMethod compositeMethod()
-    {
-        return CompMethod::None;
     }
 };
 

--- a/src/lib/tvgPictureImpl.h
+++ b/src/lib/tvgPictureImpl.h
@@ -57,13 +57,13 @@ struct Picture::Impl
     }
 
 
-    void* update(RenderMethod &renderer, const RenderTransform* transform, vector<Composite>& compList, RenderUpdateFlag flag)
+    bool update(RenderMethod &renderer, const RenderTransform* transform, vector<Composite>& compList, void** edata, RenderUpdateFlag flag)
     {
         reload();
 
-        if (!paint) return nullptr;
+        if (!paint) return false;
 
-        return paint->pImpl->update(renderer, transform, compList, flag);
+        return paint->pImpl->update(renderer, transform, compList, edata, flag);
     }
 
     bool render(RenderMethod &renderer)

--- a/src/lib/tvgRender.h
+++ b/src/lib/tvgRender.h
@@ -23,6 +23,7 @@
 #define _TVG_RENDER_H_
 
 #include "tvgCommon.h"
+#include <vector>
 
 namespace tvg
 {
@@ -34,6 +35,11 @@ struct Surface
     uint32_t stride;
     uint32_t w, h;
     uint32_t cs;
+};
+
+struct Composite {
+    void* compEData;
+    CompMethod method;
 };
 
 enum RenderUpdateFlag {None = 0, Path = 1, Color = 2, Gradient = 4, Stroke = 8, Transform = 16, All = 32};

--- a/src/lib/tvgRender.h
+++ b/src/lib/tvgRender.h
@@ -59,7 +59,7 @@ class RenderMethod
 {
 public:
     virtual ~RenderMethod() {}
-    virtual void* prepare(TVG_UNUSED const Shape& shape, TVG_UNUSED void* data, TVG_UNUSED const RenderTransform* transform, TVG_UNUSED RenderUpdateFlag flags) { return nullptr; }
+    virtual void* prepare(TVG_UNUSED const Shape& shape, TVG_UNUSED void* data, TVG_UNUSED const RenderTransform* transform, TVG_UNUSED vector<Composite>& compList, TVG_UNUSED RenderUpdateFlag flags) { return nullptr; }
     virtual bool dispose(TVG_UNUSED const Shape& shape, TVG_UNUSED void *data) { return true; }
     virtual bool preRender() { return true; }
     virtual bool render(TVG_UNUSED const Shape& shape, TVG_UNUSED void *data) { return true; }

--- a/src/lib/tvgRender.h
+++ b/src/lib/tvgRender.h
@@ -38,7 +38,7 @@ struct Surface
 };
 
 struct Composite {
-    void* compEData;
+    void* edata;
     CompMethod method;
 };
 

--- a/src/lib/tvgRender.h
+++ b/src/lib/tvgRender.h
@@ -22,8 +22,8 @@
 #ifndef _TVG_RENDER_H_
 #define _TVG_RENDER_H_
 
-#include "tvgCommon.h"
 #include <vector>
+#include "tvgCommon.h"
 
 namespace tvg
 {

--- a/src/lib/tvgSceneImpl.h
+++ b/src/lib/tvgSceneImpl.h
@@ -44,12 +44,14 @@ struct Scene::Impl
         return true;
     }
 
-    bool update(RenderMethod &renderer, const RenderTransform* transform, RenderUpdateFlag flag)
+    void* update(RenderMethod &renderer, const RenderTransform* transform, vector<Composite>& compList, RenderUpdateFlag flag)
     {
+        void *edata = nullptr;
         for(auto paint: paints) {
-            if (!paint->pImpl->update(renderer, transform, static_cast<uint32_t>(flag))) return false;
+            edata = paint->pImpl->update(renderer, transform, compList, static_cast<uint32_t>(flag));
+            if (!edata) return nullptr;
         }
-        return true;
+        return edata;
     }
 
     bool render(RenderMethod &renderer)
@@ -103,33 +105,6 @@ struct Scene::Impl
         }
 
         return ret.release();
-    }
-
-    bool composite(unique_ptr<Paint> comp, CompMethod method)
-    {
-        auto c = comp.release();
-        for(auto paint: paints) {
-            if(!paint->pImpl->composite(c, method)) return false;
-        }
-        return false;
-    }
-
-    bool composite(Paint* comp, CompMethod method)
-    {
-        for(auto paint: paints) {
-            if(!paint->pImpl->composite(comp, method)) return false;
-        }
-        return false;
-    }
-
-    Paint* composite()
-    {
-        return nullptr;
-    }
-
-    CompMethod compositeMethod()
-    {
-        return CompMethod::None;
     }
 };
 

--- a/src/lib/tvgSceneImpl.h
+++ b/src/lib/tvgSceneImpl.h
@@ -104,6 +104,33 @@ struct Scene::Impl
 
         return ret.release();
     }
+
+    bool composite(unique_ptr<Paint> comp, CompMethod method)
+    {
+        auto c = comp.release();
+        for(auto paint: paints) {
+            if(!paint->pImpl->composite(c, method)) return false;
+        }
+        return false;
+    }
+
+    bool composite(Paint* comp, CompMethod method)
+    {
+        for(auto paint: paints) {
+            if(!paint->pImpl->composite(comp, method)) return false;
+        }
+        return false;
+    }
+
+    Paint* composite()
+    {
+        return nullptr;
+    }
+
+    CompMethod compositeMethod()
+    {
+        return CompMethod::None;
+    }
 };
 
 #endif //_TVG_SCENE_IMPL_H_

--- a/src/lib/tvgSceneImpl.h
+++ b/src/lib/tvgSceneImpl.h
@@ -44,14 +44,12 @@ struct Scene::Impl
         return true;
     }
 
-    void* update(RenderMethod &renderer, const RenderTransform* transform, vector<Composite>& compList, RenderUpdateFlag flag)
+    bool update(RenderMethod &renderer, const RenderTransform* transform, vector<Composite>& compList, void** edata, RenderUpdateFlag flag)
     {
-        void *edata = nullptr;
-        for(auto paint: paints) {
-            edata = paint->pImpl->update(renderer, transform, compList, static_cast<uint32_t>(flag));
-            if (!edata) return nullptr;
+        for (auto paint: paints) {
+            if (!paint->pImpl->update(renderer, transform, compList, edata, static_cast<uint32_t>(flag))) return false;
         }
-        return edata;
+        return true;
     }
 
     bool render(RenderMethod &renderer)

--- a/src/lib/tvgShapeImpl.h
+++ b/src/lib/tvgShapeImpl.h
@@ -228,49 +228,18 @@ struct Shape::Impl
         return renderer.render(*shape, edata);
     }
 
-    bool update(RenderMethod& renderer, const RenderTransform* transform, RenderUpdateFlag pFlag)
+    void* update(RenderMethod& renderer, const RenderTransform* transform, vector<Composite>& compList, RenderUpdateFlag pFlag)
     {
-        if (comp && compMethod == CompMethod::ClipPath) {
-           eCompData = renderer.prepare(*comp, eCompData, transform, static_cast<RenderUpdateFlag>(pFlag | flag));
-        }
-        edata = renderer.prepare(*shape, edata, transform, static_cast<RenderUpdateFlag>(pFlag | flag));
-
+        edata = renderer.prepare(*shape, edata, transform, compList, static_cast<RenderUpdateFlag>(pFlag | flag));
         flag = RenderUpdateFlag::None;
 
-        if (edata) return true;
-        return false;
+        return edata;
     }
 
     bool bounds(float* x, float* y, float* w, float* h)
     {
         if (!path) return false;
         return path->bounds(x, y, w, h);
-    }
-
-    bool composite(unique_ptr<Paint> comp, CompMethod method)
-    {
-        this->comp = static_cast<Shape*>(comp.release());
-        this->compMethod = method;
-        if (this->comp) return true;
-        return false;
-    }
-
-    bool composite(Paint* comp, CompMethod method)
-    {
-        this->comp = static_cast<Shape*>(comp);
-        this->compMethod = method;
-        if (this->comp) return true;
-        return false;
-    }
-
-    Paint* composite()
-    {
-        return static_cast<Shape*>(this->comp);
-    }
-
-    CompMethod compositeMethod()
-    {
-        return compMethod;
     }
 
     bool strokeWidth(float width)

--- a/src/lib/tvgShapeImpl.h
+++ b/src/lib/tvgShapeImpl.h
@@ -200,10 +200,6 @@ struct Shape::Impl
     Shape *shape = nullptr;
     uint32_t flag = RenderUpdateFlag::None;
 
-    Shape* comp = nullptr;
-    void *eCompData = nullptr;              //engine data
-    CompMethod compMethod = CompMethod::None;
-
     Impl(Shape* s) : path(new ShapePath), shape(s)
     {
     }
@@ -217,9 +213,6 @@ struct Shape::Impl
 
     bool dispose(RenderMethod& renderer)
     {
-        if (comp && eCompData) {
-            renderer.dispose(*comp, eCompData);
-        }
         return renderer.dispose(*shape, edata);
     }
 
@@ -228,12 +221,13 @@ struct Shape::Impl
         return renderer.render(*shape, edata);
     }
 
-    void* update(RenderMethod& renderer, const RenderTransform* transform, vector<Composite>& compList, RenderUpdateFlag pFlag)
+    bool update(RenderMethod& renderer, const RenderTransform* transform, vector<Composite>& compList, void** edata, RenderUpdateFlag pFlag)
     {
-        edata = renderer.prepare(*shape, edata, transform, compList, static_cast<RenderUpdateFlag>(pFlag | flag));
+        this->edata = renderer.prepare(*shape, this->edata, transform, compList, static_cast<RenderUpdateFlag>(pFlag | flag));
         flag = RenderUpdateFlag::None;
-
-        return edata;
+        if (edata) *edata = this->edata;
+        if (this->edata) return true;
+        return false;
     }
 
     bool bounds(float* x, float* y, float* w, float* h)


### PR DESCRIPTION
#49 
Paint object can composite by using composite API.
ClipPath composite is clipping by path unit of paint.
The following cases are supported.

Shape->composite(Shape);
Scene->composite(Shape);
Picture->composite(Shape);

Add enum
  enum CompMethod { None = 0, ClipPath };

Add APIs
  Result Paint::composite(std::unique_ptr<Paint> comp, CompMethod methd);