### PR TITLE
common fill: code refactoring

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -122,7 +122,7 @@ public:
 
     uint32_t colorStops(const ColorStop** colorStops) const noexcept;
     FillSpread spread() const noexcept;
-    std::unique_ptr<Fill> duplicate() const noexcept;
+    Fill* duplicate() const noexcept;
 
     _TVG_DECALRE_IDENTIFIER();
     _TVG_DECLARE_PRIVATE(Fill);

--- a/src/lib/tvgFill.cpp
+++ b/src/lib/tvgFill.cpp
@@ -85,7 +85,7 @@ FillSpread Fill::spread() const noexcept
 }
 
 
-unique_ptr<Fill> Fill::duplicate() const noexcept
+Fill* Fill::duplicate() const noexcept
 {
     return pImpl->duplicate();
 }

--- a/src/lib/tvgFill.h
+++ b/src/lib/tvgFill.h
@@ -28,7 +28,7 @@ template<typename T>
 struct DuplicateMethod
 {
     virtual ~DuplicateMethod(){}
-    virtual unique_ptr<T> duplicate() = 0;
+    virtual T* duplicate() = 0;
 };
 
 template<class T>
@@ -39,7 +39,7 @@ struct FillDup : DuplicateMethod<Fill>
     FillDup(T* _inst) : inst(_inst) {}
     ~FillDup(){}
 
-    unique_ptr<Fill> duplicate() override
+    Fill* duplicate() override
     {
         return inst->duplicate();
     }
@@ -63,7 +63,7 @@ struct Fill::Impl
         this->dup = dup;
     }
 
-    unique_ptr<Fill> duplicate()
+    Fill* duplicate()
     {
         auto ret = dup->duplicate();
         if (!ret) return nullptr;

--- a/src/lib/tvgLinearGradient.cpp
+++ b/src/lib/tvgLinearGradient.cpp
@@ -32,7 +32,7 @@ struct LinearGradient::Impl
     float x2 = 0;
     float y2 = 0;
 
-    unique_ptr<Fill> duplicate()
+    Fill* duplicate()
     {
         auto ret = LinearGradient::gen();
         if (!ret) return nullptr;
@@ -42,7 +42,7 @@ struct LinearGradient::Impl
         ret->pImpl->x2 = x2;
         ret->pImpl->y2 = y2;
 
-        return ret;
+        return ret.release();
     }
 };
 

--- a/src/lib/tvgPaint.h
+++ b/src/lib/tvgPaint.h
@@ -34,7 +34,7 @@ namespace tvg
         virtual bool update(RenderMethod& renderer, const RenderTransform* transform, RenderUpdateFlag pFlag) = 0;
         virtual bool render(RenderMethod& renderer) = 0;
         virtual bool bounds(float* x, float* y, float* w, float* h) const = 0;
-        virtual unique_ptr<Paint> duplicate() = 0;
+        virtual Paint* duplicate() = 0;
     };
 
     struct Paint::Impl
@@ -150,7 +150,7 @@ namespace tvg
 
         Paint* duplicate()
         {
-            return smethod->duplicate().release();
+            return smethod->duplicate();
         }
     };
 
@@ -183,7 +183,7 @@ namespace tvg
             return inst->render(renderer);
         }
 
-        unique_ptr<Paint> duplicate() override
+        Paint* duplicate() override
         {
             return inst->duplicate();
         }

--- a/src/lib/tvgPictureImpl.h
+++ b/src/lib/tvgPictureImpl.h
@@ -105,7 +105,7 @@ struct Picture::Impl
         return Result::Success;
     }
 
-    unique_ptr<Paint> duplicate()
+    Paint* duplicate()
     {
         //TODO:
         return nullptr;

--- a/src/lib/tvgRadialGradient.cpp
+++ b/src/lib/tvgRadialGradient.cpp
@@ -31,7 +31,7 @@ struct RadialGradient::Impl
     float cy = 0;
     float radius = 0;
 
-    unique_ptr<Fill> duplicate()
+    Fill* duplicate()
     {
         auto ret = RadialGradient::gen();
         if (!ret) return nullptr;
@@ -40,7 +40,7 @@ struct RadialGradient::Impl
         ret->pImpl->cy = cy;
         ret->pImpl->radius = radius;
 
-        return ret;
+        return ret.release();
     }
 };
 

--- a/src/lib/tvgSceneImpl.h
+++ b/src/lib/tvgSceneImpl.h
@@ -89,7 +89,7 @@ struct Scene::Impl
         return true;
     }
 
-    unique_ptr<Paint> duplicate()
+    Paint* duplicate()
     {
         //TODO:
         return nullptr;

--- a/src/lib/tvgShapeImpl.h
+++ b/src/lib/tvgShapeImpl.h
@@ -176,7 +176,7 @@ struct Shape::Impl
         return true;
     }
 
-    unique_ptr<Paint> duplicate()
+    Paint* duplicate()
     {
         auto ret = Shape::gen();
         if (!ret) return nullptr;
@@ -200,11 +200,11 @@ struct Shape::Impl
         }
 
         if (fill) {
-            dup->fill = fill->duplicate().release();
+            dup->fill = fill->duplicate();
             dup->flag |= RenderUpdateFlag::Gradient;
         }
 
-        return ret;
+        return ret.release();
     }
 };
 


### PR DESCRIPTION
removed unique_ptr in the interface because it's hard to get polymorphism benefits in programming perspective.