### PR TITLE
SvgPath: When path end(Z,z), Current point are returned to starting p…

### DIFF
--- a/src/loaders/svg/tvgSvgPath.cpp
+++ b/src/loaders/svg/tvgSvgPath.cpp
@@ -280,7 +280,7 @@ static int _numberCount(char cmd)
 }
 
 
-static void _processCommand(vector<PathCommand>* cmds, vector<Point>* pts, char cmd, float* arr, int count, Point* cur, Point* curCtl, bool *isQuadratic)
+static void _processCommand(vector<PathCommand>* cmds, vector<Point>* pts, char cmd, float* arr, int count, Point* cur, Point* curCtl, Point* startPoint, bool *isQuadratic)
 {
     int i;
     switch (cmd) {
@@ -321,6 +321,7 @@ static void _processCommand(vector<PathCommand>* cmds, vector<Point>* pts, char 
             cmds->push_back(PathCommand::MoveTo);
             pts->push_back(p);
             *cur = {arr[0] ,arr[1]};
+            *startPoint = {arr[0] ,arr[1]};
             break;
         }
         case 'l':
@@ -432,6 +433,7 @@ static void _processCommand(vector<PathCommand>* cmds, vector<Point>* pts, char 
         case 'z':
         case 'Z': {
             cmds->push_back(PathCommand::Close);
+            *cur = *startPoint;
             break;
         }
         case 'a':
@@ -503,6 +505,7 @@ tuple<vector<PathCommand>, vector<Point>> svgPathToTvgPath(const char* svgPath)
     int numberCount = 0;
     Point cur = { 0, 0 };
     Point curCtl = { 0, 0 };
+    Point startPoint = { 0, 0 };
     char cmd = 0;
     bool isQuadratic = false;
     char* path = (char*)svgPath;
@@ -515,7 +518,7 @@ tuple<vector<PathCommand>, vector<Point>> svgPathToTvgPath(const char* svgPath)
     while ((path[0] != '\0')) {
         path = _nextCommand(path, &cmd, numberArray, &numberCount);
         if (!path) break;
-        _processCommand(&cmds, &pts, cmd, numberArray, numberCount, &cur, &curCtl, &isQuadratic);
+        _processCommand(&cmds, &pts, cmd, numberArray, numberCount, &cur, &curCtl, &startPoint, &isQuadratic);
     }
 
     setlocale(LC_NUMERIC, curLocale);


### PR DESCRIPTION
…oint(M,m)

When path ends with 'z' or 'Z' command, if 'm' comes as next command,
the current point is incorrectly referenced.
Since 'Z', 'z' means to close the path,
so, Save point and reuse it when 'M' or 'm' is called.

[Error case]
``` html
<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
    <path d="M 52.17,20
             H 11.92
             V 43
             H 52.17
             Z
             m -1.5,21.5
             H 13.42
             v -20
             H 50.67
             Z
" fill="#a8b7c1" stroke="#F00" stroke-width="0.5" />
</svg>
```