### PR TITLE
gradient: Fixed radial gradient setter.

### DIFF
--- a/src/lib/tvgRadialGradient.cpp
+++ b/src/lib/tvgRadialGradient.cpp
@@ -64,7 +64,7 @@ RadialGradient::~RadialGradient()
 
 Result RadialGradient::radial(float cx, float cy, float radius) noexcept
 {
-    if (radius < FLT_EPSILON) return Result::InvalidArguments;
+    if (radius < 0) return Result::InvalidArguments;
 
     pImpl->cx = cx;
     pImpl->cy = cy;


### PR DESCRIPTION
Removed check for gradient radius. Because of check, x and y values
was ignored when radius equals 0 and api was not usable
in integration with external libs which sets gradient center and
radius in separeted functions.