### PR TITLE
gl_engine: fix compile error.

### DIFF
--- a/src/lib/gl_engine/tvgGlCommon.h
+++ b/src/lib/gl_engine/tvgGlCommon.h
@@ -23,8 +23,10 @@
 #ifndef _TVG_GL_COMMON_H_
 #define _TVG_GL_COMMON_H_
 
-#include "tvgCommon.h"
 #include <assert.h>
+#include <GLES2/gl2.h>
+#include "tvgCommon.h"
+#include "tvgRender.h"
 
 
 #define GL_CHECK(x) \

--- a/src/lib/gl_engine/tvgGlGeometry.cpp
+++ b/src/lib/gl_engine/tvgGlGeometry.cpp
@@ -20,11 +20,9 @@
  * SOFTWARE.
  */
 
+#include <float.h>
 #include "tvgGlGpuBuffer.h"
 #include "tvgGlGeometry.h"
-#include "tvgGlCommon.h"
-
-#include <GLES2/gl2.h>
 
 
 uint32_t GlGeometry::getPrimitiveCount()

--- a/src/lib/gl_engine/tvgGlGeometry.h
+++ b/src/lib/gl_engine/tvgGlGeometry.h
@@ -23,6 +23,8 @@
 #ifndef _TVG_GL_GEOMETRY_H_
 #define _TVG_GL_GEOMETRY_H_
 
+#include <math.h>
+#include <vector>
 #include "tvgGlCommon.h"
 
 class GlPoint

--- a/src/lib/gl_engine/tvgGlGpuBuffer.cpp
+++ b/src/lib/gl_engine/tvgGlGpuBuffer.cpp
@@ -20,10 +20,11 @@
  * SOFTWARE.
  */
 
-#include "tvgGlCommon.h"
 #include "tvgGlGpuBuffer.h"
 
-#include <assert.h>
+/************************************************************************/
+/* Internal Class Implementation                                        */
+/************************************************************************/
 
 GlGpuBuffer::GlGpuBuffer()
 {

--- a/src/lib/gl_engine/tvgGlGpuBuffer.h
+++ b/src/lib/gl_engine/tvgGlGpuBuffer.h
@@ -23,8 +23,7 @@
 #ifndef _TVG_GL_GPU_BUFFER_H_
 #define _TVG_GL_GPU_BUFFER_H_
 
-#include <stdlib.h>
-#include <GLES2/gl2.h>
+#include "tvgGlCommon.h"
 
 class GlGpuBuffer
 {

--- a/src/lib/gl_engine/tvgGlProgram.cpp
+++ b/src/lib/gl_engine/tvgGlProgram.cpp
@@ -20,14 +20,20 @@
  * SOFTWARE.
  */
 
-#include "tvgGlCommon.h"
+#include <iostream>
 #include "tvgGlProgram.h"
 
-#include <GLES2/gl2.h>
 
+/************************************************************************/
+/* Internal Class Implementation                                        */
+/************************************************************************/
 
 uint32_t GlProgram::mCurrentProgram = 0;
 
+
+/************************************************************************/
+/* External Class Implementation                                        */
+/************************************************************************/
 
 unique_ptr<GlProgram> GlProgram::gen(std::shared_ptr<GlShader> shader)
 {

--- a/src/lib/gl_engine/tvgGlProgram.h
+++ b/src/lib/gl_engine/tvgGlProgram.h
@@ -23,10 +23,8 @@
 #ifndef _TVG_GL_PROGRAM_H_
 #define _TVG_GL_PROGRAM_H_
 
-#include "tvgGlShader.h"
-
-#include <memory>
 #include <map>
+#include "tvgGlShader.h"
 
 class GlProgram
 {

--- a/src/lib/gl_engine/tvgGlPropertyInterface.cpp
+++ b/src/lib/gl_engine/tvgGlPropertyInterface.cpp
@@ -1,7 +1,37 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 #include "tvgGlPropertyInterface.h"
-#include "tvgGlRenderTask.h"
+
+/************************************************************************/
+/* Internal Class Implementation                                        */
+/************************************************************************/
 
 VertexProperty  PropertyInterface::mEmptyProperty;
+
+
+/************************************************************************/
+/* External Class Implementation                                        */
+/************************************************************************/
 
 VertexProperty& PropertyInterface::addProperty(GlRenderTask* rTask, std::shared_ptr<GlProgram> prog, std::string name, uint32_t propFormatSize, VertexProperty::PropertyType propType)
 {

--- a/src/lib/gl_engine/tvgGlPropertyInterface.h
+++ b/src/lib/gl_engine/tvgGlPropertyInterface.h
@@ -1,12 +1,30 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 #ifndef _TVG_GL_PROPERTY_INTERFACE_H_
 #define _TVG_GL_PROPERTY_INTERFACE_H_
 
-#include "tvgGlRendererProperties.h"
 #include "tvgGlRenderTask.h"
 
-#include <string>
-#include <memory>
-#include <map>
 
 #define ADD_ATTRIBUTE_PROPERTY(var, rtask, prog, varName, formatSize, location) \
     var = &PropertyInterface::addProperty(rtask, prog, varName, formatSize, VertexProperty::PropertyType::ATTRIBUTE); \

--- a/src/lib/gl_engine/tvgGlRenderTask.cpp
+++ b/src/lib/gl_engine/tvgGlRenderTask.cpp
@@ -1,12 +1,33 @@
-#include "tvgGlCommon.h"
-#include "tvgGlShaderSrc.h"
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 #include "tvgGlRenderTask.h"
+#include "tvgGlShaderSrc.h"
 #include "tvgGlPropertyInterface.h"
 
-#include <memory>
-#include <string>
-#include <GLES2/gl2.h>
 
+/************************************************************************/
+/* External Class Implementation                                        */
+/************************************************************************/
 
 GlRenderTask::GlRenderTask(RenderTypes renderType, shared_ptr<GlShader> shader)
 {

--- a/src/lib/gl_engine/tvgGlRenderTask.h
+++ b/src/lib/gl_engine/tvgGlRenderTask.h
@@ -1,13 +1,29 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 #ifndef _TVG_GL_RENDER_TASK_H_
 #define _TVG_GL_RENDER_TASK_H_
 
-#include "tvgGlShader.h"
-#include "tvgGlProgram.h"
 #include "tvgGlRendererProperties.h"
-
-#include <string>
-#include <memory>
-#include <map>
 
 #define MAX_GRADIENT_STOPS 4
 

--- a/src/lib/gl_engine/tvgGlRenderer.cpp
+++ b/src/lib/gl_engine/tvgGlRenderer.cpp
@@ -19,11 +19,10 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-#include "tvgGlShaderSrc.h"
+
+#include "tvgGlRenderer.h"
 #include "tvgGlGpuBuffer.h"
 #include "tvgGlGeometry.h"
-#include "tvgGlCommon.h"
-#include "tvgGlRenderer.h"
 #include "tvgGlPropertyInterface.h"
 
 /************************************************************************/
@@ -31,6 +30,7 @@
 /************************************************************************/
 static bool initEngine = false;
 static uint32_t rendererCnt = 0;
+
 
 static void _termEngine()
 {

--- a/src/lib/gl_engine/tvgGlRenderer.h
+++ b/src/lib/gl_engine/tvgGlRenderer.h
@@ -23,8 +23,6 @@
 #ifndef _TVG_GL_RENDERER_H_
 #define _TVG_GL_RENDERER_H_
 
-#include "tvgGlCommon.h"
-#include "tvgGlProgram.h"
 #include "tvgGlRenderTask.h"
 
 class GlRenderer : public RenderMethod

--- a/src/lib/gl_engine/tvgGlRendererProperties.h
+++ b/src/lib/gl_engine/tvgGlRendererProperties.h
@@ -1,13 +1,31 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 #ifndef _TVG_GL_RENDER_PROPERTIES_H_
 #define _TVG_GL_RENDER_PROPERTIES_H_
 
-#include "tvgGlShader.h"
-#include "tvgGlProgram.h"
-
-#include <string>
-#include <memory>
 #include <vector>
-#include <map>
+#include "tvgGlCommon.h"
+#include "tvgGlProgram.h"
 
 class PropertyValue
 {

--- a/src/lib/gl_engine/tvgGlShader.cpp
+++ b/src/lib/gl_engine/tvgGlShader.cpp
@@ -20,11 +20,13 @@
  * SOFTWARE.
  */
 
-#include "tvgGlCommon.h"
+#include <iostream>
 #include "tvgGlShader.h"
 
-#include <GLES2/gl2.h>
 
+/************************************************************************/
+/* External Class Implementation                                        */
+/************************************************************************/
 
 shared_ptr<GlShader> GlShader::gen(const char* vertSrc, const char* fragSrc)
 {

--- a/src/lib/gl_engine/tvgGlShader.h
+++ b/src/lib/gl_engine/tvgGlShader.h
@@ -23,7 +23,7 @@
 #ifndef _TVG_GL_SHADER_H_
 #define _TVG_GL_SHADER_H_
 
-#include <memory>
+#include "tvgGlCommon.h"
 
 class GlShader
 {

--- a/src/lib/gl_engine/tvgGlShaderSrc.cpp
+++ b/src/lib/gl_engine/tvgGlShaderSrc.cpp
@@ -20,9 +20,8 @@
  * SOFTWARE.
  */
 
-#include "tvgGlShaderSrc.h"
-
 #include <string>
+#include "tvgGlShaderSrc.h"
 
 #define TVG_COMPOSE_SHADER(shader) #shader
 


### PR DESCRIPTION
After refactoring header includsion, gl_engine has a break at file dependencies.
now this fixes it.