### PR TITLE
SvgLoader: Implement ClipPath style

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -940,6 +940,8 @@ static bool _attrParseGNode(void* data, const char* key, const char* value)
         node->transform = _parseTransformationMatrix(value);
     } else if (!strcmp(key, "id")) {
         node->id = _copyId(value);
+    } else if (!strcmp(key, "clip-path")) {
+        _handleClipPathAttr(loader, node, value);
     } else {
         return _parseStyleAttr(loader, key, value);
     }
@@ -1068,6 +1070,8 @@ static bool _attrParsePathNode(void* data, const char* key, const char* value)
         path->path = _copyId(value);
     } else if (!strcmp(key, "style")) {
         return simpleXmlParseW3CAttribute(value, _parseStyleAttr, loader);
+    } else if (!strcmp(key, "clip-path")) {
+        _handleClipPathAttr(loader, node, value);
     } else if (!strcmp(key, "id")) {
         node->id = _copyId(value);
     } else {
@@ -1122,6 +1126,8 @@ static bool _attrParseCircleNode(void* data, const char* key, const char* value)
 
     if (!strcmp(key, "style")) {
         return simpleXmlParseW3CAttribute(value, _parseStyleAttr, loader);
+    } else if (!strcmp(key, "clip-path")) {
+        _handleClipPathAttr(loader, node, value);
     } else if (!strcmp(key, "id")) {
         node->id = _copyId(value);
     } else {
@@ -1178,6 +1184,8 @@ static bool _attrParseEllipseNode(void* data, const char* key, const char* value
         node->id = _copyId(value);
     } else if (!strcmp(key, "style")) {
         return simpleXmlParseW3CAttribute(value, _parseStyleAttr, loader);
+    } else if (!strcmp(key, "clip-path")) {
+        _handleClipPathAttr(loader, node, value);
     } else {
         return _parseStyleAttr(loader, key, value);
     }
@@ -1247,6 +1255,8 @@ static bool _attrParsePolygonNode(void* data, const char* key, const char* value
         return _attrParsePolygonPoints(value, &polygon->points, &polygon->pointsCount);
     } else if (!strcmp(key, "style")) {
         return simpleXmlParseW3CAttribute(value, _parseStyleAttr, loader);
+    } else if (!strcmp(key, "clip-path")) {
+        _handleClipPathAttr(loader, node, value);
     } else if (!strcmp(key, "id")) {
         node->id = _copyId(value);
     } else {
@@ -1321,6 +1331,8 @@ static bool _attrParseRectNode(void* data, const char* key, const char* value)
         node->id = _copyId(value);
     } else if (!strcmp(key, "style")) {
         ret = simpleXmlParseW3CAttribute(value, _parseStyleAttr, loader);
+    } else if (!strcmp(key, "clip-path")) {
+        _handleClipPathAttr(loader, node, value);
     } else {
         ret = _parseStyleAttr(loader, key, value);
     }
@@ -1379,6 +1391,8 @@ static bool _attrParseLineNode(void* data, const char* key, const char* value)
         node->id = _copyId(value);
     } else if (!strcmp(key, "style")) {
         return simpleXmlParseW3CAttribute(value, _parseStyleAttr, loader);
+    } else if (!strcmp(key, "clip-path")) {
+        _handleClipPathAttr(loader, node, value);
     } else {
         return _parseStyleAttr(loader, key, value);
     }
@@ -1574,6 +1588,8 @@ static bool _attrParseUseNode(void* data, const char* key, const char* value)
         nodeFrom = _findChildById(defs, id->c_str());
         _cloneNode(nodeFrom, node);
         delete id;
+    } else if (!strcmp(key, "clip-path")) {
+        _handleClipPathAttr(loader, node, value);
     } else {
         _attrParseGNode(data, key, value);
     }

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -1445,7 +1445,7 @@ static SvgNode* _findChildById(SvgNode* node, const char* id)
 static SvgNode* _findNodeById(SvgNode *node, string* id)
 {
     SvgNode* result = nullptr;
-    if ((node->id != nullptr) && !node->id->compare(*id)) return node;
+    if (node->id && !node->id->compare(*id)) return node;
 
     if (node->child.cnt > 0) {
         auto child = node->child.list;

--- a/src/loaders/svg/tvgSvgLoaderCommon.h
+++ b/src/loaders/svg/tvgSvgLoaderCommon.h
@@ -45,6 +45,7 @@ enum class SvgNodeType
     Tspan,
     Use,
     Video,
+    ClipPath,
     //Custome_command,   //Not support
     Unknown
 };
@@ -60,12 +61,18 @@ enum class SvgLengthType
     In,
 };
 
+enum class SvgCompositeFlags
+{
+    ClipPath = 0x01,
+};
+
 enum class SvgFillFlags
 {
-    Paint = 0x1,
-    Opacity = 0x2,
-    Gradient = 0x4,
-    FillRule = 0x8
+    Paint = 0x01,
+    Opacity = 0x02,
+    Gradient = 0x04,
+    FillRule = 0x08,
+    ClipPath = 0x16
 };
 
 enum class SvgStrokeFlags
@@ -244,6 +251,13 @@ struct SvgGradientStop
     uint8_t a;
 };
 
+struct SvgComposite
+{
+    SvgCompositeFlags flags;
+    string *url;
+    SvgNode* node;
+};
+
 struct SvgPaint
 {
     SvgStyleGradient* gradient;
@@ -300,6 +314,7 @@ struct SvgStyleProperty
 {
     SvgStyleFill fill;
     SvgStyleStroke stroke;
+    SvgComposite comp;
     int opacity;
     uint8_t r;
     uint8_t g;

--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -359,10 +359,10 @@ unique_ptr<Scene> _sceneBuildHelper(SvgNode* node, float vx, float vy, float vw,
                     (*child)->style->opacity = ((*child)->style->opacity * node->style->opacity) / 255.0f;
                     scene->push(_shapeBuildHelper(*child, vx, vy, vw, vh));
                 }
-
+            }
             //Apply composite node
             if (node->style->comp.node) {
-                 //Composite ClipPath
+                //Composite ClipPath
                 if (((int)node->style->comp.flags & (int)SvgCompositeFlags::ClipPath)) {
                     auto compNode = node->style->comp.node;
                     if (compNode->child.cnt > 0) {
@@ -372,7 +372,6 @@ unique_ptr<Scene> _sceneBuildHelper(SvgNode* node, float vx, float vy, float vw,
                         scene->composite(move(comp), CompositeMethod::ClipPath);
                     }
                 }
-            }
             }
         }
         return scene;


### PR DESCRIPTION
#49
Supports case of using style attribute for defined `<clipPath>`.
In SVG, `<clipPath>` can be used as a `"clipPath"` attribute or a style `"clip-path"`.
This patch only supports when `"clip-path"` of style is declared.
The remaining features will be added later.

[Spec]
https://drafts.fxtf.org/css-masking-1/#elementdef-clippath

[Example SVG case]
```html
<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
	 viewBox="0 0 64 64" enable-background="new 0 0 64 64" xml:space="preserve">
 <defs>
      <clipPath id="clipPath">
          <rect x="15" y="15" width="40" height="40" fill="#F00" />
          <circle cx="20" cy="20" r="10" fill="#F00" />
      </clipPath>
  </defs>
  <circle cx="25" cy="25" r="20"
          style="fill: #0000ff; clip-path: url(#clipPath); " />
</svg>
```

![image](https://user-images.githubusercontent.com/7413838/95284722-d7e41680-0899-11eb-8354-0ecd00026396.png)
left : circle with clip-path, right: normal circle

![image](https://user-images.githubusercontent.com/7413838/95713245-2a11a700-0ca1-11eb-9a50-c318ea63e50d.png)
[clip-path_test_svgs.zip](https://github.com/Samsung/thorvg/files/5363354/clip-path_test_svgs.zip)
ellipse, circle, path, g
polyline, polygon, rect



