### PR TITLE
Bezier curve: extension of the termination condition in bezLength()

### DIFF
--- a/src/lib/tvgBezier.cpp
+++ b/src/lib/tvgBezier.cpp
@@ -74,7 +74,7 @@ float bezLength(const Bezier& cur)
     auto len = _lineLength(cur.start, cur.ctrl1) + _lineLength(cur.ctrl1, cur.ctrl2) + _lineLength(cur.ctrl2, cur.end);
     auto chord = _lineLength(cur.start, cur.end);
 
-    if (fabs(len - chord) > FLT_EPSILON) {
+    if (fabs(len - chord) > BEZIER_EPSILON) {
         bezSplit(cur, left, right);
         return bezLength(left) + bezLength(right);
     }
@@ -124,7 +124,7 @@ float bezAt(const Bezier& bz, float at)
         bezSplitLeft(right, t, left);
         len = bezLength(left);
 
-        if (fabs(len - at) < FLT_EPSILON || fabs(smallest - biggest) < FLT_EPSILON) {
+        if (fabs(len - at) < BEZIER_EPSILON || fabs(smallest - biggest) < BEZIER_EPSILON) {
             break;
         }
 

--- a/src/lib/tvgBezier.h
+++ b/src/lib/tvgBezier.h
@@ -27,6 +27,8 @@
 namespace tvg
 {
 
+#define BEZIER_EPSILON 1e-4f
+
 struct Bezier
 {
     Point start;


### PR DESCRIPTION
Added a condition that prevents bezLength() function
from making infinite number of calls.

- Description :
Plotting a curve with a dashed stroke in some cases crashed. This is because the condition for the termination of the bezLength() function was never satisfied. There was still a discrepancy , which was greater than 

The difference between the length of two approximations of the Bezier curve:
 - the straight line from the start to the end point 
and 
 - the length calculated as a sum of three lines (start-ctrl1, ctrl1-ctrl2 and ctrl2-end) 
was > FLT_EPSILON.

In such a case, the algorithm splits the curve into two smaller ones, but because of the finite density of floats, the calculation of of the points of the new Bezier curves ended with one of them being exactly same as the other (or the initial one).

- Issue Tickets (if any) :

- Tests or Samples (if any) :
An example that is crashing without this correction: BezierLength.cpp
The example is available here:
https://github.com/mgrudzinska/thorvg/tree/mgrudzinska/BezLength_ex_segf

- Screen Shots (if any) :
