### PR TITLE
common shape: fix reset() bug.

### DIFF
--- a/src/lib/tvgShape.cpp
+++ b/src/lib/tvgShape.cpp
@@ -51,9 +51,7 @@ unique_ptr<Shape> Shape::gen() noexcept
 
 Result Shape::reset() noexcept
 {
-    pImpl->path->reset();
-
-    pImpl->flag |= RenderUpdateFlag::Path;
+    pImpl->reset();
 
     return Result::Success;
 }

--- a/src/lib/tvgShapeImpl.h
+++ b/src/lib/tvgShapeImpl.h
@@ -305,6 +305,24 @@ struct Shape::Impl
         return true;
     }
 
+    void reset()
+    {
+        path->reset();
+
+        if (fill) {
+            delete(fill);
+            fill = nullptr;
+        }
+        if (stroke) {
+            delete(stroke);
+            stroke = nullptr;
+        }
+
+        color[0] = color[1] = color[2] = color[3] = 0;
+
+        flag = RenderUpdateFlag::All;
+    }
+
     Paint* duplicate()
     {
         auto ret = Shape::gen();


### PR DESCRIPTION
- Description :

Previous reset() doesn't implemented properly.
It resets only path data.

Now Shape resets all drawing properties.

- Issue Tickets (if any) :
https://github.com/Samsung/thorvg/issues/56

- Tests or Samples (if any) :

`tvg_engine_init(TVG_ENGINE_SW | TVG_ENGINE_GL, 0);

Tvg_Canvas* canvas = tvg_swcanvas_create();
tvg_swcanvas_set_target(canvas, buffer, WIDTH, WIDTH, HEIGHT, TVG_COLORSPACE_ARGB8888);

Tvg_Paint* shape = tvg_shape_new();
tvg_shape_append_rect(shape, 0, 0, 200, 200, 0, 0);

tvg_shape_set_stroke_color(shape, 255, 0, 0, 255);
tvg_shape_set_stroke_width(shape, 4);
tvg_shape_set_fill_color(shape, 0, 0, 255, 255);

tvg_canvas_push(canvas, shape);

tvg_canvas_draw(canvas);
tvg_canvas_sync(canvas);

tvg_shape_reset(shape);
tvg_canvas_update_paint(canvas, shape);

tvg_canvas_draw(canvas);
tvg_canvas_sync(canvas);
tvg_canvas_destroy(canvas);

tvg_engine_term(TVG_ENGINE_SW | TVG_ENGINE_GL);`

- Screen Shots (if any) :
