### PR TITLE
dash pattern: handling dash patterns < 1

### DIFF
--- a/src/lib/sw_engine/tvgSwCommon.h
+++ b/src/lib/sw_engine/tvgSwCommon.h
@@ -165,7 +165,7 @@ struct SwStroke
 struct SwDashStroke
 {
     SwOutline* outline;
-    int32_t curLen;
+    float curLen;
     int32_t curIdx;
     Point ptStart;
     Point ptCur;

--- a/src/lib/sw_engine/tvgSwShape.cpp
+++ b/src/lib/sw_engine/tvgSwShape.cpp
@@ -113,7 +113,6 @@ static void _outlineMoveTo(SwOutline& outline, const Point* to, const Matrix* tr
     _growOutlinePoint(outline, 1);
 
     outline.pts[outline.ptsCnt] = _transform(to, transform);
-
     outline.types[outline.ptsCnt] = SW_CURVE_TYPE_POINT;
 
     if (outline.ptsCnt > 0) {
@@ -285,7 +284,7 @@ static void _dashCubicTo(SwDashStroke& dash, const Point* ctrl1, const Point* ct
     _growOutlinePoint(*dash.outline, dash.outline->ptsCnt >> 1);
     _growOutlineContour(*dash.outline, dash.outline->cntrsCnt >> 1);
 
-    Bezier cur = { dash.ptCur, *ctrl1, *ctrl2, *to};
+    Bezier cur = {dash.ptCur, *ctrl1, *ctrl2, *to};
     auto len = bezLength(cur);
 
     if (len < dash.curLen) {

--- a/src/lib/tvgShape.cpp
+++ b/src/lib/tvgShape.cpp
@@ -339,6 +339,9 @@ Result Shape::stroke(const float* dashPattern, uint32_t cnt) noexcept
 {
     if (cnt < 2 || !dashPattern) return Result::InvalidArguments;
 
+    for (uint32_t i = 0; i < cnt; i++)
+        if (dashPattern[i] < FLT_EPSILON) return Result::InvalidArguments;
+
     if (!pImpl->strokeDash(dashPattern, cnt)) return Result::FailedAllocation;
 
     return Result::Success;
@@ -350,6 +353,7 @@ uint32_t Shape::strokeDash(const float** dashPattern) const noexcept
     if (!pImpl->stroke) return 0;
 
     if (dashPattern) *dashPattern = pImpl->stroke->dashPattern;
+
     return pImpl->stroke->dashCnt;
 }
 


### PR DESCRIPTION
For the dash pattern values (both, length and gap) < 1 the program crashed.
curLen - variable type changed from int to float.

- Description :
For the dash pattern values (both, length and gap) < 1, the program crashes, because it falls into the infinite while loop (the total length of the dashed outline is reduced in each step by a value of zero, so it never gets smaller and the while loop termination condition is never satisfied).

The curLen variable changed to be float type instead of int, as it holds the current value of the plotted pattern, which is a float type.

- Issue Tickets (if any) :

- Tests or Samples (if any) :
Example that crashes without this correction: SmallDashPatterns.cpp
https://github.com/mgrudzinska/thorvg/tree/mgrudzinska/curLen_ex_crash

- Screen Shots (if any) :
