### PR TITLE
tvgSvgLoader: Add points copy of missing polygon/polyline

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -1487,13 +1487,13 @@ static void _copyAttr(SvgNode* to, SvgNode* from)
         }
         case SvgNodeType::Polygon: {
             to->node.polygon.pointsCount = from->node.polygon.pointsCount;
-            to->node.polygon.points = (float*)calloc(to->node.polygon.pointsCount, sizeof(float));
+            to->node.polygon.points = (float*)malloc(to->node.polygon.pointsCount * sizeof(float));
             memcpy(to->node.polygon.points, from->node.polygon.points, to->node.polygon.pointsCount * sizeof(float));
             break;
         }
         case SvgNodeType::Polyline: {
             to->node.polyline.pointsCount = from->node.polyline.pointsCount;
-            to->node.polyline.points = (float*)calloc(to->node.polyline.pointsCount, sizeof(float));
+            to->node.polyline.points = (float*)malloc(to->node.polyline.pointsCount * sizeof(float));
             memcpy(to->node.polyline.points, from->node.polyline.points, to->node.polyline.pointsCount * sizeof(float));
             break;
         }

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -1488,11 +1488,13 @@ static void _copyAttr(SvgNode* to, SvgNode* from)
         case SvgNodeType::Polygon: {
             to->node.polygon.pointsCount = from->node.polygon.pointsCount;
             to->node.polygon.points = (float*)calloc(to->node.polygon.pointsCount, sizeof(float));
+            memcpy(to->node.polygon.points, from->node.polygon.points, to->node.polygon.pointsCount * sizeof(float));
             break;
         }
         case SvgNodeType::Polyline: {
             to->node.polyline.pointsCount = from->node.polyline.pointsCount;
             to->node.polyline.points = (float*)calloc(to->node.polyline.pointsCount, sizeof(float));
+            memcpy(to->node.polyline.points, from->node.polyline.points, to->node.polyline.pointsCount * sizeof(float));
             break;
         }
         default: {


### PR DESCRIPTION
- Description :
When using `<use>` node, do atrribute copy.
At that time, when target(`url`) is `polygon` or `polyline`,
points array is not copied, causing a problem in output.
So, add missing `memcpy()`

- Tests or Samples (if any) :
Test SVG Sample
```html
<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
viewBox="0 0 64 64" enable-background="new 0 0 64 64" xml:space="preserve">
    <g opacity="0.5">
        <defs>
            <polygon id="test" opacity="0.5" points="41.8,14.5 22.2,14.5 22.2,22.8 41.8,40.7"/>
        </defs>
        <use xlink:href="#test"  overflow="visible"/>
    </g>
</svg>
```
