### PR TITLE
sw_engine: fix missing shape update issue.

### DIFF
--- a/src/examples/Stress.cpp
+++ b/src/examples/Stress.cpp
@@ -8,6 +8,7 @@
 #define NUM_PER_LINE 16
 #define SIZE 50
 
+static bool rendered = false;
 static int count = 0;
 static int frame = 0;
 static std::vector<tvg::Picture*> pictures;
@@ -108,10 +109,14 @@ void drawSwView(void* data, Eo* obj)
 
     t4 = ecore_time_get();
     printf("[%5d]: total[%fs] update[%fs], render[%fs]\n", ++frame, t4 - t1, t2 - t1, t4 - t3);
+
+    rendered = true;
 }
 
 void transitSwCb(Elm_Transit_Effect *effect, Elm_Transit* transit, double progress)
 {
+    if (!rendered) return;
+
     t1 = ecore_time_get();
 
     for (auto picture : pictures) {
@@ -124,7 +129,9 @@ void transitSwCb(Elm_Transit_Effect *effect, Elm_Transit* transit, double progre
     //Update Efl Canvas
     auto img = (Eo*) effect;
     evas_object_image_pixels_dirty_set(img, EINA_TRUE);
-    evas_object_image_data_update_add(img, 0, 0, WIDTH, HEIGHT);    
+    evas_object_image_data_update_add(img, 0, 0, WIDTH, HEIGHT);
+
+    rendered = false;
 }
 
 

--- a/src/lib/sw_engine/tvgSwCommon.h
+++ b/src/lib/sw_engine/tvgSwCommon.h
@@ -270,6 +270,7 @@ SwFixed mathMean(SwFixed angle1, SwFixed angle2);
 void shapeReset(SwShape* shape);
 bool shapeGenOutline(SwShape* shape, const Shape* sdata, const Matrix* transform);
 bool shapePrepare(SwShape* shape, const Shape* sdata, const SwSize& clip, const Matrix* transform);
+bool shapePrepared(SwShape* shape);
 bool shapeGenRle(SwShape* shape, const Shape* sdata, const SwSize& clip, bool antiAlias, bool hasComposite);
 void shapeDelOutline(SwShape* shape);
 void shapeResetStroke(SwShape* shape, const Shape* sdata, const Matrix* transform);

--- a/src/lib/sw_engine/tvgSwShape.cpp
+++ b/src/lib/sw_engine/tvgSwShape.cpp
@@ -459,6 +459,12 @@ bool shapePrepare(SwShape* shape, const Shape* sdata, const SwSize& clip, const 
 }
 
 
+bool shapePrepared(SwShape* shape)
+{
+    return shape->rle ? true : false;
+}
+
+
 bool shapeGenRle(SwShape* shape, TVG_UNUSED const Shape* sdata, const SwSize& clip, bool antiAlias, bool hasComposite)
 {
     //FIXME: Should we draw it?


### PR DESCRIPTION
It missed to update shape data if visilibity is changed from false to true by alpha.

Also, it needs to update engine shape data for every requests.

There scenario can be allowed,

1. update shape
2. change shape property
3. update shape
4. draw

previously engine could skip step 3, its result was not properly expected.

@fix #84

- Description :

- Issue Tickets (if any) :

- Tests or Samples (if any) :

- Screen Shots (if any) :
