### PR TITLE
thorvg viewer: fix scale problem

### DIFF
--- a/src/wasm/thorvgwasm.cpp
+++ b/src/wasm/thorvgwasm.cpp
@@ -23,7 +23,6 @@ public:
 
     bool load(string data, int width, int height)
     {
-        uint32_t pw, ph;
         float w, h;
 
         mErrorMsg = "None";
@@ -55,16 +54,10 @@ public:
 
         /* get default size */
         mPicture->viewbox(nullptr, nullptr, &w, &h);
-
-        pw = mDefaultWidth;
-        ph = mDefaultHeight;
         mDefaultWidth = static_cast<uint32_t>(w);
         mDefaultHeight = static_cast<uint32_t>(h);
 
-        if (pw != mDefaultWidth || ph != mDefaultHeight) {
-            updateScale();
-        }
-
+        updateScale();
         updateSize(width, height);
 
         if (mSwCanvas->push(unique_ptr<Picture>(mPicture)) != Result::Success) {


### PR DESCRIPTION
If viewer calls load() with a data which does not have size changes of both
viewbox and canvas, then load() does not set a scale value.
This makes incorrect result on viewer side.

So thorvg wasm should set a scale value, whenever load() is called.
