### PR TITLE
common canvas: Added canvas->remove API

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -149,6 +149,7 @@ public:
 
     Result reserve(uint32_t n) noexcept;
     virtual Result push(std::unique_ptr<Paint> paint) noexcept;
+    virtual Result remove(Paint *p) noexcept;
     virtual Result clear(bool free = true) noexcept;
     virtual Result update(Paint* paint) noexcept;
     virtual Result draw() noexcept;

--- a/inc/thorvg_capi.h
+++ b/inc/thorvg_capi.h
@@ -104,6 +104,7 @@ TVG_EXPORT Tvg_Result tvg_swcanvas_set_target(Tvg_Canvas* canvas, uint32_t* buff
 /************************************************************************/
 TVG_EXPORT Tvg_Result tvg_canvas_destroy(Tvg_Canvas* canvas);
 TVG_EXPORT Tvg_Result tvg_canvas_push(Tvg_Canvas* canvas, Tvg_Paint* paint);
+TVG_EXPORT Tvg_Result tvg_canvas_remove(Tvg_Canvas*canvas, Tvg_Paint* paint);
 TVG_EXPORT Tvg_Result tvg_canvas_reserve(Tvg_Canvas* canvas, uint32_t n);
 TVG_EXPORT Tvg_Result tvg_canvas_clear(Tvg_Canvas* canvas);
 TVG_EXPORT Tvg_Result tvg_canvas_update(Tvg_Canvas* canvas);

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -80,6 +80,13 @@ TVG_EXPORT Tvg_Result tvg_canvas_push(Tvg_Canvas* canvas, Tvg_Paint* paint)
 }
 
 
+TVG_EXPORT Tvg_Result tvg_canvas_remove(Tvg_Canvas* canvas, Tvg_Paint *paint)
+{
+    if (!canvas || !paint) return TVG_RESULT_INVALID_ARGUMENT;
+    return (Tvg_Result) reinterpret_cast<Canvas*>(canvas)->remove((Paint *)paint);
+}
+
+
 TVG_EXPORT Tvg_Result tvg_canvas_reserve(Tvg_Canvas* canvas, uint32_t n)
 {
     if (!canvas) return TVG_RESULT_INVALID_ARGUMENT;

--- a/src/lib/tvgCanvas.cpp
+++ b/src/lib/tvgCanvas.cpp
@@ -49,6 +49,12 @@ Result Canvas::push(unique_ptr<Paint> paint) noexcept
 }
 
 
+Result Canvas::remove(Paint *p) noexcept
+{
+    return pImpl->remove(p);
+}
+
+
 Result Canvas::clear(bool free) noexcept
 {
     return pImpl->clear(free);

--- a/src/lib/tvgCanvasImpl.h
+++ b/src/lib/tvgCanvasImpl.h
@@ -23,6 +23,7 @@
 #define _TVG_CANVAS_IMPL_H_
 
 #include <vector>
+#include <algorithm>
 #include "tvgPaint.h"
 
 /************************************************************************/
@@ -51,6 +52,15 @@ struct Canvas::Impl
         paints.push_back(p);
 
         return update(p);
+    }
+
+    Result remove(Paint *p)
+    {
+        if (!p) return Result::InvalidArguments;
+        std::vector<Paint*>::iterator it;
+        it = find(paints.begin(), paints.end(), p);
+        if (it != paints.end()) paints.erase(it);
+        return Result::Success;
     }
 
     Result clear(bool free)

--- a/src/lib/tvgCanvasImpl.h
+++ b/src/lib/tvgCanvasImpl.h
@@ -57,7 +57,7 @@ struct Canvas::Impl
     Result remove(Paint *p)
     {
         if (!p) return Result::InvalidArguments;
-        std::vector<Paint*>::iterator it;
+        vector<Paint*>::iterator it;
         it = find(paints.begin(), paints.end(), p);
         if (it != paints.end()) paints.erase(it);
         return Result::Success;


### PR DESCRIPTION
Description :

Introduce new method: `canvas-remove(Paint)` used to remove paints from
vector of paints in `Canvas` class. Additonally CAPI for new method was
added. Api is used for safly remove Paint object from canvas. It allows
to use following api sequence without crash:

```c
tvg_canvas_remove(canvas, paint);
tvg_paint_del(paint);
tvg_canvas_draw(canvas);
```

@API Additions:
Result Canvas::remove(Paint *p)
tvg_canvas_remove(Tvg_Canvas *canvas, Tvg_Paint *p)