### PR TITLE
sw_engine renderer: fix aliasing shape outline result.

### DIFF
--- a/src/lib/sw_engine/tvgSwRenderer.cpp
+++ b/src/lib/sw_engine/tvgSwRenderer.cpp
@@ -62,7 +62,10 @@ struct SwTask : Task
                 shapeReset(&shape);
                 if (!shapePrepare(&shape, sdata, clip, transform)) return;
                 if (renderShape) {
-                    auto antiAlias = (strokeAlpha > 0 && strokeWidth >= 2) ? false : true;
+                    /* We assume that if stroke width is bigger than 2,
+                       shape outline below stroke could be full covered by stroke drawing.
+                       Thus it turns off antialising in that condition. */
+                    auto antiAlias = (strokeAlpha > 0 && strokeWidth > 2) ? false : true;
                     if (!shapeGenRle(&shape, sdata, clip, antiAlias, compList.size() > 0 ? true : false)) return;
                 }
             }


### PR DESCRIPTION
There a scenario detected that stroke 2 is not enough to cover
shape outlines. So make it bigger size.

- Description :

- Issue Tickets (if any) :

- Tests or Samples (if any) : examples Svg

- Screen Shots (if any) :
