### PR TITLE
sw_engine shape: support fillRule method

### DIFF
--- a/src/lib/sw_engine/tvgSwCommon.h
+++ b/src/lib/sw_engine/tvgSwCommon.h
@@ -41,8 +41,6 @@ static double timeStamp()
 
 #define SW_CURVE_TYPE_POINT 0
 #define SW_CURVE_TYPE_CUBIC 1
-#define SW_OUTLINE_FILL_WINDING 0
-#define SW_OUTLINE_FILL_EVEN_ODD 1
 #define SW_ANGLE_PI (180L << 16)
 #define SW_ANGLE_2PI (SW_ANGLE_PI << 1)
 #define SW_ANGLE_PI2 (SW_ANGLE_PI >> 1)
@@ -106,7 +104,7 @@ struct SwOutline
     uint32_t      ptsCnt;           //number of points in the glyph
     uint32_t      reservedPtsCnt;
     uint8_t*      types;            //curve type
-    uint8_t       fillMode;         //outline fill mode
+    FillRule      fillRule;
     bool          opened;           //opened path?
 };
 

--- a/src/lib/sw_engine/tvgSwRle.cpp
+++ b/src/lib/sw_engine/tvgSwRle.cpp
@@ -170,7 +170,7 @@ static void _horizLine(RleWorker& rw, SwCoord x, SwCoord y, SwCoord area, SwCoor
 
     if (coverage < 0) coverage = -coverage;
 
-    if (rw.outline->fillMode == SW_OUTLINE_FILL_EVEN_ODD) {
+    if (rw.outline->fillRule == FillRule::EvenOdd) {
         coverage &= 511;
         if (coverage > 256) coverage = 512 - coverage;
         else if (coverage == 256) coverage = 255;

--- a/src/lib/sw_engine/tvgSwShape.cpp
+++ b/src/lib/sw_engine/tvgSwShape.cpp
@@ -578,9 +578,7 @@ bool shapeGenOutline(SwShape* shape, const Shape* sdata, const Matrix* transform
 
     if (closed) outline->opened = false;
 
-    //FIXME:
-    //outline->flags = SwOutline::FillRule::Winding;
-
+    outline->fillRule = sdata->fillRule();
     shape->outline = outline;
 
     return true;


### PR DESCRIPTION
this change supports EvenOdd fillrule in shape rendering

@Examples: examples/FillRule.cpp

@Isuses: 97

- Description :

- Issue Tickets (if any) :

- Tests or Samples (if any) :

- Screen Shots (if any) :
