### PR TITLE
common api: interface refactoring

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -245,8 +245,8 @@ public:
     //Getters
     uint32_t pathCommands(const PathCommand** cmds) const noexcept;
     uint32_t pathCoords(const Point** pts) const noexcept;
-    Result fill(uint8_t* r, uint8_t* g, uint8_t* b, uint8_t* a) const noexcept;   //TODO: => fillColor
     const Fill* fill() const noexcept;
+    Result fillColor(uint8_t* r, uint8_t* g, uint8_t* b, uint8_t* a) const noexcept;
     FillRule fillRule() const noexcept;
 
     float strokeWidth() const noexcept;

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -340,7 +340,7 @@ TVG_EXPORT Tvg_Result tvg_shape_set_fill_color(Tvg_Paint* paint, uint8_t r, uint
 TVG_EXPORT Tvg_Result tvg_shape_get_fill_color(const Tvg_Paint* paint, uint8_t* r, uint8_t* g, uint8_t* b, uint8_t* a)
 {
     if (!paint) return TVG_RESULT_INVALID_ARGUMENT;
-    return (Tvg_Result) reinterpret_cast<Shape*>(CCP(paint))->fill(r, g, b, a);
+    return (Tvg_Result) reinterpret_cast<Shape*>(CCP(paint))->fillColor(r, g, b, a);
 }
 
 

--- a/src/lib/sw_engine/tvgSwRenderer.cpp
+++ b/src/lib/sw_engine/tvgSwRenderer.cpp
@@ -56,7 +56,7 @@ struct SwTask : Task
         //Shape
         if (flags & (RenderUpdateFlag::Path | RenderUpdateFlag::Transform) || prepareShape) {
             uint8_t alpha = 0;
-            sdata->fill(nullptr, nullptr, nullptr, &alpha);
+            sdata->fillColor(nullptr, nullptr, nullptr, &alpha);
             bool renderShape = (alpha > 0 || sdata->fill());
             if (renderShape || strokeAlpha) {
                 shapeReset(&shape);
@@ -183,7 +183,7 @@ bool SwRenderer::render(const Shape& shape, void *data)
     if (auto fill = task->sdata->fill()) {
         rasterGradientShape(surface, &task->shape, fill->id());
     } else{
-        task->sdata->fill(&r, &g, &b, &a);
+        task->sdata->fillColor(&r, &g, &b, &a);
         if (a > 0) rasterSolidShape(surface, &task->shape, r, g, b, a);
     }
     task->sdata->strokeColor(&r, &g, &b, &a);

--- a/src/lib/tvgShape.cpp
+++ b/src/lib/tvgShape.cpp
@@ -283,7 +283,7 @@ Result Shape::fill(unique_ptr<Fill> f) noexcept
 }
 
 
-Result Shape::fill(uint8_t* r, uint8_t* g, uint8_t* b, uint8_t* a) const noexcept
+Result Shape::fillColor(uint8_t* r, uint8_t* g, uint8_t* b, uint8_t* a) const noexcept
 {
     if (r) *r = pImpl->color[0];
     if (g) *g = pImpl->color[1];

--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -234,7 +234,7 @@ void _applyProperty(SvgNode* node, Shape* vg, float vx, float vy, float vw, floa
     //Apply node opacity
     if (style->opacity < 255) {
         uint8_t r, g, b, a;
-        vg->fill(&r, &g, &b, &a);
+        vg->fillColor(&r, &g, &b, &a);
         vg->fill(r, g, b, (a * style->opacity) / 255.0f);
     }
 


### PR DESCRIPTION
returning color fill() method renamed to fillColor() as like others-strokeXXX, fillRule- do.

This change is for naming consistency.

- Description :

- Issue Tickets (if any) :

- Tests or Samples (if any) :

- Screen Shots (if any) :
