### PR TITLE
common api: revise fill interface.

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -93,9 +93,12 @@ public:
     Result translate(float x, float y) noexcept;
     Result transform(const Matrix& m) noexcept;
     Result bounds(float* x, float* y, float* w, float* h) const noexcept;
+    Result opacity(uint8_t alpha) noexcept;
     Paint* duplicate() const noexcept;
 
     Result composite(std::unique_ptr<Paint> target, CompositeMethod method) const noexcept;
+
+    uint8_t opacity() const noexcept;
 
     _TVG_DECLARE_ACCESSOR();
     _TVG_DECLARE_PRIVATE(Paint);
@@ -238,7 +241,7 @@ public:
     Result stroke(StrokeJoin join) noexcept;
 
     //Fill
-    Result fill(uint8_t r, uint8_t g, uint8_t b, uint8_t a) noexcept;
+    Result fill(uint8_t r, uint8_t g, uint8_t b) noexcept;
     Result fill(std::unique_ptr<Fill> f) noexcept;
     Result fill(FillRule r) noexcept;
 
@@ -246,7 +249,7 @@ public:
     uint32_t pathCommands(const PathCommand** cmds) const noexcept;
     uint32_t pathCoords(const Point** pts) const noexcept;
     const Fill* fill() const noexcept;
-    Result fillColor(uint8_t* r, uint8_t* g, uint8_t* b, uint8_t* a) const noexcept;
+    Result fillColor(uint8_t* r, uint8_t* g, uint8_t* b) const noexcept;
     FillRule fillRule() const noexcept;
 
     float strokeWidth() const noexcept;

--- a/inc/thorvg_capi.h
+++ b/inc/thorvg_capi.h
@@ -147,8 +147,10 @@ TVG_EXPORT Tvg_Result tvg_shape_set_stroke_cap(Tvg_Paint* paint, Tvg_Stroke_Cap 
 TVG_EXPORT Tvg_Result tvg_shape_get_stroke_cap(const Tvg_Paint* paint, Tvg_Stroke_Cap* cap);
 TVG_EXPORT Tvg_Result tvg_shape_set_stroke_join(Tvg_Paint* paint, Tvg_Stroke_Join join);
 TVG_EXPORT Tvg_Result tvg_shape_get_stroke_join(const Tvg_Paint* paint, Tvg_Stroke_Join* join);
-TVG_EXPORT Tvg_Result tvg_shape_set_fill_color(Tvg_Paint* paint, uint8_t r, uint8_t g, uint8_t b, uint8_t a);
-TVG_EXPORT Tvg_Result tvg_shape_get_fill_color(const Tvg_Paint* paint, uint8_t* r, uint8_t* g, uint8_t* b, uint8_t* a);
+TVG_EXPORT Tvg_Result tvg_shape_set_fill_color(Tvg_Paint* paint, uint8_t r, uint8_t g, uint8_t b);
+TVG_EXPORT Tvg_Result tvg_shape_get_fill_color(const Tvg_Paint* paint, uint8_t* r, uint8_t* g, uint8_t* b);
+TVG_EXPORT Tvg_Result tvg_shape_set_opacity(Tvg_Paint* paint, uint8_t alpha);
+TVG_EXPORT Tvg_Result tvg_shape_get_opacity(Tvg_Paint* paint, uint8_t* alpha);
 TVG_EXPORT Tvg_Result tvg_shape_set_linear_gradient(Tvg_Paint* paint, Tvg_Gradient* grad);
 TVG_EXPORT Tvg_Result tvg_shape_set_radial_gradient(Tvg_Paint* paint, Tvg_Gradient* grad);
 TVG_EXPORT Tvg_Result tvg_shape_get_gradient(const Tvg_Paint* paint, Tvg_Gradient** grad);

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -329,18 +329,31 @@ TVG_EXPORT Tvg_Result tvg_shape_get_stroke_join(const Tvg_Paint* paint, Tvg_Stro
     return TVG_RESULT_SUCCESS;
 }
 
-
-TVG_EXPORT Tvg_Result tvg_shape_set_fill_color(Tvg_Paint* paint, uint8_t r, uint8_t g, uint8_t b, uint8_t a)
+TVG_EXPORT Tvg_Result tvg_shape_set_opacity(Tvg_Paint* paint, uint8_t alpha)
 {
     if (!paint) return TVG_RESULT_INVALID_ARGUMENT;
-    return (Tvg_Result) reinterpret_cast<Shape*>(paint)->fill(r, g, b, a);
+    return (Tvg_Result) reinterpret_cast<Shape*>(paint)->opacity(alpha);
 }
 
 
-TVG_EXPORT Tvg_Result tvg_shape_get_fill_color(const Tvg_Paint* paint, uint8_t* r, uint8_t* g, uint8_t* b, uint8_t* a)
+TVG_EXPORT Tvg_Result tvg_shape_get_opacity(Tvg_Paint* paint, uint8_t* alpha)
 {
     if (!paint) return TVG_RESULT_INVALID_ARGUMENT;
-    return (Tvg_Result) reinterpret_cast<Shape*>(CCP(paint))->fillColor(r, g, b, a);
+    return (Tvg_Result) reinterpret_cast<Shape*>(CCP(paint))->opacity();
+}
+
+
+TVG_EXPORT Tvg_Result tvg_shape_set_fill_color(Tvg_Paint* paint, uint8_t r, uint8_t g, uint8_t b)
+{
+    if (!paint) return TVG_RESULT_INVALID_ARGUMENT;
+    return (Tvg_Result) reinterpret_cast<Shape*>(paint)->fill(r, g, b);
+}
+
+
+TVG_EXPORT Tvg_Result tvg_shape_get_fill_color(const Tvg_Paint* paint, uint8_t* r, uint8_t* g, uint8_t* b)
+{
+    if (!paint) return TVG_RESULT_INVALID_ARGUMENT;
+    return (Tvg_Result) reinterpret_cast<Shape*>(CCP(paint))->fillColor(r, g, b);
 }
 
 

--- a/src/examples/Arc.cpp
+++ b/src/examples/Arc.cpp
@@ -49,21 +49,21 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     //Pie Fill
     auto shape7 = tvg::Shape::gen();
     shape7->appendArc(150, 650, 80, 10, 180, true);
-    shape7->fill(255, 255, 255, 255);
+    shape7->fill(255, 255, 255);
     shape7->stroke(255, 0, 0, 255);
     shape7->stroke(2);
     if (canvas->push(move(shape7)) != tvg::Result::Success) return;
 
     auto shape8 = tvg::Shape::gen();
     shape8->appendArc(400, 650, 80, 0, 300, true);
-    shape8->fill(255, 255, 255, 255);
+    shape8->fill(255, 255, 255);
     shape8->stroke(255, 0, 0, 255);
     shape8->stroke(2);
     if (canvas->push(move(shape8)) != tvg::Result::Success) return;
 
     auto shape9 = tvg::Shape::gen();
     shape9->appendArc(600, 650, 80, 300, 60, true);
-    shape9->fill(255, 255, 255, 255);
+    shape9->fill(255, 255, 255);
     shape9->stroke(255, 0, 0, 255);
     shape9->stroke(2);
     if (canvas->push(move(shape9)) != tvg::Result::Success) return;

--- a/src/examples/Blending.cpp
+++ b/src/examples/Blending.cpp
@@ -13,19 +13,21 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     //Prepare Round Rectangle
     auto shape1 = tvg::Shape::gen();
     shape1->appendRect(0, 0, 400, 400, 50, 50);  //x, y, w, h, rx, ry
-    shape1->fill(0, 255, 0, 255);                //r, g, b, a
+    shape1->fill(0, 255, 0);                     //r, g, b
     if (canvas->push(move(shape1)) != tvg::Result::Success) return;
 
     //Prepare Circle
     auto shape2 = tvg::Shape::gen();
     shape2->appendCircle(400, 400, 200, 200);    //cx, cy, radiusW, radiusH
-    shape2->fill(255, 255, 0, 170);              //r, g, b, a
+    shape2->fill(255, 255, 0);                   //r, g, b
+    shape2->opacity(170);
     if (canvas->push(move(shape2)) != tvg::Result::Success) return;
 
     //Prepare Ellipse
     auto shape3 = tvg::Shape::gen();
     shape3->appendCircle(400, 400, 250, 100);    //cx, cy, radiusW, radiusH
-    shape3->fill(255, 255, 255, 100);            //r, g, b, a
+    shape3->fill(255, 255, 255);                 //r, g, b
+    shape3->opacity(100);
     if (canvas->push(move(shape3)) != tvg::Result::Success) return;
 
     //Prepare Star
@@ -41,13 +43,14 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     shape4->lineTo(26, 361);
     shape4->lineTo(146, 343);
     shape4->close();
-    shape4->fill(255, 0, 200, 200);
+    shape4->fill(255, 0, 200);
+    shape4->opacity(200);
     if (canvas->push(move(shape4)) != tvg::Result::Success) return;
 
     //Prepare Opaque Ellipse
     auto shape5 = tvg::Shape::gen();
     shape5->appendCircle(600, 650, 200, 150);
-    shape5->fill(0, 0, 255, 255);
+    shape5->fill(0, 0, 255);
     if (canvas->push(move(shape5)) != tvg::Result::Success) return;
 }
 

--- a/src/examples/Boundary.cpp
+++ b/src/examples/Boundary.cpp
@@ -13,31 +13,31 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     //Prepare Shape1
     auto shape1 = tvg::Shape::gen();
     shape1->appendRect(-100, -100, 1000, 1000, 50, 50);
-    shape1->fill(255, 255, 255, 255);
+    shape1->fill(255, 255, 255);
     if (canvas->push(move(shape1)) != tvg::Result::Success) return;
 
     //Prepare Shape2
     auto shape2 = tvg::Shape::gen();
     shape2->appendRect(-100, -100, 250, 250, 50, 50);
-    shape2->fill(0, 0, 255, 255);
+    shape2->fill(0, 0, 255);
     if (canvas->push(move(shape2)) != tvg::Result::Success) return;
 
     //Prepare Shape3
     auto shape3 = tvg::Shape::gen();
     shape3->appendRect(500, 500, 550, 550, 0, 0);
-    shape3->fill(0, 255, 255, 255);
+    shape3->fill(0, 255, 255);
     if (canvas->push(move(shape3)) != tvg::Result::Success) return;
 
     //Prepare Shape4
     auto shape4 = tvg::Shape::gen();
     shape4->appendCircle(800, 100, 200, 200);
-    shape4->fill(255, 255, 0, 255);
+    shape4->fill(255, 255, 0);
     if (canvas->push(move(shape4)) != tvg::Result::Success) return;
 
     //Prepare Shape5
     auto shape5 = tvg::Shape::gen();
     shape5->appendCircle(200, 650, 250, 200);
-    shape5->fill(0, 0, 0, 255);
+    shape5->fill(0, 0, 0);
     if (canvas->push(move(shape5)) != tvg::Result::Success) return;
 }
 

--- a/src/examples/Capi.cpp
+++ b/src/examples/Capi.cpp
@@ -159,7 +159,7 @@ void testCapi()
     tvg_shape_append_rect(org, 550, 10, 100, 100, 0, 0);
     tvg_shape_set_stroke_width(org, 3);
     tvg_shape_set_stroke_color(org, 255, 0, 0, 255);
-    tvg_shape_set_fill_color(org, 0, 255, 0, 255);
+    tvg_shape_set_fill_color(org, 0, 255, 0);
 
     //Duplicated paint test - should copy rectangle parameters from origin
     Tvg_Paint* dup = tvg_paint_duplicate(org);

--- a/src/examples/ClipPath.cpp
+++ b/src/examples/ClipPath.cpp
@@ -25,7 +25,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     //Background
     auto shape = tvg::Shape::gen();
     shape->appendRect(0, 0, WIDTH, HEIGHT, 0, 0);
-    shape->fill(255, 255, 255, 255);
+    shape->fill(255, 255, 255);
     if (canvas->push(move(shape)) != tvg::Result::Success) return;
 
     //////////////////////////////////////////////
@@ -34,7 +34,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
 
     auto star1 = tvg::Shape::gen();
     tvgDrawStar(star1.get());
-    star1->fill(255, 255, 0, 255);
+    star1->fill(255, 255, 0);
     star1->stroke(255 ,0, 0, 128);
     star1->stroke(10);
 
@@ -43,14 +43,15 @@ void tvgDrawCmds(tvg::Canvas* canvas)
 
     auto clipStar = tvg::Shape::gen();
     clipStar->appendCircle(200, 230, 110, 110);
-    clipStar->fill(255, 255, 255, 255); // clip object must have alpha.
+    clipStar->fill(255, 255, 255);     // clip object must have alpha.
     clipStar->translate(10, 10);
 
     star1->composite(move(clipStar), tvg::CompositeMethod::ClipPath);
 
     auto star2 = tvg::Shape::gen();
     tvgDrawStar(star2.get());
-    star2->fill(0, 255, 255, 64);
+    star2->fill(0, 255, 255);
+    star2->opacity(64);
     star2->stroke(0 ,255, 0, 128);
     star2->stroke(10);
 
@@ -59,7 +60,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
 
     auto clip = tvg::Shape::gen();
     clip->appendCircle(200, 230, 130, 130);
-    clip->fill(255, 255, 255, 255); // clip object must have alpha.
+    clip->fill(255, 255, 255);      // clip object must have alpha.
     clip->translate(10, 10);
 
     scene->push(move(star1));
@@ -74,13 +75,13 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     auto star3 = tvg::Shape::gen();
     tvgDrawStar(star3.get());
     star3->translate(400, 0);
-    star3->fill(255, 255, 0, 255);                    //r, g, b, a
-    star3->stroke(255 ,0, 0, 128);
+    star3->fill(255, 255, 0);
+    star3->stroke(255 ,0, 0, 127);
     star3->stroke(10);
 
     auto clipRect = tvg::Shape::gen();
-    clipRect->appendRect(480, 110, 200, 200, 0, 0);          //x, y, w, h, rx, ry
-    clipRect->fill(255, 255, 255, 255); // clip object must have alpha.
+    clipRect->appendRect(480, 110, 200, 200, 0, 0);     //x, y, w, h, rx, ry
+    clipRect->fill(255, 255, 255);                      // clip object must have alpha.
     clipRect->translate(20, 20);
 
     //Clipping scene to rect(shape)
@@ -99,9 +100,9 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     picture->translate(200, 400);
 
     auto clipPath = tvg::Shape::gen();
-    clipPath->appendCircle(350, 510, 110, 110);          //x, y, w, h, rx, ry
-    clipPath->appendCircle(350, 650, 50, 50);          //x, y, w, h, rx, ry
-    clipPath->fill(255, 255, 255, 255); // clip object must have alpha.
+    clipPath->appendCircle(350, 510, 110, 110);     //x, y, w, h, rx, ry
+    clipPath->appendCircle(350, 650, 50, 50);       //x, y, w, h, rx, ry
+    clipPath->fill(255, 255, 255);                  // clip object must have alpha.
     clipPath->translate(20, 20);
 
     //Clipping picture to path

--- a/src/examples/CustomTransform.cpp
+++ b/src/examples/CustomTransform.cpp
@@ -27,7 +27,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     shape->lineTo(-173, 12.5);
     shape->lineTo(-53, -5.5);
     shape->close();
-    shape->fill(0, 0, 255, 255);
+    shape->fill(0, 0, 255);
     shape->stroke(3);
     shape->stroke(255, 255, 255, 255);
     if (canvas->push(move(shape)) != tvg::Result::Success) return;

--- a/src/examples/DirectUpdate.cpp
+++ b/src/examples/DirectUpdate.cpp
@@ -14,7 +14,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     bg->appendRect(0, 0, WIDTH, HEIGHT, 0, 0);
 
     //fill property will be retained
-    bg->fill(255, 255, 255, 255);
+    bg->fill(255, 255, 255);
 
     if (canvas->push(move(bg)) != tvg::Result::Success) return;
 
@@ -28,7 +28,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     shape->appendRect(-100, -100, 200, 200, 0, 0);
 
     //fill property will be retained
-    shape->fill(127, 255, 255, 255);
+    shape->fill(127, 255, 255);
     shape->stroke(0, 0, 255, 255);
     shape->stroke(1);
 
@@ -45,7 +45,7 @@ void tvgUpdateCmds(tvg::Canvas* canvas, float progress)
     //Reset Shape
     if (pShape->reset() == tvg::Result::Success) {
         pShape->appendRect(-100 + (800 * progress), -100 + (800 * progress), 200, 200, (100 * progress), (100 * progress));
-        pShape->fill(127, 255, 255, 255);
+        pShape->fill(127, 255, 255);
         pShape->stroke(0, 0, 255, 255);
         pShape->stroke(30 * progress);
 

--- a/src/examples/Duplicate.cpp
+++ b/src/examples/Duplicate.cpp
@@ -20,7 +20,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
 
         float dashPattern[2] = {4, 4};
         shape1->stroke(dashPattern, 2);
-        shape1->fill(255, 0, 0, 255);
+        shape1->fill(255, 0, 0);
 
         //Duplicate Shape, Switch fill method
         auto shape2 = unique_ptr<tvg::Shape>(static_cast<tvg::Shape*>(shape1->duplicate()));
@@ -53,17 +53,17 @@ void tvgDrawCmds(tvg::Canvas* canvas)
 
         auto shape1 = tvg::Shape::gen();
         shape1->appendRect(0, 0, 400, 400, 50, 50);
-        shape1->fill(0, 255, 0, 255);
+        shape1->fill(0, 255, 0);
         scene1->push(move(shape1));
 
         auto shape2 = tvg::Shape::gen();
         shape2->appendCircle(400, 400, 200, 200);
-        shape2->fill(255, 255, 0, 255);
+        shape2->fill(255, 255, 0);
         scene1->push(move(shape2));
 
         auto shape3 = tvg::Shape::gen();
         shape3->appendCircle(600, 600, 150, 100);
-        shape3->fill(0, 255, 255, 255);
+        shape3->fill(0, 255, 255);
         scene1->push(move(shape3));
 
         scene1->scale(0.25);

--- a/src/examples/FillRule.cpp
+++ b/src/examples/FillRule.cpp
@@ -16,7 +16,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     shape1->lineTo(374, 160);
     shape1->lineTo(97, 365);
     shape1->close();
-    shape1->fill(255, 255, 255, 255);
+    shape1->fill(255, 255, 255);
     shape1->fill(tvg::FillRule::Winding);  //Fill all winding shapes
 
     if (canvas->push(move(shape1)) != tvg::Result::Success) return;
@@ -29,7 +29,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     shape2->lineTo(724, 460);
     shape2->lineTo(447, 665);
     shape2->close();
-    shape2->fill(255, 255, 255, 255);
+    shape2->fill(255, 255, 255);
     shape2->fill(tvg::FillRule::EvenOdd); //Fill polygons with even odd pattern
 
     if (canvas->push(move(shape2)) != tvg::Result::Success) return;

--- a/src/examples/MultiShapes.cpp
+++ b/src/examples/MultiShapes.cpp
@@ -13,19 +13,19 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     //Prepare Round Rectangle
     auto shape1 = tvg::Shape::gen();
     shape1->appendRect(0, 0, 400, 400, 50, 50);  //x, y, w, h, rx, ry
-    shape1->fill(0, 255, 0, 255);                //r, g, b, a
+    shape1->fill(0, 255, 0);                     //r, g, b
     if (canvas->push(move(shape1)) != tvg::Result::Success) return;
 
     //Prepare Circle
     auto shape2 = tvg::Shape::gen();
     shape2->appendCircle(400, 400, 200, 200);    //cx, cy, radiusW, radiusH
-    shape2->fill(255, 255, 0, 255);              //r, g, b, a
+    shape2->fill(255, 255, 0);                   //r, g, b
     if (canvas->push(move(shape2)) != tvg::Result::Success) return;
 
     //Prepare Ellipse
     auto shape3 = tvg::Shape::gen();
     shape3->appendCircle(600, 600, 150, 100);    //cx, cy, radiusW, radiusH
-    shape3->fill(0, 255, 255, 255);              //r, g, b, a
+    shape3->fill(0, 255, 255);                   //r, g, b
     if (canvas->push(move(shape3)) != tvg::Result::Success) return;
 }
 

--- a/src/examples/Path.cpp
+++ b/src/examples/Path.cpp
@@ -23,7 +23,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     shape1->lineTo(26, 161);
     shape1->lineTo(146, 143);
     shape1->close();
-    shape1->fill(0, 0, 255, 255);
+    shape1->fill(0, 0, 255);
     if (canvas->push(move(shape1)) != tvg::Result::Success) return;
 
 
@@ -42,7 +42,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     shape2->cubicTo(cx - halfRadius, cy + radius, cx - radius, cy + halfRadius, cx - radius, cy);
     shape2->cubicTo(cx - radius, cy - halfRadius, cx - halfRadius, cy - radius, cx, cy - radius);
     shape2->close();
-    shape2->fill(255, 0, 0, 255);
+    shape2->fill(255, 0, 0);
     if (canvas->push(move(shape2)) != tvg::Result::Success) return;
 
 }

--- a/src/examples/PathCopy.cpp
+++ b/src/examples/PathCopy.cpp
@@ -39,7 +39,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
 
     auto shape1 = tvg::Shape::gen();
     shape1->appendPath(cmds, 11, pts, 10);     //copy path data
-    shape1->fill(0, 255, 0, 255);
+    shape1->fill(0, 255, 0);
     if (canvas->push(move(shape1)) != tvg::Result::Success) return;
 
     /* Circle */
@@ -79,7 +79,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
 
     auto shape2 = tvg::Shape::gen();
     shape2->appendPath(cmds2, 6, pts2, 13);     //copy path data
-    shape2->fill(255, 255, 0, 255);
+    shape2->fill(255, 255, 0);
     if (canvas->push(move(shape2)) != tvg::Result::Success) return;
 
 }

--- a/src/examples/Scene.cpp
+++ b/src/examples/Scene.cpp
@@ -15,19 +15,19 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     //Prepare Round Rectangle
     auto shape1 = tvg::Shape::gen();
     shape1->appendRect(0, 0, 400, 400, 50, 50);  //x, y, w, h, rx, ry
-    shape1->fill(0, 255, 0, 255);                //r, g, b, a
+    shape1->fill(0, 255, 0);                     //r, g, b
     scene->push(move(shape1));
 
     //Prepare Circle
     auto shape2 = tvg::Shape::gen();
     shape2->appendCircle(400, 400, 200, 200);    //cx, cy, radiusW, radiusH
-    shape2->fill(255, 255, 0, 255);              //r, g, b, a
+    shape2->fill(255, 255, 0);                   //r, g, b
     scene->push(move(shape2));
 
     //Prepare Ellipse
     auto shape3 = tvg::Shape::gen();
     shape3->appendCircle(600, 600, 150, 100);    //cx, cy, radiusW, radiusH
-    shape3->fill(0, 255, 255, 255);              //r, g, b, a
+    shape3->fill(0, 255, 255);                   //r, g, b
     scene->push(move(shape3));
 
     //Create another Scene
@@ -49,7 +49,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     shape4->lineTo(26, 161);
     shape4->lineTo(146, 143);
     shape4->close();
-    shape4->fill(0, 0, 255, 255);
+    shape4->fill(0, 0, 255);
     scene2->push(move(shape4));
 
     //Circle
@@ -66,7 +66,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     shape5->cubicTo(cx + radius, cy + halfRadius, cx + halfRadius, cy + radius, cx, cy+ radius);
     shape5->cubicTo(cx - halfRadius, cy + radius, cx - radius, cy + halfRadius, cx - radius, cy);
     shape5->cubicTo(cx - radius, cy - halfRadius, cx - halfRadius, cy - radius, cx, cy - radius);
-    shape5->fill(255, 0, 0, 255);
+    shape5->fill(255, 0, 0);
     scene2->push(move(shape5));
 
     //Push scene2 onto the scene

--- a/src/examples/SceneTransform.cpp
+++ b/src/examples/SceneTransform.cpp
@@ -18,7 +18,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     //Prepare Round Rectangle (Scene1)
     auto shape1 = tvg::Shape::gen();
     shape1->appendRect(-235, -250, 400, 400, 50, 50);  //x, y, w, h, rx, ry
-    shape1->fill(0, 255, 0, 255);                      //r, g, b, a
+    shape1->fill(0, 255, 0);                           //r, g, b
     shape1->stroke(5);                                 //width
     shape1->stroke(255, 255, 255, 255);                //r, g, b, a
     scene->push(move(shape1));
@@ -26,13 +26,13 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     //Prepare Circle (Scene1)
     auto shape2 = tvg::Shape::gen();
     shape2->appendCircle(-165, -150, 200, 200);    //cx, cy, radiusW, radiusH
-    shape2->fill(255, 255, 0, 255);                //r, g, b, a
+    shape2->fill(255, 255, 0);                     //r, g, b
     scene->push(move(shape2));
 
     //Prepare Ellipse (Scene1)
     auto shape3 = tvg::Shape::gen();
     shape3->appendCircle(265, 250, 150, 100);      //cx, cy, radiusW, radiusH
-    shape3->fill(0, 255, 255, 255);                //r, g, b, a
+    shape3->fill(0, 255, 255);                     //r, g, b
     scene->push(move(shape3));
 
     scene->translate(350, 350);
@@ -58,9 +58,10 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     shape4->lineTo(-173, 12.5);
     shape4->lineTo(-53, -5.5);
     shape4->close();
-    shape4->fill(0, 0, 255, 127);
-    shape4->stroke(3);                             //width
-    shape4->stroke(0, 0, 255, 255);                //r, g, b, a
+    shape4->fill(0, 0, 255);
+    shape4->opacity(127);
+    shape4->stroke(3);
+    shape4->stroke(0, 0, 255, 255);
     scene2->push(move(shape4));
 
     //Circle (Scene2)
@@ -78,7 +79,8 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     shape5->cubicTo(cx - halfRadius, cy + radius, cx - radius, cy + halfRadius, cx - radius, cy);
     shape5->cubicTo(cx - radius, cy - halfRadius, cx - halfRadius, cy - radius, cx, cy - radius);
     shape5->close();
-    shape5->fill(255, 0, 0, 127);
+    shape5->fill(255, 0, 0);
+    shape5->opacity(127);
     scene2->push(move(shape5));
 
     scene2->translate(500, 350);

--- a/src/examples/Shape.cpp
+++ b/src/examples/Shape.cpp
@@ -14,7 +14,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     shape1->appendRect(100, 100, 300, 300, 100, 100);  //x, y, w, h, rx, ry
     shape1->appendCircle(400, 400, 100, 100);          //cx, cy, radiusW, radiusH
     shape1->appendCircle(400, 500, 170, 100);          //cx, cy, radiusW, radiusH
-    shape1->fill(255, 255, 0, 255);                    //r, g, b, a
+    shape1->fill(255, 255, 0);                         //r, g, b
 
     canvas->push(move(shape1));
 }

--- a/src/examples/Stacking.cpp
+++ b/src/examples/Stacking.cpp
@@ -17,21 +17,21 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     auto shape1 = tvg::Shape::gen();
     paints[0] = shape1.get();
     shape1->appendRect(0, 0, 400, 400, 50, 50);  //x, y, w, h, rx, ry
-    shape1->fill(0, 255, 0, 255);                //r, g, b, a
+    shape1->fill(0, 255, 0);                     //r, g, b
     if (canvas->push(move(shape1)) != tvg::Result::Success) return;
 
     //Prepare Circle
     auto shape2 = tvg::Shape::gen();
     paints[1] = shape2.get();
     shape2->appendRect(100, 100, 400, 400, 50, 50);  //x, y, w, h, rx, ry
-    shape2->fill(255, 255, 0, 255);              //r, g, b, a
+    shape2->fill(255, 255, 0);                       //r, g, b
     if (canvas->push(move(shape2)) != tvg::Result::Success) return;
 
     //Prepare Ellipse
     auto shape3 = tvg::Shape::gen();
     paints[2] = shape3.get();
     shape3->appendRect(200, 200, 400, 400, 50, 50);  //x, y, w, h, rx, ry
-    shape3->fill(0, 255, 255, 255);              //r, g, b, a
+    shape3->fill(0, 255, 255);                       //r, g, b
     if (canvas->push(move(shape3)) != tvg::Result::Success) return;
 }
 

--- a/src/examples/Stress.cpp
+++ b/src/examples/Stress.cpp
@@ -63,7 +63,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     //Background
     auto shape = tvg::Shape::gen();
     shape->appendRect(0, 0, WIDTH, HEIGHT, 0, 0);    //x, y, w, h, rx, ry
-    shape->fill(255, 255, 255, 255);                 //r, g, b, a
+    shape->fill(255, 255, 255);                      //r, g, b
 
     if (canvas->push(move(shape)) != tvg::Result::Success) return;
 

--- a/src/examples/Stroke.cpp
+++ b/src/examples/Stroke.cpp
@@ -11,7 +11,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     //Shape 1
     auto shape1 = tvg::Shape::gen();
     shape1->appendRect(50, 50, 200, 200, 0, 0);
-    shape1->fill(50, 50, 50, 255);
+    shape1->fill(50, 50, 50);
     shape1->stroke(255, 255, 255, 255);       //color: r, g, b, a
     shape1->stroke(tvg::StrokeJoin::Bevel);   //default is Bevel
     shape1->stroke(10);                       //width: 10px
@@ -21,7 +21,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     //Shape 2
     auto shape2 = tvg::Shape::gen();
     shape2->appendRect(300, 50, 200, 200, 0, 0);
-    shape2->fill(50, 50, 50, 255);
+    shape2->fill(50, 50, 50);
     shape2->stroke(255, 255, 255, 255);
     shape2->stroke(tvg::StrokeJoin::Round);
     shape2->stroke(10);
@@ -31,7 +31,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     //Shape 3
     auto shape3 = tvg::Shape::gen();
     shape3->appendRect(550, 50, 200, 200, 0, 0);
-    shape3->fill(50, 50, 50, 255);
+    shape3->fill(50, 50, 50);
     shape3->stroke(255, 255, 255, 255);
     shape3->stroke(tvg::StrokeJoin::Miter);
     shape3->stroke(10);
@@ -41,7 +41,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     //Shape 4
     auto shape4 = tvg::Shape::gen();
     shape4->appendCircle(150, 400, 100, 100);
-    shape4->fill(50, 50, 50, 255);
+    shape4->fill(50, 50, 50);
     shape4->stroke(255, 255, 255, 255);
     shape4->stroke(1);
 
@@ -50,7 +50,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     //Shape 5
     auto shape5 = tvg::Shape::gen();
     shape5->appendCircle(400, 400, 100, 100);
-    shape5->fill(50, 50, 50, 255);
+    shape5->fill(50, 50, 50);
     shape5->stroke(255, 255, 255, 255);
     shape5->stroke(2);
 
@@ -59,7 +59,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     //Shape 6
     auto shape6 = tvg::Shape::gen();
     shape6->appendCircle(650, 400, 100, 100);
-    shape6->fill(50, 50, 50, 255);
+    shape6->fill(50, 50, 50);
     shape6->stroke(255, 255, 255, 255);
     shape6->stroke(4);
 

--- a/src/examples/Svg.cpp
+++ b/src/examples/Svg.cpp
@@ -55,7 +55,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     //Background
     auto shape = tvg::Shape::gen();
     shape->appendRect(0, 0, WIDTH, HEIGHT, 0, 0);    //x, y, w, h, rx, ry
-    shape->fill(255, 255, 255, 255);                 //r, g, b, a
+    shape->fill(255, 255, 255);                      //r, g, b
 
     if (canvas->push(move(shape)) != tvg::Result::Success) return;
 

--- a/src/examples/Svg2.cpp
+++ b/src/examples/Svg2.cpp
@@ -14,7 +14,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     //Background
     auto shape = tvg::Shape::gen();
     shape->appendRect(0, 0, WIDTH, HEIGHT, 0, 0);    //x, y, w, h, rx, ry
-    shape->fill(255, 255, 255, 255);                 //r, g, b, a
+    shape->fill(255, 255, 255);                      //r, g, b
 
     if (canvas->push(move(shape)) != tvg::Result::Success) return;
 

--- a/src/examples/Transform.cpp
+++ b/src/examples/Transform.cpp
@@ -22,7 +22,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     shape->appendRect(-185, -200, 300, 300, 100, 100);
     shape->appendCircle(115, 100, 100, 100);
     shape->appendCircle(115, 200, 170, 100);
-    shape->fill(255, 255, 255, 255);
+    shape->fill(255, 255, 255);
     shape->translate(385, 400);
     if (canvas->push(move(shape)) != tvg::Result::Success) return;
 
@@ -30,7 +30,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     auto shape2 = tvg::Shape::gen();
     pShape2 = shape2.get();
     shape2->appendRect(-50, -50, 100, 100, 0, 0);
-    shape2->fill(0, 255, 255, 255);
+    shape2->fill(0, 255, 255);
     shape2->translate(400, 400);
     if (canvas->push(move(shape2)) != tvg::Result::Success) return;
 
@@ -41,7 +41,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     /* Look, how shape3's origin is different with shape2
        The center of the shape is the anchor point for transformation. */
     shape3->appendRect(100, 100, 150, 50, 20, 20);
-    shape3->fill(255, 0, 255, 255);
+    shape3->fill(255, 0, 255);
     shape3->translate(400, 400);
     if (canvas->push(move(shape3)) != tvg::Result::Success) return;
 }

--- a/src/examples/Update.cpp
+++ b/src/examples/Update.cpp
@@ -11,7 +11,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     //Shape
     auto shape = tvg::Shape::gen();
     shape->appendRect(-100, -100, 200, 200, 0, 0);
-    shape->fill(255, 255, 255, 255);
+    shape->fill(255, 255, 255);
     canvas->push(move(shape));
 }
 
@@ -25,7 +25,7 @@ void tvgUpdateCmds(tvg::Canvas* canvas, float progress)
     //Shape
     auto shape = tvg::Shape::gen();
     shape->appendRect(-100, -100, 200, 200, (100 * progress), (100 * progress));
-    shape->fill(rand()%255, rand()%255, rand()%255, 255);
+    shape->fill(rand()%255, rand()%255, rand()%255);
     shape->translate(800 * progress, 800 * progress);
     shape->scale(1 - 0.75 * progress);
     shape->rotate(360 * progress);

--- a/src/lib/sw_engine/tvgSwRenderer.cpp
+++ b/src/lib/sw_engine/tvgSwRenderer.cpp
@@ -55,9 +55,7 @@ struct SwTask : Task
 
         //Shape
         if (flags & (RenderUpdateFlag::Path | RenderUpdateFlag::Transform) || prepareShape) {
-            uint8_t alpha = 0;
-            sdata->fillColor(nullptr, nullptr, nullptr, &alpha);
-            bool renderShape = (alpha > 0 || sdata->fill());
+            bool renderShape = (sdata->opacity() > 0 || sdata->fill());
             if (renderShape || strokeAlpha) {
                 shapeReset(&shape);
                 if (!shapePrepare(&shape, sdata, clip, transform)) return;
@@ -183,7 +181,8 @@ bool SwRenderer::render(const Shape& shape, void *data)
     if (auto fill = task->sdata->fill()) {
         rasterGradientShape(surface, &task->shape, fill->id());
     } else{
-        task->sdata->fillColor(&r, &g, &b, &a);
+        task->sdata->fillColor(&r, &g, &b);
+        a = task->sdata->opacity();
         if (a > 0) rasterSolidShape(surface, &task->shape, r, g, b, a);
     }
     task->sdata->strokeColor(&r, &g, &b, &a);

--- a/src/lib/tvgPaint.cpp
+++ b/src/lib/tvgPaint.cpp
@@ -67,16 +67,19 @@ Result Paint::transform(const Matrix& m) noexcept
     return Result::FailedAllocation;
 }
 
+
 Result Paint::bounds(float* x, float* y, float* w, float* h) const noexcept
 {
     if (pImpl->bounds(x, y, w, h)) return Result::Success;
     return Result::InsufficientCondition;
 }
 
+
 Paint* Paint::duplicate() const noexcept
 {
     return pImpl->duplicate();
 }
+
 
 Result Paint::composite(std::unique_ptr<Paint> target, CompositeMethod method) const noexcept
 {
@@ -84,3 +87,16 @@ Result Paint::composite(std::unique_ptr<Paint> target, CompositeMethod method) c
     return Result::InsufficientCondition;
 }
 
+
+Result Paint::opacity(uint8_t alpha) noexcept
+{
+    pImpl->alpha = alpha;
+
+    return Result::Success;
+}
+
+
+uint8_t Paint::opacity() const noexcept
+{
+    return pImpl->alpha;
+}

--- a/src/lib/tvgPaint.h
+++ b/src/lib/tvgPaint.h
@@ -48,6 +48,8 @@ namespace tvg
         Paint* compTarget = nullptr;
         CompositeMethod compMethod = CompositeMethod::None;
 
+        uint8_t alpha = 255;
+
         ~Impl() {
             if (smethod) delete(smethod);
             if (rTransform) delete(rTransform);
@@ -178,6 +180,8 @@ namespace tvg
                     ret->pImpl->flag |= RenderUpdateFlag::Transform;
                 }
             }
+
+            ret->pImpl->alpha = alpha;
 
             return ret;
         }

--- a/src/lib/tvgShape.cpp
+++ b/src/lib/tvgShape.cpp
@@ -252,12 +252,12 @@ Result Shape::appendRect(float x, float y, float w, float h, float rx, float ry)
 }
 
 
-Result Shape::fill(uint8_t r, uint8_t g, uint8_t b, uint8_t a) noexcept
+Result Shape::fill(uint8_t r, uint8_t g, uint8_t b) noexcept
 {
     pImpl->color[0] = r;
     pImpl->color[1] = g;
     pImpl->color[2] = b;
-    pImpl->color[3] = a;
+
     pImpl->flag |= RenderUpdateFlag::Color;
 
     if (pImpl->fill) {
@@ -283,12 +283,11 @@ Result Shape::fill(unique_ptr<Fill> f) noexcept
 }
 
 
-Result Shape::fillColor(uint8_t* r, uint8_t* g, uint8_t* b, uint8_t* a) const noexcept
+Result Shape::fillColor(uint8_t* r, uint8_t* g, uint8_t* b) const noexcept
 {
     if (r) *r = pImpl->color[0];
     if (g) *g = pImpl->color[1];
     if (b) *b = pImpl->color[2];
-    if (a) *a = pImpl->color[3];
 
     return Result::Success;
 }

--- a/src/lib/tvgShapeImpl.h
+++ b/src/lib/tvgShapeImpl.h
@@ -195,11 +195,11 @@ struct Shape::Impl
     ShapePath *path = nullptr;
     Fill *fill = nullptr;
     ShapeStroke *stroke = nullptr;
-    uint8_t color[4] = {0, 0, 0, 0};    //r, g, b, a
     FillRule rule = FillRule::Winding;
     void *edata = nullptr;              //engine data
     Shape *shape = nullptr;
     uint32_t flag = RenderUpdateFlag::None;
+    uint8_t color[3] = {0, 0, 0};    //r, g, b
 
     Impl(Shape* s) : path(new ShapePath), shape(s)
     {
@@ -319,7 +319,7 @@ struct Shape::Impl
             stroke = nullptr;
         }
 
-        color[0] = color[1] = color[2] = color[3] = 0;
+        color[0] = color[1] = color[2] = 0;
 
         flag = RenderUpdateFlag::All;
     }

--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -207,8 +207,13 @@ void _applyProperty(SvgNode* node, Shape* vg, float vx, float vy, float vw, floa
 {
     SvgStyleProperty* style = node->style;
 
+    uint8_t opacity = 0;
+
     if (node->transform) vg->transform(*node->transform);
-    if (node->type == SvgNodeType::Doc || !node->display) return;
+    if (node->type == SvgNodeType::Doc || !node->display) {
+        vg->opacity(0);
+        return;
+    }
 
     //If fill property is nullptr then do nothing
     if (style->fill.paint.none) {
@@ -225,18 +230,18 @@ void _applyProperty(SvgNode* node, Shape* vg, float vx, float vy, float vw, floa
         }
     } else if (style->fill.paint.curColor) {
         //Apply the current style color
-        vg->fill(style->r, style->g, style->b, style->fill.opacity);
+        vg->fill(style->r, style->g, style->b);
+        opacity = style->fill.opacity;
     } else {
         //Apply the fill color
-        vg->fill(style->fill.paint.r, style->fill.paint.g, style->fill.paint.b, style->fill.opacity);
+        vg->fill(style->fill.paint.r, style->fill.paint.g, style->fill.paint.b);
+        opacity = style->fill.opacity;
     }
 
     //Apply node opacity
-    if (style->opacity < 255) {
-        uint8_t r, g, b, a;
-        vg->fillColor(&r, &g, &b, &a);
-        vg->fill(r, g, b, (a * style->opacity) / 255.0f);
-    }
+    if (style->opacity < 255) opacity = (opacity * style->opacity) / 255.0f;
+
+    vg->opacity(opacity);
 
     if (node->type == SvgNodeType::G) return;
 


### PR DESCRIPTION
We introduced separate opacity interface to adjust alpha value by paint.
This opacity will affect to whole paint image if paint is a group of paints.

Also, this opacity come out with a shared value among the fill/stroke alpha values.
Previously, we couldn't deal separate alpha values between fill/stroke,

now user must create separate shapes for fill & stroke if their alpha values are different.

@API Additions:

Result Paint::opacity(uint8_t alpha) noexcept;
uint8_t Paint::opacity() const noexcept;

@Issues: 94

- Description :

- Issue Tickets (if any) :

- Tests or Samples (if any) :

- Screen Shots (if any) :
