### PR TITLE
sw_engine shape: adding a dash pattern switch condition

### DIFF
--- a/src/lib/sw_engine/tvgSwShape.cpp
+++ b/src/lib/sw_engine/tvgSwShape.cpp
@@ -268,7 +268,7 @@ static void _dashLineTo(SwDashStroke& dash, const Point* to, const Matrix* trans
             _outlineMoveTo(*dash.outline, &cur.pt1, transform);
             _outlineLineTo(*dash.outline, &cur.pt2, transform);
         }
-        if (dash.curLen < 1) {
+        if (dash.curLen < 1 && TO_SWCOORD(len) > 1) {
             //move to next dash
             dash.curIdx = (dash.curIdx + 1) % dash.cnt;
             dash.curLen = dash.pattern[dash.curIdx];
@@ -314,7 +314,7 @@ static void _dashCubicTo(SwDashStroke& dash, const Point* ctrl1, const Point* ct
             _outlineMoveTo(*dash.outline, &cur.start, transform);
             _outlineCubicTo(*dash.outline, &cur.ctrl1, &cur.ctrl2, &cur.end, transform);
         }
-        if (dash.curLen < 1) {
+        if (dash.curLen < 1 && TO_SWCOORD(len) > 1) {
             //move to next dash
             dash.curIdx = (dash.curIdx + 1) % dash.cnt;
             dash.curLen = dash.pattern[dash.curIdx];


### PR DESCRIPTION
Preventing switching to the next dash pattern for a line with a length of zero.

- Description :
It may happen, that the length of the final piece of the drawn dashed curve when converted to SW_COORD is 0. Nothing is plotted even though the dash pattern can be considered used (if the remaining length of the pattern to be drawn < 1). This results in an unexpected extended gap. 

- Issue Tickets (if any) :

- Tests or Samples (if any) :
Example file: UnexpectedGap.cpp
https://github.com/mgrudzinska/thorvg/tree/mgrudzinska/dash_gap_ex

- Screen Shots (if any) :
![gap](https://user-images.githubusercontent.com/67589014/97125892-92e32f80-1735-11eb-8f54-f98ebf6c59c8.PNG)
