### PR TITLE
common paint: introduce opacity() method.

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -93,9 +93,12 @@ public:
     Result translate(float x, float y) noexcept;
     Result transform(const Matrix& m) noexcept;
     Result bounds(float* x, float* y, float* w, float* h) const noexcept;
+    Result opacity(uint8_t o) noexcept;
     Paint* duplicate() const noexcept;
 
     Result composite(std::unique_ptr<Paint> target, CompositeMethod method) const noexcept;
+
+    uint8_t opacity() const noexcept;
 
     _TVG_DECLARE_ACCESSOR();
     _TVG_DECLARE_PRIVATE(Paint);

--- a/src/examples/Opacity.cpp
+++ b/src/examples/Opacity.cpp
@@ -1,0 +1,166 @@
+#include "Common.h"
+
+/************************************************************************/
+/* Drawing Commands                                                     */
+/************************************************************************/
+
+void tvgDrawCmds(tvg::Canvas* canvas)
+{
+    if (!canvas) return;
+
+    //Prepare Circle
+    auto shape1 = tvg::Shape::gen();
+    shape1->appendCircle(400, 400, 250, 250);
+    shape1->fill(255, 255, 0, 255);
+    canvas->push(move(shape1));
+
+    //Create a Scene
+    auto scene = tvg::Scene::gen();
+    scene->opacity(127);              //Apply opacity to scene (0 - 255)
+    scene->reserve(2);
+
+    //Star
+    auto shape2 = tvg::Shape::gen();
+
+    //Appends Paths
+    shape2->moveTo(199, 34);
+    shape2->lineTo(253, 143);
+    shape2->lineTo(374, 160);
+    shape2->lineTo(287, 244);
+    shape2->lineTo(307, 365);
+    shape2->lineTo(199, 309);
+    shape2->lineTo(97, 365);
+    shape2->lineTo(112, 245);
+    shape2->lineTo(26, 161);
+    shape2->lineTo(146, 143);
+    shape2->close();
+    shape2->fill(0, 0, 255, 255);
+    scene->push(move(shape2));
+
+    //Circle
+    auto shape3 = tvg::Shape::gen();
+
+    auto cx = 550.0f;
+    auto cy = 550.0f;
+    auto radius = 125.0f;
+    auto halfRadius = radius * 0.552284f;
+
+    //Append Paths
+    shape3->moveTo(cx, cy - radius);
+    shape3->cubicTo(cx + halfRadius, cy - radius, cx + radius, cy - halfRadius, cx + radius, cy);
+    shape3->cubicTo(cx + radius, cy + halfRadius, cx + halfRadius, cy + radius, cx, cy+ radius);
+    shape3->cubicTo(cx - halfRadius, cy + radius, cx - radius, cy + halfRadius, cx - radius, cy);
+    shape3->cubicTo(cx - radius, cy - halfRadius, cx - halfRadius, cy - radius, cx, cy - radius);
+    shape3->fill(255, 0, 0, 255);
+    scene->push(move(shape3));
+
+    //Draw the Scene onto the Canvas
+    canvas->push(move(scene));
+}
+
+
+/************************************************************************/
+/* Sw Engine Test Code                                                  */
+/************************************************************************/
+
+static unique_ptr<tvg::SwCanvas> swCanvas;
+
+void tvgSwTest(uint32_t* buffer)
+{
+    //Create a Canvas
+    swCanvas = tvg::SwCanvas::gen();
+    swCanvas->target(buffer, WIDTH, WIDTH, HEIGHT, tvg::SwCanvas::ARGB8888);
+
+    /* Push the shape into the Canvas drawing list
+       When this shape is into the canvas list, the shape could update & prepare
+       internal data asynchronously for coming rendering.
+       Canvas keeps this shape node unless user call canvas->clear() */
+    tvgDrawCmds(swCanvas.get());
+}
+
+void drawSwView(void* data, Eo* obj)
+{
+    if (swCanvas->draw() == tvg::Result::Success) {
+        swCanvas->sync();
+    }
+}
+
+
+/************************************************************************/
+/* GL Engine Test Code                                                  */
+/************************************************************************/
+
+static unique_ptr<tvg::GlCanvas> glCanvas;
+
+void initGLview(Evas_Object *obj)
+{
+    static constexpr auto BPP = 4;
+
+    //Create a Canvas
+    glCanvas = tvg::GlCanvas::gen();
+    glCanvas->target(nullptr, WIDTH * BPP, WIDTH, HEIGHT);
+
+    /* Push the shape into the Canvas drawing list
+       When this shape is into the canvas list, the shape could update & prepare
+       internal data asynchronously for coming rendering.
+       Canvas keeps this shape node unless user call canvas->clear() */
+    tvgDrawCmds(glCanvas.get());
+}
+
+void drawGLview(Evas_Object *obj)
+{
+    auto gl = elm_glview_gl_api_get(obj);
+    gl->glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+    gl->glClear(GL_COLOR_BUFFER_BIT);
+
+    if (glCanvas->draw() == tvg::Result::Success) {
+        glCanvas->sync();
+    }
+}
+
+
+/************************************************************************/
+/* Main Code                                                            */
+/************************************************************************/
+
+int main(int argc, char **argv)
+{
+    tvg::CanvasEngine tvgEngine = tvg::CanvasEngine::Sw;
+
+    if (argc > 1) {
+        if (!strcmp(argv[1], "gl")) tvgEngine = tvg::CanvasEngine::Gl;
+    }
+
+    //Initialize ThorVG Engine
+    if (tvgEngine == tvg::CanvasEngine::Sw) {
+        cout << "tvg engine: software" << endl;
+    } else {
+        cout << "tvg engine: opengl" << endl;
+    }
+
+    //Threads Count
+    auto threads = std::thread::hardware_concurrency();
+
+    //Initialize ThorVG Engine
+    if (tvg::Initializer::init(tvgEngine, threads) == tvg::Result::Success) {
+
+
+        elm_init(argc, argv);
+
+        if (tvgEngine == tvg::CanvasEngine::Sw) {
+            createSwView();
+        } else {
+            createGlView();
+        }
+
+        elm_run();
+        elm_shutdown();
+
+        //Terminate ThorVG Engine
+        tvg::Initializer::term(tvgEngine);
+
+    } else {
+        cout << "engine is not supported" << endl;
+    }
+    return 0;
+}

--- a/src/examples/meson.build
+++ b/src/examples/meson.build
@@ -14,6 +14,7 @@ source_file = [
     'LinearGradient.cpp',
     'MultiCanvas.cpp',
     'MultiShapes.cpp',
+    'Opacity.cpp',
     'PathCopy.cpp',
     'Path.cpp',
     'RadialGradient.cpp',

--- a/src/lib/gl_engine/tvgGlRenderer.cpp
+++ b/src/lib/gl_engine/tvgGlRenderer.cpp
@@ -140,7 +140,7 @@ bool GlRenderer::dispose(TVG_UNUSED const Shape& shape, void *data)
 }
 
 
-void* GlRenderer::prepare(const Shape& shape, void* data, TVG_UNUSED const RenderTransform* transform, vector<Composite>& compList, RenderUpdateFlag flags)
+void* GlRenderer::prepare(const Shape& shape, void* data, TVG_UNUSED const RenderTransform* transform, TVG_UNUSED uint32_t opacity, vector<Composite>& compList, RenderUpdateFlag flags)
 {
     //prepare shape data
     GlShape* sdata = static_cast<GlShape*>(data);

--- a/src/lib/gl_engine/tvgGlRenderer.h
+++ b/src/lib/gl_engine/tvgGlRenderer.h
@@ -30,7 +30,7 @@ class GlRenderer : public RenderMethod
 public:
     Surface surface = {nullptr, 0, 0, 0};
 
-    void* prepare(const Shape& shape, void* data, const RenderTransform* transform, vector<Composite>& compList, RenderUpdateFlag flags) override;
+    void* prepare(const Shape& shape, void* data, const RenderTransform* transform, uint32_t opacity, vector<Composite>& compList, RenderUpdateFlag flags) override;
     bool dispose(const Shape& shape, void *data) override;
     bool preRender() override;
     bool render(const Shape& shape, void *data) override;

--- a/src/lib/sw_engine/tvgSwRenderer.h
+++ b/src/lib/sw_engine/tvgSwRenderer.h
@@ -34,7 +34,7 @@ namespace tvg
 class SwRenderer : public RenderMethod
 {
 public:
-    void* prepare(const Shape& shape, void* data, const RenderTransform* transform, vector<Composite>& compList, RenderUpdateFlag flags) override;
+    void* prepare(const Shape& shape, void* data, const RenderTransform* transform, uint32_t opacity, vector<Composite>& compList, RenderUpdateFlag flags) override;
     bool dispose(const Shape& shape, void *data) override;
     bool preRender() override;
     bool postRender() override;

--- a/src/lib/tvgCanvasImpl.h
+++ b/src/lib/tvgCanvasImpl.h
@@ -81,11 +81,11 @@ struct Canvas::Impl
 
         //Update single paint node
         if (paint) {
-            paint->pImpl->update(*renderer, nullptr, compList, RenderUpdateFlag::None);
+            paint->pImpl->update(*renderer, nullptr, 255, compList, RenderUpdateFlag::None);
         //Update all retained paint nodes
         } else {
             for (auto paint: paints) {
-                paint->pImpl->update(*renderer, nullptr, compList, RenderUpdateFlag::None);
+                paint->pImpl->update(*renderer, nullptr, 255, compList, RenderUpdateFlag::None);
             }
         }
         return Result::Success;

--- a/src/lib/tvgPaint.cpp
+++ b/src/lib/tvgPaint.cpp
@@ -67,16 +67,19 @@ Result Paint::transform(const Matrix& m) noexcept
     return Result::FailedAllocation;
 }
 
+
 Result Paint::bounds(float* x, float* y, float* w, float* h) const noexcept
 {
     if (pImpl->bounds(x, y, w, h)) return Result::Success;
     return Result::InsufficientCondition;
 }
 
+
 Paint* Paint::duplicate() const noexcept
 {
     return pImpl->duplicate();
 }
+
 
 Result Paint::composite(std::unique_ptr<Paint> target, CompositeMethod method) const noexcept
 {
@@ -84,3 +87,19 @@ Result Paint::composite(std::unique_ptr<Paint> target, CompositeMethod method) c
     return Result::InsufficientCondition;
 }
 
+
+Result Paint::opacity(uint8_t o) noexcept
+{
+    if (pImpl->opacity == o) return Result::Success;
+
+    pImpl->opacity = o;
+    pImpl->flag |= RenderUpdateFlag::Color;
+
+    return Result::Success;
+}
+
+
+uint8_t Paint::opacity() const noexcept
+{
+    return pImpl->opacity;
+}

--- a/src/lib/tvgPictureImpl.h
+++ b/src/lib/tvgPictureImpl.h
@@ -58,13 +58,13 @@ struct Picture::Impl
     }
 
 
-    void* update(RenderMethod &renderer, const RenderTransform* transform, vector<Composite>& compList, RenderUpdateFlag flag)
+    void* update(RenderMethod &renderer, const RenderTransform* transform, uint32_t opacity, vector<Composite>& compList, RenderUpdateFlag flag)
     {
         reload();
 
         if (!paint) return nullptr;
 
-        return paint->pImpl->update(renderer, transform, compList, flag);
+        return paint->pImpl->update(renderer, transform, opacity, compList, flag);
     }
 
     bool render(RenderMethod &renderer)

--- a/src/lib/tvgRender.h
+++ b/src/lib/tvgRender.h
@@ -65,7 +65,7 @@ class RenderMethod
 {
 public:
     virtual ~RenderMethod() {}
-    virtual void* prepare(TVG_UNUSED const Shape& shape, TVG_UNUSED void* data, TVG_UNUSED const RenderTransform* transform, TVG_UNUSED vector<Composite>& compList, TVG_UNUSED RenderUpdateFlag flags) { return nullptr; }
+    virtual void* prepare(TVG_UNUSED const Shape& shape, TVG_UNUSED void* data, TVG_UNUSED const RenderTransform* transform, uint32_t opacity, TVG_UNUSED vector<Composite>& compList, TVG_UNUSED RenderUpdateFlag flags) { return nullptr; }
     virtual bool dispose(TVG_UNUSED const Shape& shape, TVG_UNUSED void *data) { return true; }
     virtual bool preRender() { return true; }
     virtual bool render(TVG_UNUSED const Shape& shape, TVG_UNUSED void *data) { return true; }

--- a/src/lib/tvgSceneImpl.h
+++ b/src/lib/tvgSceneImpl.h
@@ -44,14 +44,14 @@ struct Scene::Impl
         return true;
     }
 
-    void* update(RenderMethod &renderer, const RenderTransform* transform, vector<Composite>& compList, RenderUpdateFlag flag)
+    void* update(RenderMethod &renderer, const RenderTransform* transform, uint32_t opacity, vector<Composite>& compList, RenderUpdateFlag flag)
     {
         /* FXIME: it requires to return list of childr engine data
            This is necessary for scene composition */
         void* edata = nullptr;
 
         for (auto paint: paints) {
-            edata = paint->pImpl->update(renderer, transform, compList, static_cast<uint32_t>(flag));
+            edata = paint->pImpl->update(renderer, transform, opacity, compList, static_cast<uint32_t>(flag));
         }
         return edata;
     }

--- a/src/lib/tvgShapeImpl.h
+++ b/src/lib/tvgShapeImpl.h
@@ -222,9 +222,9 @@ struct Shape::Impl
         return renderer.render(*shape, edata);
     }
 
-    void* update(RenderMethod& renderer, const RenderTransform* transform, vector<Composite>& compList, RenderUpdateFlag pFlag)
+    void* update(RenderMethod& renderer, const RenderTransform* transform, uint32_t opacity, vector<Composite>& compList, RenderUpdateFlag pFlag)
     {
-        this->edata = renderer.prepare(*shape, this->edata, transform, compList, static_cast<RenderUpdateFlag>(pFlag | flag));
+        this->edata = renderer.prepare(*shape, this->edata, transform, opacity, compList, static_cast<RenderUpdateFlag>(pFlag | flag));
         flag = RenderUpdateFlag::None;
         return this->edata;
     }


### PR DESCRIPTION
We introduced separate opacity interface to adjust alpha value by paint.
This opacity will affect to whole paint image if paint is a group of paints.

Also, this opacity is to multipy with fill/stroke alpha values.
This means if the opacity is valid, the paint might deal with a composition step,
which is very expensive due to additional rendering step.

One tip is, if you want to toggle on/off for a certian paint,
you can set opacity to 255 or 0.

@API Additions:

Result Paint::opacity(uint8_t o) noexcept;
uint8_t Paint::opacity() const noexcept;

@Examples: examples/Opacity

@Issues: 94
