### PR TITLE
test Canvas: Set up unit test based on gtest.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -38,16 +38,22 @@ headers = [include_directories('inc'), include_directories('.')]
 subdir('inc')
 subdir('src')
 
+if get_option('test') == true
+   subdir('test')
+endif
+
 summary = '''
 
 Summary:
     thorvg version :        @0@
     Build type      :       @1@
     Prefix          :       @2@
+    Test            :       @3@
 '''.format(
         meson.project_version(),
         get_option('buildtype'),
         get_option('prefix'),
+        get_option('test'),
     )
 
 message(summary)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -32,3 +32,8 @@ option('examples',
     type: 'boolean',
     value: false,
     description: 'Enable building examples')
+
+option('test',
+   type: 'boolean',
+   value: false,
+   description: 'Enable building unit tests')

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,0 +1,19 @@
+
+#TODO:Need to change warning level to 3
+override_default = ['warning_level=0', 'werror=false']
+
+gtest_dep  = dependency('gtest')
+
+canvas_test_sources = [
+    'testsuite.cpp',
+    'test_canvas.cpp',
+    ]
+
+canvas_testsuite = executable('canvasTestSuite',
+                              canvas_test_sources,
+                              include_directories : headers,
+                              override_options : override_default,
+                              dependencies : [gtest_dep, thorvg_lib_dep],
+                              )
+
+test('Canvas Testsuite', canvas_testsuite)

--- a/test/test_canvas.cpp
+++ b/test/test_canvas.cpp
@@ -1,0 +1,28 @@
+#include <gtest/gtest.h>
+#include <iostream>
+#include <thread>
+#include <thorvg.h>
+
+class CanvasTest : public ::testing::Test {
+public:
+    void SetUp() {
+        auto threads = std::thread::hardware_concurrency();
+        //Initialize ThorVG Engine
+        if (tvg::Initializer::init(tvgEngine, threads) == tvg::Result::Success) {
+            swCanvas = tvg::SwCanvas::gen();
+        }
+    }
+    void TearDown() {
+
+        //Terminate ThorVG Engine
+        tvg::Initializer::term(tvgEngine);
+    }
+public:
+    std::unique_ptr<tvg::SwCanvas> swCanvas;
+    tvg::CanvasEngine tvgEngine = tvg::CanvasEngine::Sw;
+};
+
+TEST_F(CanvasTest, GenerateCanvas) {
+    ASSERT_TRUE(swCanvas != nullptr);
+}
+

--- a/test/testsuite.cpp
+++ b/test/testsuite.cpp
@@ -1,0 +1,7 @@
+#include <gtest/gtest.h>
+
+int main(int argc, char **argv) {
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}
+


### PR DESCRIPTION
- Description :
In test directory, set up unit_test based on gtest
First, add a test for SwCanvas generate.

- Issue Tickets (if any) :
https://github.com/Samsung/thorvg/issues/45

- Tests or Samples (if any) :
[meson build]
sudo ninja -C {builddir} test

