### PR TITLE
sw_engine shape: improvement of the rectangle fast tracking algorithm

### DIFF
--- a/src/lib/sw_engine/tvgSwShape.cpp
+++ b/src/lib/sw_engine/tvgSwShape.cpp
@@ -430,13 +430,14 @@ bool _fastTrack(const SwOutline* outline)
     auto pt3 = outline->pts + 2;
     auto pt4 = outline->pts + 3;
 
-    auto min1 = pt1->y < pt3->y ? pt1 : pt3;
-    auto min2 = pt2->y < pt4->y ? pt2 : pt4;
-    if (min1->y != min2->y) return false;
+    SwPoint a;
+    SwPoint b;
+    a.x = pt1->x;
+    a.y = pt3->y;
+    b.x = pt3->x;
+    b.y = pt1->y;
 
-    SwCoord len1 = pow(pt1->x - pt3->x, 2) + pow(pt1->y - pt3->y, 2);
-    SwCoord len2 = pow(pt2->x - pt4->x, 2) + pow(pt2->y - pt4->y, 2);
-    if (len1 == len2) return true;
+    if ((*pt2 == a && *pt4 == b) || (*pt2 == b && *pt4 == a)) return true;
 
     return false;
 }


### PR DESCRIPTION
- Description :
The algorithm erroneously treated some shapes (like isosceles trapezoids  and specifically arranged zero width parallelograms) as rectangles, witch causes the whole bbox to be filled - undesirable behavior.

- Issue Tickets (if any) : #77 

- Tests or Samples (if any) :
   a) Stress.cpp from examples 
   b) Svg.cpp for the image errorsStress.svg:
https://github.com/mgrudzinska/thorvg/tree/mgrudzinska/Stress_ex_error

- Screen Shots (if any) :
errorsStress.svg:

Before (wrong):
![stressErr](https://user-images.githubusercontent.com/67589014/97807515-9577e480-1c61-11eb-9a7b-6328e53f4d07.PNG)

After (correct):
![stressCor](https://user-images.githubusercontent.com/67589014/97807414-de7b6900-1c60-11eb-8743-43d5a5245116.PNG)