### PR TITLE
common capi: Added opacity C bindings.

### DIFF
--- a/inc/thorvg_capi.h
+++ b/inc/thorvg_capi.h
@@ -120,6 +120,8 @@ TVG_EXPORT Tvg_Result tvg_paint_scale(Tvg_Paint* paint, float factor);
 TVG_EXPORT Tvg_Result tvg_paint_rotate(Tvg_Paint* paint, float degree);
 TVG_EXPORT Tvg_Result tvg_paint_translate(Tvg_Paint* paint, float x, float y);
 TVG_EXPORT Tvg_Result tvg_paint_transform(Tvg_Paint* paint, const Tvg_Matrix* m);
+TVG_EXPORT Tvg_Result tvg_paint_set_opacity(Tvg_Paint* paint, uint8_t opacity);
+TVG_EXPORT Tvg_Result tvg_paint_get_opacity(Tvg_Paint* paint, uint8_t* opacity);
 TVG_EXPORT Tvg_Paint* tvg_paint_duplicate(Tvg_Paint* paint);
 
 /************************************************************************/

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -162,13 +162,26 @@ TVG_EXPORT Tvg_Result tvg_paint_transform(Tvg_Paint* paint, const Tvg_Matrix* m)
 }
 
 
-
 TVG_EXPORT Tvg_Paint* tvg_paint_duplicate(Tvg_Paint* paint)
 {
     if (!paint) return NULL;
     return (Tvg_Paint*) reinterpret_cast<Paint*>(paint)->duplicate();
 }
 
+
+TVG_EXPORT Tvg_Result tvg_paint_set_opacity(Tvg_Paint* paint, uint8_t opacity)
+{
+    if (!paint) return TVG_RESULT_INVALID_ARGUMENT;
+    return (Tvg_Result) reinterpret_cast<Paint*>(paint)->opacity(opacity);
+}
+
+
+TVG_EXPORT Tvg_Result tvg_paint_get_opacity(Tvg_Paint* paint, uint8_t* opacity)
+{
+    if (!paint || !opacity)  return TVG_RESULT_INVALID_ARGUMENT;
+    *opacity = reinterpret_cast<Paint*>(paint)->opacity();
+    return TVG_RESULT_SUCCESS;
+}
 
 /************************************************************************/
 /* Shape API                                                            */


### PR DESCRIPTION
- Descriptions:
Added opacity setter/getter to CAPI. They will be useful to simplify
code responsible for set visiblility of paint.

@API Additions:
Tvg_Result tvg_paint_set_opacity(Tvg_Paint* paint, uint8_t opacity)
Tvg_Result tvg_paint_get_opacity(Tvg_Paint* paint, uint8_t* opacity)

- Issue Tickets (if any) :
#94