### PR TITLE
sw_engine: performance optimization.

### DIFF
--- a/src/lib/gl_engine/tvgGlRenderer.cpp
+++ b/src/lib/gl_engine/tvgGlRenderer.cpp
@@ -180,7 +180,7 @@ void* GlRenderer::prepare(const Shape& shape, void* data, TVG_UNUSED const Rende
 }
 
 
-int GlRenderer::init()
+int GlRenderer::init(uint32_t threads)
 {
     if (rendererCnt > 0) return false;
     if (initEngine) return true;

--- a/src/lib/gl_engine/tvgGlRenderer.h
+++ b/src/lib/gl_engine/tvgGlRenderer.h
@@ -40,7 +40,7 @@ public:
     bool clear() override;
 
     static GlRenderer* gen();
-    static int init();
+    static int init(TVG_UNUSED uint32_t threads);
     static int term();
 
 private:

--- a/src/lib/sw_engine/meson.build
+++ b/src/lib/sw_engine/meson.build
@@ -5,6 +5,7 @@ source_file = [
    'tvgSwRenderer.h',
    'tvgSwRaster.cpp',
    'tvgSwRenderer.cpp',
+   'tvgSwResMgr.cpp',
    'tvgSwRle.cpp',
    'tvgSwShape.cpp',
    'tvgSwStroke.cpp',

--- a/src/lib/sw_engine/tvgSwCommon.h
+++ b/src/lib/sw_engine/tvgSwCommon.h
@@ -266,13 +266,13 @@ bool mathSmallCubic(SwPoint* base, SwFixed& angleIn, SwFixed& angleMid, SwFixed&
 SwFixed mathMean(SwFixed angle1, SwFixed angle2);
 
 void shapeReset(SwShape* shape);
-bool shapeGenOutline(SwShape* shape, const Shape* sdata, const Matrix* transform);
-bool shapePrepare(SwShape* shape, const Shape* sdata, const SwSize& clip, const Matrix* transform);
+bool shapeGenOutline(SwShape* shape, const Shape* sdata, unsigned tid, const Matrix* transform);
+bool shapePrepare(SwShape* shape, const Shape* sdata, unsigned tid, const SwSize& clip, const Matrix* transform);
 bool shapePrepared(SwShape* shape);
 bool shapeGenRle(SwShape* shape, const Shape* sdata, const SwSize& clip, bool antiAlias, bool hasComposite);
-void shapeDelOutline(SwShape* shape);
+void shapeDelOutline(SwShape* shape, uint32_t tid);
 void shapeResetStroke(SwShape* shape, const Shape* sdata, const Matrix* transform);
-bool shapeGenStrokeRle(SwShape* shape, const Shape* sdata, const Matrix* transform, const SwSize& clip);
+bool shapeGenStrokeRle(SwShape* shape, const Shape* sdata, unsigned tid, const Matrix* transform, const SwSize& clip);
 void shapeFree(SwShape* shape);
 void shapeDelStroke(SwShape* shape);
 bool shapeGenFillColors(SwShape* shape, const Fill* fill, const Matrix* transform, SwSurface* surface, bool ctable);
@@ -295,13 +295,17 @@ void rleFree(SwRleData* rle);
 void rleClipPath(SwRleData *rle, const SwRleData *clip);
 void rleClipRect(SwRleData *rle, const SwBBox* clip);
 
+bool resMgrInit(uint32_t threads);
+bool resMgrTerm();
+bool resMgrClear();
+SwOutline* resMgrRequestOutline(unsigned idx);
+void resMgrRetrieveOutline(unsigned idx);
 
 bool rasterCompositor(SwSurface* surface);
 bool rasterGradientShape(SwSurface* surface, SwShape* shape, unsigned id);
 bool rasterSolidShape(SwSurface* surface, SwShape* shape, uint8_t r, uint8_t g, uint8_t b, uint8_t a);
 bool rasterStroke(SwSurface* surface, SwShape* shape, uint8_t r, uint8_t g, uint8_t b, uint8_t a);
 bool rasterClear(SwSurface* surface);
-
 
 static inline void rasterRGBA32(uint32_t *dst, uint32_t val, uint32_t offset, int32_t len)
 {

--- a/src/lib/sw_engine/tvgSwRenderer.h
+++ b/src/lib/sw_engine/tvgSwRenderer.h
@@ -43,7 +43,7 @@ public:
     bool render(const Shape& shape, void *data) override;
 
     static SwRenderer* gen();
-    static bool init();
+    static bool init(uint32_t threads);
     static bool term();
 
 private:

--- a/src/lib/sw_engine/tvgSwResMgr.cpp
+++ b/src/lib/sw_engine/tvgSwResMgr.cpp
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#include <vector>
+#include "tvgSwCommon.h"
+
+
+/************************************************************************/
+/* Internal Class Implementation                                        */
+/************************************************************************/
+
+static unsigned threadsCnt = 1;
+static vector<SwOutline> sharedOutline;
+
+
+/************************************************************************/
+/* External Class Implementation                                        */
+/************************************************************************/
+
+SwOutline* resMgrRequestOutline(unsigned idx)
+{
+    return &sharedOutline[idx];
+}
+
+
+void resMgrRetrieveOutline(unsigned idx)
+{
+    sharedOutline[idx].cntrsCnt = 0;
+    sharedOutline[idx].ptsCnt = 0;
+}
+
+
+bool resMgrInit(unsigned threads)
+{
+    sharedOutline.reserve(threads);
+    sharedOutline.resize(threads);
+    threadsCnt = threads;
+
+    for (auto& outline : sharedOutline) {
+        outline.cntrs = nullptr;
+        outline.pts = nullptr;
+        outline.types = nullptr;
+        outline.cntrsCnt = outline.reservedCntrsCnt = 0;
+        outline.ptsCnt = outline.reservedPtsCnt = 0;
+    }
+
+    return true;
+}
+
+
+bool resMgrClear()
+{
+    for (auto& outline : sharedOutline) {
+        if (outline.cntrs) {
+            free(outline.cntrs);
+            outline.cntrs = nullptr;
+        }
+        if (outline.pts) {
+            free(outline.pts);
+            outline.pts = nullptr;
+        }
+        if (outline.types) {
+            free(outline.types);
+            outline.types = nullptr;
+        }
+        outline.cntrsCnt = outline.reservedCntrsCnt = 0;
+        outline.ptsCnt = outline.reservedPtsCnt = 0;
+    }
+    return true;
+}
+
+
+bool resMgrTerm()
+{
+    return resMgrClear();
+}

--- a/src/lib/tvgInitializer.cpp
+++ b/src/lib/tvgInitializer.cpp
@@ -49,12 +49,12 @@ Result Initializer::init(CanvasEngine engine, uint32_t threads) noexcept
 
     if (static_cast<uint32_t>(engine) & static_cast<uint32_t>(CanvasEngine::Sw)) {
         #ifdef THORVG_SW_RASTER_SUPPORT
-            if (!SwRenderer::init()) return Result::InsufficientCondition;
+            if (!SwRenderer::init(threads)) return Result::InsufficientCondition;
             nonSupport = false;
         #endif
     } else if (static_cast<uint32_t>(engine) & static_cast<uint32_t>(CanvasEngine::Gl)) {
         #ifdef THORVG_GL_RASTER_SUPPORT
-            if (!GlRenderer::init()) return Result::InsufficientCondition;
+            if (!GlRenderer::init(threads)) return Result::InsufficientCondition;
             nonSupport = false;
         #endif
     } else {

--- a/src/lib/tvgTaskScheduler.cpp
+++ b/src/lib/tvgTaskScheduler.cpp
@@ -133,7 +133,7 @@ public:
             }
 
             if (!success && !taskQueues[i].pop(&task)) break;
-            (*task)();
+            (*task)(i);
         }
     }
 
@@ -149,7 +149,7 @@ public:
             taskQueues[i % threadCnt].push(task);
         //Sync
         } else {
-            task->run();
+            task->run(0);
         }
     }
 };

--- a/src/lib/tvgTaskScheduler.h
+++ b/src/lib/tvgTaskScheduler.h
@@ -50,12 +50,12 @@ public:
     }
 
 protected:
-    virtual void run() = 0;
+    virtual void run(unsigned tid) = 0;
 
 private:
-    void operator()()
+    void operator()(unsigned tid)
     {
-        run();
+        run(tid);
         sender.set_value();
     }
 

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -2431,7 +2431,7 @@ SvgLoader::~SvgLoader()
 }
 
 
-void SvgLoader::run()
+void SvgLoader::run(unsigned tid)
 {
     if (!simpleXmlParse(content, size, true, _svgLoaderParser, &(loaderData))) return;
 

--- a/src/loaders/svg/tvgSvgLoader.h
+++ b/src/loaders/svg/tvgSvgLoader.h
@@ -44,7 +44,7 @@ public:
     bool header();
     bool read() override;
     bool close() override;
-    void run() override;
+    void run(unsigned tid) override;
 
     unique_ptr<Scene> data() override;
 };


### PR DESCRIPTION
we introduced shared memory pool for avoiding reallocate memory
while it process the stroke outlines, It experimentally increase
the outline data if we use the allocated memory for multiples shape strokes,
we don't need to alloc/free memory during the process.

This shared outline memory is allocated for threads count
so that we don't interrupt memory access during the tasks.

- Description :

- Issue Tickets (if any) : https://github.com/Samsung/thorvg/issues/75
- Tests or Samples (if any) :

- Screen Shots (if any) :
