### PR TITLE
examples: revise example code.

### DIFF
--- a/src/examples/Arc.cpp
+++ b/src/examples/Arc.cpp
@@ -93,6 +93,7 @@ void drawSwView(void* data, Eo* obj)
     if (swCanvas->draw() == tvg::Result::Success) {
         swCanvas->sync();
     }
+    swCanvas->clear();  //Flush out cached resource
 }
 
 

--- a/src/examples/Blending.cpp
+++ b/src/examples/Blending.cpp
@@ -76,6 +76,9 @@ void drawSwView(void* data, Eo* obj)
     if (swCanvas->draw() == tvg::Result::Success) {
         swCanvas->sync();
     }
+
+    //Explicitly clear all retained resources.
+    swCanvas->clear();
 }
 
 
@@ -109,6 +112,9 @@ void drawGLview(Evas_Object *obj)
     if (glCanvas->draw() == tvg::Result::Success) {
         glCanvas->sync();
     }
+
+    //Explicitly clear all retained resources.
+    glCanvas->clear();
 }
 
 

--- a/src/examples/Boundary.cpp
+++ b/src/examples/Boundary.cpp
@@ -65,6 +65,9 @@ void drawSwView(void* data, Eo* obj)
     if (swCanvas->draw() == tvg::Result::Success) {
         swCanvas->sync();
     }
+
+    //Explicitly clear all retained resources.
+    swCanvas->clear();
 }
 
 
@@ -98,6 +101,9 @@ void drawGLview(Evas_Object *obj)
     if (glCanvas->draw() == tvg::Result::Success) {
         glCanvas->sync();
     }
+
+    //Explicitly clear all retained resources.
+    glCanvas->clear();
 }
 
 

--- a/src/examples/ClipPath.cpp
+++ b/src/examples/ClipPath.cpp
@@ -135,6 +135,9 @@ void drawSwView(void* data, Eo* obj)
     if (swCanvas->draw() == tvg::Result::Success) {
         swCanvas->sync();
     }
+
+    //Explicitly clear all retained resources.
+    swCanvas->clear();
 }
 
 
@@ -168,6 +171,9 @@ void drawGLview(Evas_Object *obj)
     if (glCanvas->draw() == tvg::Result::Success) {
         glCanvas->sync();
     }
+
+    //Explicitly clear all retained resources.
+    glCanvas->clear();
 }
 
 

--- a/src/examples/Duplicate.cpp
+++ b/src/examples/Duplicate.cpp
@@ -117,6 +117,9 @@ void drawSwView(void* data, Eo* obj)
     if (swCanvas->draw() == tvg::Result::Success) {
         swCanvas->sync();
     }
+
+    //Explicitly clear all retained resources.
+    swCanvas->clear();
 }
 
 
@@ -150,6 +153,9 @@ void drawGLview(Evas_Object *obj)
     if (glCanvas->draw() == tvg::Result::Success) {
         glCanvas->sync();
     }
+
+    //Explicitly clear all retained resources.
+    glCanvas->clear();
 }
 
 

--- a/src/examples/FillRule.cpp
+++ b/src/examples/FillRule.cpp
@@ -59,6 +59,9 @@ void drawSwView(void* data, Eo* obj)
     if (swCanvas->draw() == tvg::Result::Success) {
         swCanvas->sync();
     }
+
+    //Explicitly clear all retained resources.
+    swCanvas->clear();
 }
 
 
@@ -92,6 +95,9 @@ void drawGLview(Evas_Object *obj)
     if (glCanvas->draw() == tvg::Result::Success) {
         glCanvas->sync();
     }
+
+    //Explicitly clear all retained resources.
+    glCanvas->clear();
 }
 
 

--- a/src/examples/LinearGradient.cpp
+++ b/src/examples/LinearGradient.cpp
@@ -94,6 +94,9 @@ void drawSwView(void* data, Eo* obj)
     if (swCanvas->draw() == tvg::Result::Success) {
         swCanvas->sync();
     }
+
+    //Explicitly clear all retained resources.
+    swCanvas->clear();
 }
 
 
@@ -127,6 +130,9 @@ void drawGLview(Evas_Object *obj)
     if (glCanvas->draw() == tvg::Result::Success) {
         glCanvas->sync();
     }
+
+    //Explicitly clear all retained resources.
+    glCanvas->clear();
 }
 
 

--- a/src/examples/MultiCanvas.cpp
+++ b/src/examples/MultiCanvas.cpp
@@ -79,6 +79,9 @@ void drawSwView(void* data, Eo* obj)
     if (canvas->draw() == tvg::Result::Success) {
         canvas->sync();
     }
+
+    //Explicitly clear all retained resources.
+    canvas->clear();
 }
 
 
@@ -160,6 +163,9 @@ void drawGLview(Evas_Object *obj)
     if (canvas->draw() == tvg::Result::Success) {
         canvas->sync();
     }
+
+    //Explicitly clear all retained resources.
+    canvas->clear();
 }
 
 

--- a/src/examples/MultiShapes.cpp
+++ b/src/examples/MultiShapes.cpp
@@ -54,6 +54,9 @@ void drawSwView(void* data, Eo* obj)
     if (swCanvas->draw() == tvg::Result::Success) {
         swCanvas->sync();
     }
+
+    //Explicitly clear all retained resources.
+    swCanvas->clear();
 }
 
 
@@ -87,6 +90,9 @@ void drawGLview(Evas_Object *obj)
     if (glCanvas->draw() == tvg::Result::Success) {
         glCanvas->sync();
     }
+
+    //Explicitly clear all retained resources.
+    glCanvas->clear();
 }
 
 

--- a/src/examples/Opacity.cpp
+++ b/src/examples/Opacity.cpp
@@ -83,6 +83,9 @@ void drawSwView(void* data, Eo* obj)
     if (swCanvas->draw() == tvg::Result::Success) {
         swCanvas->sync();
     }
+
+    //Explicitly clear all retained resources.
+    swCanvas->clear();
 }
 
 
@@ -116,6 +119,9 @@ void drawGLview(Evas_Object *obj)
     if (glCanvas->draw() == tvg::Result::Success) {
         glCanvas->sync();
     }
+
+    //Explicitly clear all retained resources.
+    glCanvas->clear();
 }
 
 

--- a/src/examples/Path.cpp
+++ b/src/examples/Path.cpp
@@ -71,6 +71,9 @@ void drawSwView(void* data, Eo* obj)
     if (swCanvas->draw() == tvg::Result::Success) {
         swCanvas->sync();
     }
+
+    //Explicitly clear all retained resources.
+    swCanvas->clear();
 }
 
 
@@ -104,6 +107,9 @@ void drawGLview(Evas_Object *obj)
     if (glCanvas->draw() == tvg::Result::Success) {
         glCanvas->sync();
     }
+
+    //Explicitly clear all retained resources.
+    glCanvas->clear();
 }
 
 

--- a/src/examples/PathCopy.cpp
+++ b/src/examples/PathCopy.cpp
@@ -108,6 +108,9 @@ void drawSwView(void* data, Eo* obj)
     if (swCanvas->draw() == tvg::Result::Success) {
         swCanvas->sync();
     }
+
+    //Explicitly clear all retained resources.
+    swCanvas->clear();
 }
 
 
@@ -141,6 +144,9 @@ void drawGLview(Evas_Object *obj)
     if (glCanvas->draw() == tvg::Result::Success) {
         glCanvas->sync();
     }
+
+    //Explicitly clear all retained resources.
+    glCanvas->clear();
 }
 
 

--- a/src/examples/RadialGradient.cpp
+++ b/src/examples/RadialGradient.cpp
@@ -94,6 +94,9 @@ void drawSwView(void* data, Eo* obj)
     if (swCanvas->draw() == tvg::Result::Success) {
         swCanvas->sync();
     }
+
+    //Explicitly clear all retained resources.
+    swCanvas->clear();
 }
 
 
@@ -127,6 +130,9 @@ void drawGLview(Evas_Object *obj)
     if (glCanvas->draw() == tvg::Result::Success) {
         glCanvas->sync();
     }
+
+    //Explicitly clear all retained resources.
+    glCanvas->clear();
 }
 
 

--- a/src/examples/Scene.cpp
+++ b/src/examples/Scene.cpp
@@ -101,6 +101,9 @@ void drawSwView(void* data, Eo* obj)
     if (swCanvas->draw() == tvg::Result::Success) {
         swCanvas->sync();
     }
+
+    //Explicitly clear all retained resources.
+    swCanvas->clear();
 }
 
 
@@ -134,6 +137,9 @@ void drawGLview(Evas_Object *obj)
     if (glCanvas->draw() == tvg::Result::Success) {
         glCanvas->sync();
     }
+
+    //Explicitly clear all retained resources.
+    glCanvas->clear();
 }
 
 

--- a/src/examples/Shape.cpp
+++ b/src/examples/Shape.cpp
@@ -44,6 +44,9 @@ void drawSwView(void* data, Eo* obj)
     if (swCanvas->draw() == tvg::Result::Success) {
         swCanvas->sync();
     }
+
+    //Explicitly clear all retained resources.
+    swCanvas->clear();
 }
 
 
@@ -77,6 +80,9 @@ void drawGLview(Evas_Object *obj)
     if (glCanvas->draw() == tvg::Result::Success) {
         glCanvas->sync();
     }
+
+    //Explicitly clear all retained resources.
+    glCanvas->clear();
 }
 
 

--- a/src/examples/Stroke.cpp
+++ b/src/examples/Stroke.cpp
@@ -102,6 +102,8 @@ void drawSwView(void* data, Eo* obj)
     if (swCanvas->draw() == tvg::Result::Success) {
         swCanvas->sync();
     }
+    //Explicitly clear all retained resources.
+    swCanvas->clear();
 }
 
 
@@ -135,6 +137,8 @@ void drawGLview(Evas_Object *obj)
     if (glCanvas->draw() == tvg::Result::Success) {
         glCanvas->sync();
     }
+    //Explicitly clear all retained resources.
+    glCanvas->clear();
 }
 
 

--- a/src/examples/StrokeLine.cpp
+++ b/src/examples/StrokeLine.cpp
@@ -176,6 +176,8 @@ void drawSwView(void* data, Eo* obj)
     if (swCanvas->draw() == tvg::Result::Success) {
         swCanvas->sync();
     }
+    //Explicitly clear all retained resources.
+    swCanvas->clear();
 }
 
 
@@ -209,6 +211,8 @@ void drawGLview(Evas_Object *obj)
     if (glCanvas->draw() == tvg::Result::Success) {
         glCanvas->sync();
     }
+    //Explicitly clear all retained resources.
+    glCanvas->clear();
 }
 
 
@@ -236,7 +240,6 @@ int main(int argc, char **argv)
 
     //Initialize ThorVG Engine
     if (tvg::Initializer::init(tvgEngine, threads) == tvg::Result::Success) {
-
 
         elm_init(argc, argv);
 

--- a/src/examples/Svg.cpp
+++ b/src/examples/Svg.cpp
@@ -97,6 +97,8 @@ void drawSwView(void* data, Eo* obj)
     if (swCanvas->draw() == tvg::Result::Success) {
         swCanvas->sync();
     }
+    //Explicitly clear all retained resources.
+    swCanvas->clear();
 }
 
 
@@ -130,6 +132,8 @@ void drawGLview(Evas_Object *obj)
     if (glCanvas->draw() == tvg::Result::Success) {
         glCanvas->sync();
     }
+    //Explicitly clear all retained resources.
+    glCanvas->clear();
 }
 
 

--- a/src/examples/Svg2.cpp
+++ b/src/examples/Svg2.cpp
@@ -69,6 +69,8 @@ void drawSwView(void* data, Eo* obj)
     if (swCanvas->draw() == tvg::Result::Success) {
         swCanvas->sync();
     }
+    //Explicitly clear all retained resources.
+    swCanvas->clear();
 }
 
 
@@ -102,6 +104,8 @@ void drawGLview(Evas_Object *obj)
     if (glCanvas->draw() == tvg::Result::Success) {
         glCanvas->sync();
     }
+    //Explicitly clear all retained resources.
+    glCanvas->clear();
 }
 
 

--- a/src/examples/Update.cpp
+++ b/src/examples/Update.cpp
@@ -19,9 +19,6 @@ void tvgUpdateCmds(tvg::Canvas* canvas, float progress)
 {
     if (!canvas) return;
 
-    //Explicitly clear all retained paint nodes.
-    if (canvas->clear() != tvg::Result::Success) return;
-
     //Shape
     auto shape = tvg::Shape::gen();
     shape->appendRect(-100, -100, 200, 200, (100 * progress), (100 * progress));
@@ -68,6 +65,8 @@ void drawSwView(void* data, Eo* obj)
     if (swCanvas->draw() == tvg::Result::Success) {
         swCanvas->sync();
     }
+    //Explicitly clear all retained resources.
+    swCanvas->clear();
 }
 
 
@@ -101,6 +100,8 @@ void drawGLview(Evas_Object *obj)
     if (glCanvas->draw() == tvg::Result::Success) {
         glCanvas->sync();
     }
+    //Explicitly clear all retained resources.
+    glCanvas->clear();
 }
 
 void transitGlCb(Elm_Transit_Effect *effect, Elm_Transit* transit, double progress)

--- a/src/lib/sw_engine/tvgSwResMgr.cpp
+++ b/src/lib/sw_engine/tvgSwResMgr.cpp
@@ -50,6 +50,7 @@ void resMgrRetrieveOutline(unsigned idx)
 
 bool resMgrInit(unsigned threads)
 {
+    if (threads == 0) threads = 1;
     sharedOutline.reserve(threads);
     sharedOutline.resize(threads);
     threadsCnt = threads;


### PR DESCRIPTION
Move the Clear call to the end of drawing those scenarios doesn't need to retain paints resources.

We should show the examples as the best usage.

@Issues: 75

- Description :

- Issue Tickets (if any) :

- Tests or Samples (if any) :

- Screen Shots (if any) :
