### PR TITLE
fix compilation on Windows

### DIFF
--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -20,6 +20,7 @@
  * SOFTWARE.
  */
 
+#include <string>
 #include <thorvg.h>
 #include "thorvg_capi.h"
 

--- a/src/lib/tvgFill.h
+++ b/src/lib/tvgFill.h
@@ -22,7 +22,8 @@
 #ifndef _TVG_FILL_H_
 #define _TVG_FILL_H_
 
-#include <string.h>
+#include <cstdlib>
+#include <cstring>
 #include "tvgCommon.h"
 
 template<typename T>
@@ -75,7 +76,7 @@ struct Fill::Impl
         memcpy(ret->pImpl->colorStops, colorStops, sizeof(ColorStop) * cnt);
 
         return ret;
-    }    
+    }
 };
 
 #endif  //_TVG_FILL_H_

--- a/src/loaders/svg/tvgXmlParser.cpp
+++ b/src/loaders/svg/tvgXmlParser.cpp
@@ -23,9 +23,9 @@
 #include <ctype.h>
 #include <cstring>
 #ifdef _WIN32
-# include <malloc.h>
+    #include <malloc.h>
 #else
-# include <alloca.h>
+    #include <alloca.h>
 #endif
 
 #include "tvgXmlParser.h"

--- a/src/loaders/svg/tvgXmlParser.cpp
+++ b/src/loaders/svg/tvgXmlParser.cpp
@@ -22,7 +22,11 @@
 
 #include <ctype.h>
 #include <cstring>
-#include <alloca.h>
+#ifdef _WIN32
+# include <malloc.h>
+#else
+# include <alloca.h>
+#endif
 
 #include "tvgXmlParser.h"
 


### PR DESCRIPTION
alloca.h does not exist on Windows
include string in the C api, neccesary to cas a char * to a std::string

