### PR TITLE
common renderer: code refactoring.

### DIFF
--- a/src/lib/gl_engine/tvgGlRenderer.cpp
+++ b/src/lib/gl_engine/tvgGlRenderer.cpp
@@ -65,7 +65,7 @@ bool GlRenderer::target(TVG_UNUSED uint32_t* buffer, uint32_t stride, uint32_t w
 }
 
 
-bool GlRenderer::flush()
+bool GlRenderer::sync()
 {
     GL_CHECK(glFinish());
     GlRenderTask::unload();

--- a/src/lib/gl_engine/tvgGlRenderer.h
+++ b/src/lib/gl_engine/tvgGlRenderer.h
@@ -36,7 +36,7 @@ public:
     bool render(const Shape& shape, void *data) override;
     bool postRender() override;
     bool target(uint32_t* buffer, uint32_t stride, uint32_t w, uint32_t h);
-    bool flush() override;
+    bool sync() override;
     bool clear() override;
 
     static GlRenderer* gen();

--- a/src/lib/tvgCanvas.cpp
+++ b/src/lib/tvgCanvas.cpp
@@ -69,7 +69,7 @@ Result Canvas::update(Paint* paint) noexcept
 
 Result Canvas::sync() noexcept
 {
-    if (pImpl->renderer->flush()) return Result::Success;
+    if (pImpl->renderer->sync()) return Result::Success;
 
     return Result::InsufficientCondition;
 }

--- a/src/lib/tvgRender.h
+++ b/src/lib/tvgRender.h
@@ -71,7 +71,7 @@ public:
     virtual bool render(TVG_UNUSED const Shape& shape, TVG_UNUSED void *data) { return true; }
     virtual bool postRender() { return true; }
     virtual bool clear() { return true; }
-    virtual bool flush() { return true; }
+    virtual bool sync() { return true; }
 };
 
 }


### PR DESCRIPTION
renamed internal methods from flush() to sync()
since flush() is reserved for caching flush.

- Description :

- Issue Tickets (if any) :

- Tests or Samples (if any) :

- Screen Shots (if any) :
