### PR TITLE
capi examples: Added scene API C bindings.

### DIFF
--- a/inc/thorvg_capi.h
+++ b/inc/thorvg_capi.h
@@ -170,13 +170,20 @@ TVG_EXPORT Tvg_Result tvg_gradient_set_spread(Tvg_Gradient* grad, const Tvg_Stro
 TVG_EXPORT Tvg_Result tvg_gradient_get_spread(Tvg_Gradient* grad, Tvg_Stroke_Fill* spread);
 TVG_EXPORT Tvg_Result tvg_gradient_del(Tvg_Gradient* grad);
 
-
 /************************************************************************/
 /* Picture API                                                          */
 /************************************************************************/
 TVG_EXPORT Tvg_Paint* tvg_picture_new();
 TVG_EXPORT Tvg_Result tvg_picture_load(Tvg_Paint* paint, const char* path);
 TVG_EXPORT Tvg_Result tvg_picture_get_viewbox(const Tvg_Paint* paint, float* x, float* y, float* w, float* h);
+
+/************************************************************************/
+/* Scene API                                                            */
+/************************************************************************/
+TVG_EXPORT Tvg_Paint* tvg_scene_new();
+TVG_EXPORT Tvg_Result tvg_scene_reserve(Tvg_Paint* scene, uint32_t size);
+TVG_EXPORT Tvg_Result tvg_scene_push(Tvg_Paint* scene, Tvg_Paint* paint);
+
 
 #ifdef __cplusplus
 }

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -475,6 +475,23 @@ TVG_EXPORT Tvg_Result tvg_gradient_get_spread(Tvg_Gradient* grad, Tvg_Stroke_Fil
     return TVG_RESULT_SUCCESS;
 }
 
+TVG_EXPORT Tvg_Paint* tvg_scene_new()
+{
+    return (Tvg_Paint*) Scene::gen().release();
+}
+
+TVG_EXPORT Tvg_Result tvg_scene_reserve(Tvg_Paint* scene, uint32_t size)
+{
+    if (!scene) return TVG_RESULT_INVALID_ARGUMENT;
+    return (Tvg_Result) reinterpret_cast<Scene*>(scene)->reserve(size);
+}
+
+TVG_EXPORT Tvg_Result tvg_scene_push(Tvg_Paint* scene, Tvg_Paint* paint)
+{
+    if (!scene || !paint) return TVG_RESULT_INVALID_ARGUMENT;
+    return (Tvg_Result) reinterpret_cast<Scene*>(scene)->push(unique_ptr<Paint>((Paint*)paint));
+}
+
 
 #ifdef __cplusplus
 }

--- a/src/examples/Capi.cpp
+++ b/src/examples/Capi.cpp
@@ -165,6 +165,22 @@ void testCapi()
     Tvg_Paint* dup = tvg_paint_duplicate(org);
     tvg_canvas_push(canvas, dup);
 
+    //Scene test
+    Tvg_Paint* scene = tvg_scene_new();
+
+    Tvg_Paint* scene_shape_1 = tvg_shape_new();
+    tvg_shape_append_rect(scene_shape_1, 650, 410, 100, 50, 10, 10);
+    tvg_shape_set_fill_color(scene_shape_1, 0, 255, 0, 255);
+
+    Tvg_Paint* scene_shape_2 = tvg_shape_new();
+    tvg_shape_append_rect(scene_shape_2, 650, 470, 100, 50, 10, 10);
+    tvg_shape_set_fill_color(scene_shape_2, 0, 255, 0, 255);
+
+    tvg_scene_push(scene, scene_shape_1);
+    tvg_scene_push(scene, scene_shape_2);
+    tvg_paint_set_opacity(scene, 100);
+
+    tvg_canvas_push(canvas, scene);
     tvg_canvas_draw(canvas);
     tvg_canvas_sync(canvas);
 


### PR DESCRIPTION
Scene CAPI allows to use scene functionaliy in C applications such as
set opacity to few shapes at one time or implement transparent layers.

@API Additions:
```c
Tvg_Paint* tvg_scene_new();
Tvg_Result tvg_scene_reserve(Tvg_Paint* scene, uint32_t size);
Tvg_Result tvg_scene_push(Tvg_Paint* scene, Tvg_Paint *paint);
```

Examples:
```c
Tvg_Paint *scene = tvg_scene_new();

Tvg_Paint *shape1 = tvg_shape_new();
tvg_shape_append_rect(shape1, 10, 10, 100, 100, 0, 0);
tvg_shape_set_fill_color(shape1, 255, 0, 0, 255);

Tvg_Paint *shape2 = tvg_shape_new();
tvg_shape_append_rect(shape2, 120, 10, 100, 100, 0, 0);
tvg_shape_set_fill_color(shape2, 255, 0, 0, 255);

tvg_scene_push(scene, shape1);
tvg_scene_push(scene, shape2);

tvg_paint_set_opacity(scene, 100);

tvg_canvas_push(canvas, scene);
```