### PR TITLE
capi: Added free flag to clear API.

### DIFF
--- a/inc/thorvg_capi.h
+++ b/inc/thorvg_capi.h
@@ -1,6 +1,8 @@
 #ifndef __THORVG_CAPI_H__
 #define __THORVG_CAPI_H__
 
+#include <stdbool.h>
+
 #ifdef TVG_EXPORT
     #undef TVG_EXPORT
 #endif
@@ -105,7 +107,7 @@ TVG_EXPORT Tvg_Result tvg_swcanvas_set_target(Tvg_Canvas* canvas, uint32_t* buff
 TVG_EXPORT Tvg_Result tvg_canvas_destroy(Tvg_Canvas* canvas);
 TVG_EXPORT Tvg_Result tvg_canvas_push(Tvg_Canvas* canvas, Tvg_Paint* paint);
 TVG_EXPORT Tvg_Result tvg_canvas_reserve(Tvg_Canvas* canvas, uint32_t n);
-TVG_EXPORT Tvg_Result tvg_canvas_clear(Tvg_Canvas* canvas);
+TVG_EXPORT Tvg_Result tvg_canvas_clear(Tvg_Canvas* canvas, bool free);
 TVG_EXPORT Tvg_Result tvg_canvas_update(Tvg_Canvas* canvas);
 TVG_EXPORT Tvg_Result tvg_canvas_update_paint(Tvg_Canvas* canvas, Tvg_Paint* paint);
 TVG_EXPORT Tvg_Result tvg_canvas_draw(Tvg_Canvas* canvas);

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -88,10 +88,10 @@ TVG_EXPORT Tvg_Result tvg_canvas_reserve(Tvg_Canvas* canvas, uint32_t n)
 }
 
 
-TVG_EXPORT Tvg_Result tvg_canvas_clear(Tvg_Canvas* canvas)
+TVG_EXPORT Tvg_Result tvg_canvas_clear(Tvg_Canvas* canvas, bool free)
 {
     if (!canvas) return TVG_RESULT_INVALID_ARGUMENT;
-    return (Tvg_Result) reinterpret_cast<Canvas*>(canvas)->clear();
+    return (Tvg_Result) reinterpret_cast<Canvas*>(canvas)->clear(free);
 }
 
 


### PR DESCRIPTION
Cpp implementaiton of library has free flag which was not used in
capi bindings.

@API changes
from: tvg_canvas_clear(Tvg_Canvas *canvas);
to: tvg_canvas_clear(Tvg_Canvas *canvas, bool free);
