### PR TITLE
capi: Added fill rule API.

### DIFF
--- a/inc/thorvg_capi.h
+++ b/inc/thorvg_capi.h
@@ -68,6 +68,11 @@ typedef enum {
 } Tvg_Stroke_Fill;
 
 
+typedef enum {
+    TVG_FILL_RULE_WINDING = 0,
+    TVG_FILL_RULE_EVEN_ODD
+} Tvg_Fill_Rule;
+
 typedef struct
 {
     float x, y;
@@ -153,6 +158,8 @@ TVG_EXPORT Tvg_Result tvg_shape_set_stroke_join(Tvg_Paint* paint, Tvg_Stroke_Joi
 TVG_EXPORT Tvg_Result tvg_shape_get_stroke_join(const Tvg_Paint* paint, Tvg_Stroke_Join* join);
 TVG_EXPORT Tvg_Result tvg_shape_set_fill_color(Tvg_Paint* paint, uint8_t r, uint8_t g, uint8_t b, uint8_t a);
 TVG_EXPORT Tvg_Result tvg_shape_get_fill_color(const Tvg_Paint* paint, uint8_t* r, uint8_t* g, uint8_t* b, uint8_t* a);
+TVG_EXPORT Tvg_Result tvg_shape_set_fill_rule(Tvg_Paint* paint, Tvg_Fill_Rule rule);
+TVG_EXPORT Tvg_Result tvg_shape_get_fill_rule(const Tvg_Paint* paint, Tvg_Fill_Rule* rule);
 TVG_EXPORT Tvg_Result tvg_shape_set_linear_gradient(Tvg_Paint* paint, Tvg_Gradient* grad);
 TVG_EXPORT Tvg_Result tvg_shape_set_radial_gradient(Tvg_Paint* paint, Tvg_Gradient* grad);
 TVG_EXPORT Tvg_Result tvg_shape_get_gradient(const Tvg_Paint* paint, Tvg_Gradient** grad);

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -358,6 +358,21 @@ TVG_EXPORT Tvg_Result tvg_shape_get_fill_color(const Tvg_Paint* paint, uint8_t* 
 }
 
 
+TVG_EXPORT Tvg_Result tvg_shape_set_fill_rule(Tvg_Paint* paint, Tvg_Fill_Rule rule)
+{
+    if (!paint) return TVG_RESULT_INVALID_ARGUMENT;
+    return (Tvg_Result) reinterpret_cast<Shape*>(paint)->fill((FillRule)rule);
+}
+
+
+TVG_EXPORT Tvg_Result tvg_shape_get_fill_rule(const Tvg_Paint* paint, Tvg_Fill_Rule* rule)
+{
+    if (!paint || !rule) return TVG_RESULT_INVALID_ARGUMENT;
+    *rule = (Tvg_Fill_Rule) reinterpret_cast<Shape*>(CCP(paint))->fillRule();
+    return TVG_RESULT_SUCCESS;
+}
+
+
 TVG_EXPORT Tvg_Result tvg_shape_set_linear_gradient(Tvg_Paint* paint, Tvg_Gradient* gradient)
 {
     if (!paint) return TVG_RESULT_INVALID_ARGUMENT;


### PR DESCRIPTION
Description:
Added capi binding for fill rule setter and getter.

@API changes:
```c
enum Tvg_Fill_Rule {
  TVG_FILL_RULE_WINDING = 0,
  TVG_FILL_RULE_EVEN_ODD = 1,
}

Tvg_Result     tvg_shape_set_fill_rule(Tvg_Paint* paint, Tvg_Fill_Rule rule)
Tvg_Fill_Rule  tvg_shape_get_fill_rule(Tvg_Paint* paint, Tvg_Fill_Rule* rule)
```