### PR TITLE
examples: ignore loading raw image file.

### DIFF
--- a/src/examples/MultiCanvas.cpp
+++ b/src/examples/MultiCanvas.cpp
@@ -84,6 +84,10 @@ void drawSwView(void* data, Eo* obj)
 
 void tvgSwTest(const char* name, const char* path, void* data)
 {
+    //ignore if not svgs.
+    const char *ext = name + strlen(name) - 3;
+    if (strcmp(ext, "svg")) return;
+
     Eo* win = (Eo*) data;
 
     uint32_t* buffer = (uint32_t*) calloc(sizeof(uint32_t), SIZE * SIZE);
@@ -106,7 +110,7 @@ void tvgSwTest(const char* name, const char* path, void* data)
 
     tvgDrawCmds(canvas.get(), path, name);
 
-    canvases.push_back(move(canvas));    
+    canvases.push_back(move(canvas));
 }
 
 

--- a/src/examples/Svg.cpp
+++ b/src/examples/Svg.cpp
@@ -14,6 +14,10 @@ static std::vector<unique_ptr<tvg::Picture>> pictures;
 
 void svgDirCallback(const char* name, const char* path, void* data)
 {
+    //ignore if not svgs.
+    const char *ext = name + strlen(name) - 3;
+    if (strcmp(ext, "svg")) return;
+
     auto picture = tvg::Picture::gen();
 
     char buf[PATH_MAX];


### PR DESCRIPTION
in the last commit, it added a raw image file in the images folder.
It breaks Multicanvas, Svg which try to load all kinds of files in it.

We don't need to load all files by figuring out file extension name.

- Description :

- Issue Tickets (if any) :

- Tests or Samples (if any) :

- Screen Shots (if any) :
