### PR TITLE
common capi: Added scene clear API

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -303,6 +303,7 @@ public:
 
     Result push(std::unique_ptr<Paint> paint) noexcept;
     Result reserve(uint32_t size) noexcept;
+    Result clear() noexcept;
 
     static std::unique_ptr<Scene> gen() noexcept;
 

--- a/inc/thorvg_capi.h
+++ b/inc/thorvg_capi.h
@@ -185,6 +185,7 @@ TVG_EXPORT Tvg_Result tvg_picture_get_viewbox(const Tvg_Paint* paint, float* x, 
 TVG_EXPORT Tvg_Paint* tvg_scene_new();
 TVG_EXPORT Tvg_Result tvg_scene_reserve(Tvg_Paint* scene, uint32_t size);
 TVG_EXPORT Tvg_Result tvg_scene_push(Tvg_Paint* scene, Tvg_Paint* paint);
+TVG_EXPORT Tvg_Result tvg_scene_clear(Tvg_Paint* scene);
 
 
 #ifdef __cplusplus

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -492,6 +492,12 @@ TVG_EXPORT Tvg_Result tvg_scene_push(Tvg_Paint* scene, Tvg_Paint* paint)
     return (Tvg_Result) reinterpret_cast<Scene*>(scene)->push(unique_ptr<Paint>((Paint*)paint));
 }
 
+TVG_EXPORT Tvg_Result tvg_scene_clear(Tvg_Paint* scene)
+{
+    if (!scene) return TVG_RESULT_INVALID_ARGUMENT;
+    return (Tvg_Result) reinterpret_cast<Scene*>(scene)->clear();
+}
+
 
 #ifdef __cplusplus
 }

--- a/src/lib/tvgScene.cpp
+++ b/src/lib/tvgScene.cpp
@@ -59,3 +59,11 @@ Result Scene::reserve(uint32_t size) noexcept
 
     return Result::Success;
 }
+
+
+Result Scene::clear() noexcept
+{
+    pImpl->paints.clear();
+
+    return Result::Success;
+}


### PR DESCRIPTION
Scene::clear() API allows users to remove shapes on their own, without
a crash in paint->dispose() or tvg_paint_del() methods. This case is
needed especially when thorvg is used to draw frames, when in one frame
we have scene with shape, and in next frames (future time stamps) user
deletes shapes

@API additions
```cpp
Result Scene::clear();
```
```c
Tvg_Result tvg_scene_clear(Tvg_Paint *scene);
```

Example:
```c
Tvg_Paint *scene = tvg_scene_new();
Tvg_Paint *shape = tvg_shape_new();

tvg_scene_push(scene, shape);
tvg_scene_clear();
//Now we can safelly free resources manually
tvg_paint_del(scene);
//Without tvg_scene_clear() memory allocatad for shape was double released
tvg_paint_del(shape);
```
