### PR TITLE
common Scene: Fix validation check for child's bounds

### DIFF
--- a/src/lib/tvgSceneImpl.h
+++ b/src/lib/tvgSceneImpl.h
@@ -77,12 +77,12 @@ struct Scene::Impl
             auto w2 = 0.0f;
             auto h2 = 0.0f;
 
-            if (paint->pImpl->bounds(&x2, &y2, &w2, &h2)) return false;
+            if (!paint->pImpl->bounds(&x2, &y2, &w2, &h2)) continue;
 
             //Merge regions
             if (x2 < x) x = x2;
             if (x + w < x2 + w2) w = (x2 + w2) - x;
-            if (y2 < y) y = x2;
+            if (y2 < y) y = y2;
             if (y + h < y2 + h2) h = (y2 + h2) - y;
         }
 

--- a/test/meson.build
+++ b/test/meson.build
@@ -17,3 +17,17 @@ canvas_testsuite = executable('canvasTestSuite',
                               )
 
 test('Canvas Testsuite', canvas_testsuite)
+
+paint_test_sources = [
+    'testsuite.cpp',
+    'test_paint.cpp',
+    ]
+
+paint_testsuite = executable('paintTestSuite',
+                              paint_test_sources,
+                              include_directories : headers,
+                              override_options : override_default,
+                              dependencies : [gtest_dep, thorvg_lib_dep],
+                              )
+
+test('Paint Testsuite', paint_testsuite)

--- a/test/test_paint.cpp
+++ b/test/test_paint.cpp
@@ -1,0 +1,56 @@
+#include <gtest/gtest.h>
+#include <iostream>
+#include <thread>
+#include <thorvg.h>
+
+class PaintTest : public ::testing::Test {
+public:
+    void SetUp() {
+        auto threads = std::thread::hardware_concurrency();
+        //Initialize ThorVG Engine
+        if (tvg::Initializer::init(tvgEngine, threads) == tvg::Result::Success) {
+            swCanvas = tvg::SwCanvas::gen();
+
+            scene = tvg::Scene::gen();
+
+            shape = tvg::Shape::gen();
+        }
+    }
+    void TearDown() {
+
+        //Terminate ThorVG Engine
+        tvg::Initializer::term(tvgEngine);
+    }
+public:
+    std::unique_ptr<tvg::SwCanvas> swCanvas;
+    std::unique_ptr<tvg::Scene> scene;
+    std::unique_ptr<tvg::Shape> shape;
+    tvg::CanvasEngine tvgEngine = tvg::CanvasEngine::Sw;
+};
+
+TEST_F(PaintTest, GenerateShape) {
+    ASSERT_TRUE(swCanvas != nullptr);
+    ASSERT_TRUE(shape != nullptr);
+}
+
+TEST_F(PaintTest, GenerateScene) {
+    ASSERT_TRUE(swCanvas != nullptr);
+    ASSERT_TRUE(scene != nullptr);
+}
+
+TEST_F(PaintTest, SceneBounds) {
+    ASSERT_TRUE(swCanvas != nullptr);
+    ASSERT_TRUE(scene != nullptr);
+
+    ASSERT_EQ(shape->appendRect(10.0, 20.0, 100.0, 200.0, 0, 0), tvg::Result::Success);
+
+    ASSERT_EQ(scene->push(std::move(shape)), tvg::Result::Success);
+
+    float x, y, w, h;
+    ASSERT_EQ(scene->bounds(&x, &y, &w, &h), tvg::Result::Success);
+    ASSERT_EQ(x, 10.0);
+    ASSERT_EQ(y, 20.0);
+    ASSERT_EQ(w, 100.0);
+    ASSERT_EQ(h, 200.0);
+}
+


### PR DESCRIPTION
- Description :
Fix typo. and Change return to continue.
Even if the child's boundary calculation is wrong,
other child's boundary should be calculated.

- Tests or Samples (if any) :
./test/test_paint.c : SceneBounds
