### PR TITLE
common Picture : Introduce Picture's size setter, getter APIs

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -282,6 +282,9 @@ public:
     Result load(uint32_t* data, uint32_t w, uint32_t h, bool copy) noexcept;
     Result viewbox(float* x, float* y, float* w, float* h) const noexcept;
 
+    Result size(uint32_t w, uint32_t h) noexcept;
+    Result size(uint32_t* w, uint32_t* h) const noexcept;
+
     static std::unique_ptr<Picture> gen() noexcept;
 
     _TVG_DECLARE_PRIVATE(Picture);

--- a/src/examples/Svg.cpp
+++ b/src/examples/Svg.cpp
@@ -25,25 +25,8 @@ void svgDirCallback(const char* name, const char* path, void* data)
 
     if (picture->load(buf) != tvg::Result::Success) return;
 
-    float x, y, w, h;
-    picture->viewbox(&x, &y, &w, &h);
-
-    float rate = (SIZE/(w > h ? w : h));
-    picture->scale(rate);
-
-    x *= rate;
-    y *= rate;
-    w *= rate;
-    h *= rate;
-
-    //Center Align ?
-    if (w > h) {
-         y -= (SIZE - h) * 0.5f;
-    } else {
-         x -= (SIZE - w) * 0.5f;
-    }
-
-    picture->translate((count % NUM_PER_LINE) * SIZE - x, SIZE * (count / NUM_PER_LINE) - y);
+    picture->size(SIZE, SIZE);
+    picture->translate((count % NUM_PER_LINE) * SIZE, SIZE * (count / NUM_PER_LINE));
 
     pictures.push_back(move(picture));
 

--- a/src/lib/tvgLoader.h
+++ b/src/lib/tvgLoader.h
@@ -36,6 +36,10 @@ public:
     float vw = 0;
     float vh = 0;
 
+    uint32_t w;
+    uint32_t h;
+    bool preserveAspect;
+
     virtual ~Loader() {}
 
     virtual bool open(const string& path) { /* Not supported */ return false; };

--- a/src/lib/tvgLoader.h
+++ b/src/lib/tvgLoader.h
@@ -36,9 +36,9 @@ public:
     float vw = 0;
     float vh = 0;
 
-    uint32_t w;
-    uint32_t h;
-    bool preserveAspect;
+    uint32_t w = 0; //default size
+    uint32_t h = 0; //default size
+    bool preserveAspect = true; //keep aspect ratio by default.
 
     virtual ~Loader() {}
 

--- a/src/lib/tvgPicture.cpp
+++ b/src/lib/tvgPicture.cpp
@@ -73,3 +73,18 @@ Result Picture::viewbox(float* x, float* y, float* w, float* h) const noexcept
     if (pImpl->viewbox(x, y, w, h)) return Result::Success;
     return Result::InsufficientCondition;
 }
+
+
+Result Picture::size(uint32_t w, uint32_t h) noexcept
+{
+    if (pImpl->size(w, h)) return Result::Success;
+    return Result::InsufficientCondition;
+}
+
+
+Result Picture::size(uint32_t* w, uint32_t* h) const noexcept
+{
+    if (pImpl->size(w, h)) return Result::Success;
+    return Result::InsufficientCondition;
+}
+

--- a/src/lib/tvgPicture.cpp
+++ b/src/lib/tvgPicture.cpp
@@ -84,7 +84,8 @@ Result Picture::size(uint32_t w, uint32_t h) noexcept
 
 Result Picture::size(uint32_t* w, uint32_t* h) const noexcept
 {
-    if (pImpl->size(w, h)) return Result::Success;
-    return Result::InsufficientCondition;
+    if (w) *w = pImpl->w;
+    if (h) *h = pImpl->h;
+    return Result::Success;
 }
 

--- a/src/lib/tvgPictureImpl.h
+++ b/src/lib/tvgPictureImpl.h
@@ -38,6 +38,8 @@ struct Picture::Impl
     Picture *picture = nullptr;
     void *edata = nullptr;              //engine data
 
+    uint32_t w = 0, h = 0;
+
     Impl(Picture* p) : picture(p)
     {
     }
@@ -98,6 +100,20 @@ struct Picture::Impl
         if (y) *y = loader->vy;
         if (w) *w = loader->vw;
         if (h) *h = loader->vh;
+        return true;
+    }
+
+    bool size(uint32_t w, uint32_t h)
+    {
+        this->w = w;
+        this->h = h;
+        return true;
+    }
+
+    bool size(uint32_t* w, uint32_t* h)
+    {
+        if (w) *w = this->w;
+        if (h) *h = this->h;
         return true;
     }
 

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -2461,10 +2461,15 @@ bool SvgLoader::header()
 
     if (loaderData.doc && loaderData.doc->type == SvgNodeType::Doc) {
         //Return the brief resource info such as viewbox:
-        this->vx = loaderData.doc->node.doc.vx;
-        this->vy = loaderData.doc->node.doc.vy;
-        this->vw = loaderData.doc->node.doc.vw;
-        this->vh = loaderData.doc->node.doc.vh;
+        vx = loaderData.doc->node.doc.vx;
+        vy = loaderData.doc->node.doc.vy;
+        vw = loaderData.doc->node.doc.vw;
+        vh = loaderData.doc->node.doc.vh;
+
+        w = loaderData.doc->node.doc.w;
+        h = loaderData.doc->node.doc.h;
+
+        preserveAspect = loaderData.doc->node.doc.preserveAspect;
     } else {
         //LOG: No SVG File. There is no <svg/>
         return false;

--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -395,10 +395,5 @@ unique_ptr<Scene> SvgSceneBuilder::build(SvgNode* node)
 {
     if (!node || (node->type != SvgNodeType::Doc)) return nullptr;
 
-    viewBox.x = node->node.doc.vx;
-    viewBox.y = node->node.doc.vy;
-    viewBox.w = node->node.doc.vw;
-    viewBox.h = node->node.doc.vh;
-    preserveAspect = node->node.doc.preserveAspect;
-    return _sceneBuildHelper(node, viewBox.x, viewBox.y, viewBox.w, viewBox.h, 255);
+    return _sceneBuildHelper(node, node->node.doc.vx, node->node.doc.vy, node->node.doc.vw, node->node.doc.vh, 255);
 }

--- a/src/loaders/svg/tvgSvgSceneBuilder.h
+++ b/src/loaders/svg/tvgSvgSceneBuilder.h
@@ -27,13 +27,6 @@
 
 class SvgSceneBuilder
 {
-private:
-    struct {
-        int x, y;
-        uint32_t w, h;
-    } viewBox = {0, 0, 0, 0};
-    bool     preserveAspect = false;
-
 public:
     SvgSceneBuilder();
     ~SvgSceneBuilder();


### PR DESCRIPTION
- Description :
Add picture's resize API. The file loaded by picture may or may not have a size.
Therefore, if there is a size, it transforms the size of the Vector object of the picture.
When resizing, if preserveAspect is true, the aspect ratio is kept.
If false, the aspect ratio is not kept.
[Added APIs]
Result size(uint32_t w, uint32_t h) noexcept;
Result size(uint32_t* w, uint32_t* h) const noexcept;

- Issue Tickets (if any) :
https://github.com/Samsung/thorvg/issues/148

- Tests or Samples (if any) :
src/example/Svg
