### PR TITLE
sw_engine raster: support opacity composition.

### DIFF
--- a/src/examples/Opacity.cpp
+++ b/src/examples/Opacity.cpp
@@ -35,6 +35,10 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     shape2->lineTo(146, 143);
     shape2->close();
     shape2->fill(0, 0, 255, 255);
+    shape2->stroke(10);
+    shape2->stroke(255, 255, 255, 255);
+    shape2->opacity(127);
+
     scene->push(move(shape2));
 
     //Circle
@@ -52,6 +56,9 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     shape3->cubicTo(cx - halfRadius, cy + radius, cx - radius, cy + halfRadius, cx - radius, cy);
     shape3->cubicTo(cx - radius, cy - halfRadius, cx - halfRadius, cy - radius, cx, cy - radius);
     shape3->fill(255, 0, 0, 255);
+    shape3->stroke(10);
+    shape3->stroke(0, 0, 255, 255);
+    shape3->opacity(200);
     scene->push(move(shape3));
 
     //Draw the Scene onto the Canvas

--- a/src/examples/Stress.cpp
+++ b/src/examples/Stress.cpp
@@ -53,7 +53,7 @@ void svgDirCallback(const char* name, const char* path, void* data)
     }
 
     cout << "SVG: " << buf << endl;
-    pictures.push_back(picture.release());    
+    pictures.push_back(picture.release());
 }
 
 void tvgDrawCmds(tvg::Canvas* canvas)

--- a/src/lib/sw_engine/tvgSwRenderer.h
+++ b/src/lib/sw_engine/tvgSwRenderer.h
@@ -49,7 +49,8 @@ public:
     static bool term();
 
 private:
-    SwSurface* surface = nullptr;
+    SwSurface* mainSurface = nullptr;
+    SwSurface* compSurface = nullptr;   //Composition Surface to use temporarily in the intermediate rendering
     vector<SwTask*> tasks;
 
     SwRenderer(){};

--- a/src/lib/tvgSceneImpl.h
+++ b/src/lib/tvgSceneImpl.h
@@ -46,21 +46,29 @@ struct Scene::Impl
 
     void* update(RenderMethod &renderer, const RenderTransform* transform, uint32_t opacity, vector<Composite>& compList, RenderUpdateFlag flag)
     {
-        /* FXIME: it requires to return list of childr engine data
+        /* FXIME: it requires to return list of children engine data
            This is necessary for scene composition */
         void* edata = nullptr;
 
         for (auto paint : paints) {
             edata = paint->pImpl->update(renderer, transform, opacity, compList, static_cast<uint32_t>(flag));
         }
+
         return edata;
     }
 
     bool render(RenderMethod &renderer)
     {
+        //TODO: composition begin
+        //auto data = renderer.beginComp();
+
         for (auto paint : paints) {
             if (!paint->pImpl->render(renderer)) return false;
-        }
+        }     
+
+        //TODO: composition end
+        //renderer.endComp(edata);
+
         return true;
     }
 


### PR DESCRIPTION
This implementation supports shape + stroke opacity composition.

Currently, tvg shape provides individual alpha values for filling & stroking

These alpha values are working individually, meaning that if stroking is half translucent,
user can see that translucent stroking is crossed the shape outlines.

Sometimes this result can be expected but user also expects the shape filling is invisible
behind of translucent stroking.

For this reason, Paint provides an additional api opacity()
that applies opacity value to whole paint attributes.

This is a little expensive job, please consider if you can possibly avoid that usage.

See Opacity example.

@Issues: 94

- Description :

- Issue Tickets (if any) :

- Tests or Samples (if any) :

- Screen Shots (if any) :
