### PR TITLE
sw_engine renderer: refactoring code & optimize composition.

### DIFF
--- a/src/lib/sw_engine/tvgSwRaster.cpp
+++ b/src/lib/sw_engine/tvgSwRaster.cpp
@@ -91,6 +91,7 @@ static SwBBox _clipRegion(Surface* surface, SwBBox& in)
     return bbox;
 }
 
+
 static bool _rasterTranslucentRect(SwSurface* surface, const SwBBox& region, uint32_t color)
 {
     auto buffer = surface->buffer + (region.min.y * surface->stride) + region.min.x;
@@ -502,7 +503,7 @@ bool rasterImage(SwSurface* surface, SwImage* image, const Matrix* transform, ui
     Matrix invTransform;
 
     if (transform) _inverse(transform, &invTransform);
-    else invTransform = { 1, 0, 0, 0, 1, 0, 0, 0, 1 };
+    else invTransform = {1, 0, 0, 0, 1, 0, 0, 0, 1};
 
     if (image->rle) {
         if (opacity < 255) return _rasterTranslucentImageRle(surface, image->rle, image->data, image->w, image->h, opacity, &invTransform);

--- a/src/lib/sw_engine/tvgSwRenderer.h
+++ b/src/lib/sw_engine/tvgSwRenderer.h
@@ -27,6 +27,8 @@
 
 struct SwSurface;
 struct SwTask;
+struct SwShapeTask;
+struct SwImage;
 
 namespace tvg
 {
@@ -56,6 +58,7 @@ private:
     SwRenderer(){};
     ~SwRenderer();
 
+    bool prepareComposite(const SwShapeTask* task, SwImage* image);
     void prepareCommon(SwTask* task, const RenderTransform* transform, uint32_t opacity, vector<Composite>& compList, RenderUpdateFlag flags);
 };
 


### PR DESCRIPTION
Move the prepare stage of shape & stroking composition stage to a separate function
this returns SwImage to use in composite stage.

Also clear partial region buffer since we know composition area.

- Description :

- Issue Tickets (if any) :

- Tests or Samples (if any) :

- Screen Shots (if any) :
