### PR TITLE
picture svg_loader: use viewbox size as default image size.

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -283,8 +283,8 @@ public:
     //TODO: Replace with size(). Remove API
     Result viewbox(float* x, float* y, float* w, float* h) const noexcept;
 
-    Result size(uint32_t w, uint32_t h) noexcept;
-    Result size(uint32_t* w, uint32_t* h) const noexcept;
+    Result size(float w, float h) noexcept;
+    Result size(float* w, float* h) const noexcept;
 
     static std::unique_ptr<Picture> gen() noexcept;
 

--- a/src/lib/tvgLoader.h
+++ b/src/lib/tvgLoader.h
@@ -35,9 +35,6 @@ public:
     float vy = 0;
     float vw = 0;
     float vh = 0;
-
-    uint32_t w = 0; //default size
-    uint32_t h = 0; //default size
     bool preserveAspect = true; //keep aspect ratio by default.
 
     virtual ~Loader() {}

--- a/src/lib/tvgLoader.h
+++ b/src/lib/tvgLoader.h
@@ -35,6 +35,7 @@ public:
     float vy = 0;
     float vw = 0;
     float vh = 0;
+    float w = 0, h = 0;         //default image size
     bool preserveAspect = true; //keep aspect ratio by default.
 
     virtual ~Loader() {}

--- a/src/lib/tvgPicture.cpp
+++ b/src/lib/tvgPicture.cpp
@@ -75,14 +75,14 @@ Result Picture::viewbox(float* x, float* y, float* w, float* h) const noexcept
 }
 
 
-Result Picture::size(uint32_t w, uint32_t h) noexcept
+Result Picture::size(float w, float h) noexcept
 {
     if (pImpl->size(w, h)) return Result::Success;
     return Result::InsufficientCondition;
 }
 
 
-Result Picture::size(uint32_t* w, uint32_t* h) const noexcept
+Result Picture::size(float* w, float* h) const noexcept
 {
     if (w) *w = pImpl->w;
     if (h) *h = pImpl->h;

--- a/src/lib/tvgPictureImpl.h
+++ b/src/lib/tvgPictureImpl.h
@@ -37,8 +37,7 @@ struct Picture::Impl
     uint32_t *pixels = nullptr;
     Picture *picture = nullptr;
     void *edata = nullptr;              //engine data
-
-    uint32_t w = 0, h = 0;
+    float w = 0, h = 0;
     bool resizing = false;
 
     Impl(Picture* p) : picture(p)
@@ -61,8 +60,8 @@ struct Picture::Impl
 
     void resize()
     {
-        auto sx = float(w) / loader->vw;
-        auto sy = float(h) / loader->vh;
+        auto sx = w / loader->vw;
+        auto sy = h / loader->vh;
 
         if (loader->preserveAspect) {
             //Scale
@@ -73,8 +72,8 @@ struct Picture::Impl
             auto vy = loader->vy * scale;
             auto vw = loader->vw * scale;
             auto vh = loader->vh * scale;
-            if (vw > vh) vy -= (float(h) - vh) * 0.5f;
-            else vx -= (float(w) - vw) * 0.5f;
+            if (vw > vh) vy -= (h - vh) * 0.5f;
+            else vx -= (w - vw) * 0.5f;
             paint->translate(-vx, -vy);
         } else {
             //Align
@@ -82,8 +81,8 @@ struct Picture::Impl
             auto vy = loader->vy * sy;
             auto vw = loader->vw * sx;
             auto vh = loader->vh * sy;
-            if (vw > vh) vy -= (float(h) - vh) * 0.5f;
-            else vx -= (float(w) - vw) * 0.5f;
+            if (vw > vh) vy -= (h - vh) * 0.5f;
+            else vx -= (w - vw) * 0.5f;
 
             Matrix m = {sx, 0, -vx, 0, sy, -vy, 0, 0, 1};
             paint->transform(m);
@@ -99,7 +98,7 @@ struct Picture::Impl
                 if (scene) {
                     paint = scene.release();
                     loader->close();
-                    if (w != loader->w && h != loader->w) resize();
+                    if (w != loader->vw && h != loader->vw) resize();
                     if (paint) return RenderUpdateFlag::None;
                 }
             }
@@ -160,8 +159,8 @@ struct Picture::Impl
         loader = LoaderMgr::loader(path);
         if (!loader) return Result::NonSupport;
         if (!loader->read()) return Result::Unknown;
-        w = loader->w;
-        h = loader->h;
+        w = loader->vw;
+        h = loader->vh;
         return Result::Success;
     }
 
@@ -171,8 +170,8 @@ struct Picture::Impl
         loader = LoaderMgr::loader(data, size);
         if (!loader) return Result::NonSupport;
         if (!loader->read()) return Result::Unknown;
-        w = loader->w;
-        h = loader->h;
+        w = loader->vw;
+        h = loader->vh;
         return Result::Success;
     }
 

--- a/src/lib/tvgPictureImpl.h
+++ b/src/lib/tvgPictureImpl.h
@@ -99,14 +99,7 @@ struct Picture::Impl
                 if (scene) {
                     paint = scene.release();
                     loader->close();
-
-                    if (w == 0 && h == 0) {
-                        w = loader->w;
-                        h = loader->h;
-                    } else {
-                        resize();
-                    }
-
+                    if (w != loader->w && h != loader->w) resize();
                     if (paint) return RenderUpdateFlag::None;
                 }
             }
@@ -167,6 +160,8 @@ struct Picture::Impl
         loader = LoaderMgr::loader(path);
         if (!loader) return Result::NonSupport;
         if (!loader->read()) return Result::Unknown;
+        w = loader->w;
+        h = loader->h;
         return Result::Success;
     }
 
@@ -176,6 +171,8 @@ struct Picture::Impl
         loader = LoaderMgr::loader(data, size);
         if (!loader) return Result::NonSupport;
         if (!loader->read()) return Result::Unknown;
+        w = loader->w;
+        h = loader->h;
         return Result::Success;
     }
 

--- a/src/lib/tvgPictureImpl.h
+++ b/src/lib/tvgPictureImpl.h
@@ -98,7 +98,7 @@ struct Picture::Impl
                 if (scene) {
                     paint = scene.release();
                     loader->close();
-                    if (w != loader->vw && h != loader->vw) resize();
+                    if (w != loader->w && h != loader->h) resize();
                     if (paint) return RenderUpdateFlag::None;
                 }
             }
@@ -159,8 +159,8 @@ struct Picture::Impl
         loader = LoaderMgr::loader(path);
         if (!loader) return Result::NonSupport;
         if (!loader->read()) return Result::Unknown;
-        w = loader->vw;
-        h = loader->vh;
+        w = loader->w;
+        h = loader->h;
         return Result::Success;
     }
 
@@ -170,8 +170,8 @@ struct Picture::Impl
         loader = LoaderMgr::loader(data, size);
         if (!loader) return Result::NonSupport;
         if (!loader->read()) return Result::Unknown;
-        w = loader->vw;
-        h = loader->vh;
+        w = loader->w;
+        h = loader->h;
         return Result::Success;
     }
 

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -2468,8 +2468,13 @@ bool SvgLoader::header()
         //Return the brief resource info such as viewbox:
         vx = loaderData.doc->node.doc.vx;
         vy = loaderData.doc->node.doc.vy;
-        vw = loaderData.doc->node.doc.vw;
-        vh = loaderData.doc->node.doc.vh;
+        w = vw = loaderData.doc->node.doc.vw;
+        h = vh = loaderData.doc->node.doc.vh;
+
+        //Override size
+        if (loaderData.doc->node.doc.w > 0) w = loaderData.doc->node.doc.w;
+        if (loaderData.doc->node.doc.h > 0) h = loaderData.doc->node.doc.h;
+
         preserveAspect = loaderData.doc->node.doc.preserveAspect;
     } else {
         //LOG: No SVG File. There is no <svg/>

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -2471,8 +2471,11 @@ bool SvgLoader::header()
         vw = loaderData.doc->node.doc.vw;
         vh = loaderData.doc->node.doc.vh;
 
-        w = loaderData.doc->node.doc.w;
-        h = loaderData.doc->node.doc.h;
+        //Use viewbox size as image size
+        w = static_cast<uint32_t>(loaderData.doc->node.doc.vw);
+        h = static_cast<uint32_t>(loaderData.doc->node.doc.vh);
+        //w = loaderData.doc->node.doc.w;
+        //h = loaderData.doc->node.doc.h;
 
         preserveAspect = loaderData.doc->node.doc.preserveAspect;
     } else {

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -2470,13 +2470,6 @@ bool SvgLoader::header()
         vy = loaderData.doc->node.doc.vy;
         vw = loaderData.doc->node.doc.vw;
         vh = loaderData.doc->node.doc.vh;
-
-        //Use viewbox size as image size
-        w = static_cast<uint32_t>(loaderData.doc->node.doc.vw);
-        h = static_cast<uint32_t>(loaderData.doc->node.doc.vh);
-        //w = loaderData.doc->node.doc.w;
-        //h = loaderData.doc->node.doc.h;
-
         preserveAspect = loaderData.doc->node.doc.preserveAspect;
     } else {
         //LOG: No SVG File. There is no <svg/>


### PR DESCRIPTION
In perspective of Picture, Size of Picture should be view size
of the svg. Not content size.

Even viewbox is mandatory used but not content size.
Thus we can't use it.

- Description :

- Issue Tickets (if any) :

- Tests or Samples (if any) :

- Screen Shots (if any) :
