### PR TITLE
common sw_engine: code refactoring & stabilizing.

### DIFF
--- a/src/lib/gl_engine/tvgGlRenderer.cpp
+++ b/src/lib/gl_engine/tvgGlRenderer.cpp
@@ -162,14 +162,14 @@ bool GlRenderer::dispose(void *data)
 }
 
 
-void* GlRenderer::prepare(TVG_UNUSED const Picture& picture, TVG_UNUSED void* data, TVG_UNUSED uint32_t *buffer, TVG_UNUSED const RenderTransform* transform, TVG_UNUSED uint32_t opacity, TVG_UNUSED vector<Composite>& compList, TVG_UNUSED RenderUpdateFlag flags)
+void* GlRenderer::prepare(TVG_UNUSED const Picture& picture, TVG_UNUSED void* data, TVG_UNUSED uint32_t *buffer, TVG_UNUSED const RenderTransform* transform, TVG_UNUSED uint32_t opacity, TVG_UNUSED Array<Composite>& compList, TVG_UNUSED RenderUpdateFlag flags)
 {
     //TODO:
     return nullptr;
 }
 
 
-void* GlRenderer::prepare(const Shape& shape, void* data, TVG_UNUSED const RenderTransform* transform, TVG_UNUSED uint32_t opacity, vector<Composite>& compList, RenderUpdateFlag flags)
+void* GlRenderer::prepare(const Shape& shape, void* data, TVG_UNUSED const RenderTransform* transform, TVG_UNUSED uint32_t opacity, Array<Composite>& compList, RenderUpdateFlag flags)
 {
     //prepare shape data
     GlShape* sdata = static_cast<GlShape*>(data);

--- a/src/lib/gl_engine/tvgGlRenderer.h
+++ b/src/lib/gl_engine/tvgGlRenderer.h
@@ -30,8 +30,8 @@ class GlRenderer : public RenderMethod
 public:
     Surface surface = {nullptr, 0, 0, 0};
 
-    void* prepare(const Shape& shape, void* data, const RenderTransform* transform, uint32_t opacity, vector<Composite>& compList, RenderUpdateFlag flags) override;
-    void* prepare(const Picture& picture, void* data, uint32_t *buffer, const RenderTransform* transform, uint32_t opacity, vector<Composite>& compList, RenderUpdateFlag flags) override;
+    void* prepare(const Shape& shape, void* data, const RenderTransform* transform, uint32_t opacity, Array<Composite>& compList, RenderUpdateFlag flags) override;
+    void* prepare(const Picture& picture, void* data, uint32_t *buffer, const RenderTransform* transform, uint32_t opacity, Array<Composite>& compList, RenderUpdateFlag flags) override;
     bool dispose(void *data) override;
     void* beginComposite(uint32_t x, uint32_t y, uint32_t w, uint32_t h) override;
     bool endComposite(void* ctx, uint32_t opacity) override;

--- a/src/lib/sw_engine/tvgSwRenderer.h
+++ b/src/lib/sw_engine/tvgSwRenderer.h
@@ -22,7 +22,6 @@
 #ifndef _TVG_SW_RENDERER_H_
 #define _TVG_SW_RENDERER_H_
 
-#include <vector>
 #include "tvgRender.h"
 
 struct SwSurface;
@@ -36,8 +35,8 @@ namespace tvg
 class SwRenderer : public RenderMethod
 {
 public:
-    void* prepare(const Shape& shape, void* data, const RenderTransform* transform, uint32_t opacity, vector<Composite>& compList, RenderUpdateFlag flags) override;
-    void* prepare(const Picture& picture, void* data, uint32_t *buffer, const RenderTransform* transform, uint32_t opacity, vector<Composite>& compList, RenderUpdateFlag flags) override;
+    void* prepare(const Shape& shape, void* data, const RenderTransform* transform, uint32_t opacity, Array<Composite>& compList, RenderUpdateFlag flags) override;
+    void* prepare(const Picture& picture, void* data, uint32_t *buffer, const RenderTransform* transform, uint32_t opacity, Array<Composite>& compList, RenderUpdateFlag flags) override;
     void* beginComposite(uint32_t x, uint32_t y, uint32_t w, uint32_t h) override;
     bool endComposite(void* ctx, uint32_t opacity) override;
     bool dispose(void *data) override;
@@ -54,13 +53,13 @@ public:
     static bool term();
 
 private:
-    SwSurface*    surface = nullptr;
-    vector<SwTask*> tasks;
+    SwSurface*     surface = nullptr;
+    Array<SwTask*> tasks;
 
     SwRenderer(){};
     ~SwRenderer();
 
-    void prepareCommon(SwTask* task, const RenderTransform* transform, uint32_t opacity, vector<Composite>& compList, RenderUpdateFlag flags);
+    void prepareCommon(SwTask* task, const RenderTransform* transform, uint32_t opacity, Array<Composite>& compList, RenderUpdateFlag flags);
 };
 
 }

--- a/src/lib/sw_engine/tvgSwRle.cpp
+++ b/src/lib/sw_engine/tvgSwRle.cpp
@@ -621,7 +621,7 @@ SwSpan* _intersectSpansRegion(const SwRleData *clip, const SwRleData *targetRle,
     auto clipSpans = clip->spans;
     auto clipEnd = clip->spans + clip->size;
 
-    while (spanCnt && spans < end ) {
+    while (spanCnt > 0 && spans < end ) {
         if (clipSpans > clipEnd) {
             spans = end;
             break;

--- a/src/lib/tvgArray.h
+++ b/src/lib/tvgArray.h
@@ -36,7 +36,10 @@ struct Array
 
     void push(T element)
     {
-        reserve((count + 1) * 2);
+        if (count + 1 > reserved) {
+            reserved = (count + 1) * 2;
+            data = static_cast<T*>(realloc(data, sizeof(T) * reserved));
+        }
         data[count++] = element;
     }
 

--- a/src/lib/tvgArray.h
+++ b/src/lib/tvgArray.h
@@ -22,6 +22,7 @@
 #ifndef _TVG_ARRAY_H_
 #define _TVG_ARRAY_H_
 
+#include <memory.h>
 
 namespace tvg
 {
@@ -35,11 +36,16 @@ struct Array
 
     void push(T element)
     {
-        if (count + 1 > reserved) {
-            reserved = (count + 1) * 2;
+        reserve((count + 1) * 2);
+        data[count++] = element;
+    }
+
+    void reserve(uint32_t size)
+    {
+        if (size > reserved) {
+            reserved = size;
             data = static_cast<T*>(realloc(data, sizeof(T) * reserved));
         }
-        data[count++] = element;
     }
 
     void pop()
@@ -47,13 +53,25 @@ struct Array
         if (count > 0) --count;
     }
 
-    void clear()
+    void reset()
     {
         if (data) {
             free(data);
             data = nullptr;
         }
         count = reserved = 0;
+    }
+
+    void clear()
+    {
+        count = 0;
+    }
+
+    void operator=(const Array& rhs)
+    {
+        reserve(rhs.count);
+        memcpy(data, rhs.data, sizeof(T) * reserved);
+        count = rhs.count;
     }
 
     ~Array()

--- a/src/lib/tvgCanvasImpl.h
+++ b/src/lib/tvgCanvasImpl.h
@@ -96,7 +96,7 @@ struct Canvas::Impl
 
         if (!renderer->preRender()) return Result::InsufficientCondition;
 
-            for (auto paint = paints.data; paint < (paints.data + paints.count); ++paint) {
+        for (auto paint = paints.data; paint < (paints.data + paints.count); ++paint) {
             if (!(*paint)->pImpl->render(*renderer)) return Result::InsufficientCondition;
         }
 

--- a/src/lib/tvgPaint.h
+++ b/src/lib/tvgPaint.h
@@ -25,7 +25,7 @@
 #include <float.h>
 #include <math.h>
 #include "tvgRender.h"
-#include "tvgArray.h"
+
 
 namespace tvg
 {

--- a/src/lib/tvgPictureImpl.h
+++ b/src/lib/tvgPictureImpl.h
@@ -110,7 +110,7 @@ struct Picture::Impl
         return RenderUpdateFlag::None;
     }
 
-    void* update(RenderMethod &renderer, const RenderTransform* transform, uint32_t opacity, vector<Composite>& compList, RenderUpdateFlag pFlag)
+    void* update(RenderMethod &renderer, const RenderTransform* transform, uint32_t opacity, Array<Composite>& compList, RenderUpdateFlag pFlag)
     {
         uint32_t flag = reload();
 

--- a/src/lib/tvgRender.h
+++ b/src/lib/tvgRender.h
@@ -22,8 +22,8 @@
 #ifndef _TVG_RENDER_H_
 #define _TVG_RENDER_H_
 
-#include <vector>
 #include "tvgCommon.h"
+#include "tvgArray.h"
 
 namespace tvg
 {
@@ -65,8 +65,8 @@ class RenderMethod
 {
 public:
     virtual ~RenderMethod() {}
-    virtual void* prepare(const Shape& shape, void* data, const RenderTransform* transform, uint32_t opacity, vector<Composite>& compList, RenderUpdateFlag flags) = 0;
-    virtual void* prepare(const Picture& picture, void* data, uint32_t *buffer, const RenderTransform* transform, uint32_t opacity, vector<Composite>& compList, RenderUpdateFlag flags) = 0;
+    virtual void* prepare(const Shape& shape, void* data, const RenderTransform* transform, uint32_t opacity, Array<Composite>& compList, RenderUpdateFlag flags) = 0;
+    virtual void* prepare(const Picture& picture, void* data, uint32_t *buffer, const RenderTransform* transform, uint32_t opacity, Array<Composite>& compList, RenderUpdateFlag flags) = 0;
     virtual void* beginComposite(uint32_t x, uint32_t y, uint32_t w, uint32_t h) = 0;
     virtual bool endComposite(void* ctx, uint32_t opacity) = 0;
     virtual bool dispose(void *data) = 0;

--- a/src/lib/tvgScene.cpp
+++ b/src/lib/tvgScene.cpp
@@ -47,7 +47,7 @@ Result Scene::push(unique_ptr<Paint> paint) noexcept
 {
     auto p = paint.release();
     if (!p) return Result::MemoryCorruption;
-    pImpl->paints.push_back(p);
+    pImpl->paints.push(p);
 
     return Result::Success;
 }

--- a/src/lib/tvgShapeImpl.h
+++ b/src/lib/tvgShapeImpl.h
@@ -223,7 +223,7 @@ struct Shape::Impl
         return renderer.render(*shape, edata);
     }
 
-    void* update(RenderMethod& renderer, const RenderTransform* transform, uint32_t opacity, vector<Composite>& compList, RenderUpdateFlag pFlag)
+    void* update(RenderMethod& renderer, const RenderTransform* transform, uint32_t opacity, Array<Composite>& compList, RenderUpdateFlag pFlag)
     {
         this->edata = renderer.prepare(*shape, this->edata, transform, opacity, compList, static_cast<RenderUpdateFlag>(pFlag | flag));
         flag = RenderUpdateFlag::None;

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -2196,6 +2196,7 @@ static void _styleInherit(SvgStyleProperty* child, SvgStyleProperty* parent)
     if (!((int)child->stroke.flags & (int)SvgStrokeFlags::Dash)) {
         if (parent->stroke.dash.array.count > 0) {
             child->stroke.dash.array.clear();
+            child->stroke.dash.array.reserve(parent->stroke.dash.array.count);
             for (uint32_t i = 0; i < parent->stroke.dash.array.count; ++i) {
                 child->stroke.dash.array.push(parent->stroke.dash.array.data[i]);
             }
@@ -2297,7 +2298,7 @@ static void _freeGradientStyle(SvgStyleGradient* grad)
         auto colorStop = grad->stops.data[i];
         free(colorStop);
     }
-    grad->stops.clear();
+    grad->stops.reset();
     free(grad);
 }
 
@@ -2308,7 +2309,7 @@ static void _freeNodeStyle(SvgStyleProperty* style)
     _freeGradientStyle(style->fill.paint.gradient);
     delete style->fill.paint.url;
     _freeGradientStyle(style->stroke.paint.gradient);
-    if (style->stroke.dash.array.count > 0) style->stroke.dash.array.clear();
+    if (style->stroke.dash.array.count > 0) style->stroke.dash.array.reset();
     delete style->stroke.paint.url;
     free(style);
 }
@@ -2321,7 +2322,7 @@ static void _freeNode(SvgNode* node)
     for (uint32_t i = 0; i < node->child.count; ++i, ++child) {
         _freeNode(*child);
     }
-    node->child.clear();
+    node->child.reset();
 
     delete node->id;
     free(node->transform);
@@ -2349,7 +2350,7 @@ static void _freeNode(SvgNode* node)
                  _freeGradientStyle(*gradients);
                  ++gradients;
              }
-             node->node.defs.gradients.clear();
+             node->node.defs.gradients.reset();
              break;
          }
          default: {
@@ -2540,11 +2541,11 @@ bool SvgLoader::close()
         _freeGradientStyle(*gradients);
         ++gradients;
     }
-    loaderData.gradients.clear();
+    loaderData.gradients.reset();
 
     _freeNode(loaderData.doc);
     loaderData.doc = nullptr;
-    loaderData.stack.clear();
+    loaderData.stack.reset();
 
     return true;
 }


### PR DESCRIPTION
Apply tvg Array instead of std::vector

Fix Composition Target memory leak

binary comparison:

[libthorvg.so] 1785376 >> 1607416
[text] 121255 >> 118277
[data] 7792 >> 7736
[dec] 129119 >> 126085

- Description :

- Issue Tickets (if any) :

- Tests or Samples (if any) :

- Screen Shots (if any) :
