### PR TITLE
sw_engine raster: Fixed crash in raster API

### DIFF
--- a/src/lib/tvgCanvasImpl.h
+++ b/src/lib/tvgCanvasImpl.h
@@ -108,7 +108,7 @@ struct Canvas::Impl
     Result invalidate()
     {
         for (auto paint = paints.data; paint < (paints.data + paints.count); ++paint) {
-            (*paint)->pImpl->flag = RenderUpdateFlag::All;
+            (*paint)->pImpl->flag = RenderUpdateFlag::All ^ RenderUpdateFlag::Transform;
         }
 
         return Result::Success;

--- a/src/lib/tvgCanvasImpl.h
+++ b/src/lib/tvgCanvasImpl.h
@@ -104,6 +104,15 @@ struct Canvas::Impl
 
         return Result::Success;
     }
+
+    Result invalidate()
+    {
+        for (auto paint = paints.data; paint < (paints.data + paints.count); ++paint) {
+            (*paint)->pImpl->flag = RenderUpdateFlag::All;
+        }
+
+        return Result::Success;
+    }
 };
 
 #endif /* _TVG_CANVAS_IMPL_H_ */

--- a/src/lib/tvgRender.h
+++ b/src/lib/tvgRender.h
@@ -44,7 +44,7 @@ struct Compositor {
     uint32_t        opacity;
 };
 
-enum RenderUpdateFlag {None = 0, Path = 1, Color = 2, Gradient = 4, Stroke = 8, Transform = 16, Image = 32, All = 64};
+enum RenderUpdateFlag {None = 0, Path = 1, Color = 2, Gradient = 4, Stroke = 8, Transform = 16, Image = 32, All = 63};
 
 struct RenderTransform
 {

--- a/src/lib/tvgSwCanvas.cpp
+++ b/src/lib/tvgSwCanvas.cpp
@@ -66,6 +66,7 @@ Result SwCanvas::target(uint32_t* buffer, uint32_t stride, uint32_t w, uint32_t 
     if (!renderer) return Result::MemoryCorruption;
 
     if (!renderer->target(buffer, stride, w, h, cs)) return Result::InvalidArguments;
+    Canvas::pImpl->invalidate();
 
     return Result::Success;
 #endif


### PR DESCRIPTION
Crash occurs when surface is smaller than span. There is no need to render RLE outside of surface.

@Issues: 
#180 