### PR TITLE
sw_engine renderer: optimize composition data usage.

### DIFF
--- a/src/lib/sw_engine/tvgSwRenderer.h
+++ b/src/lib/sw_engine/tvgSwRenderer.h
@@ -28,6 +28,7 @@ struct SwSurface;
 struct SwTask;
 struct SwShapeTask;
 struct SwImage;
+struct SwComposite;
 
 namespace tvg
 {
@@ -53,8 +54,9 @@ public:
     static bool term();
 
 private:
-    SwSurface*     surface = nullptr;
-    Array<SwTask*> tasks;
+    SwSurface*          surface = nullptr;
+    Array<SwTask*>      tasks;
+    Array<SwComposite*> composites;
 
     SwRenderer(){};
     ~SwRenderer();


### PR DESCRIPTION
Use cache mechanism for composition data so that we don't reallocate
composition memory several times in one frame rendering.

@Issues: 168

- Description :

- Issue Tickets (if any) :

- Tests or Samples (if any) :

- Screen Shots (if any) :
