### PR TITLE
svg_loader XmlParser: Print unsupported elements, attribute with log option

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -28,6 +28,10 @@ if get_option('bindings').contains('capi') == true
     config_h.set10('THORVG_CAPI_BINDING_SUPPORT', true)
 endif
 
+if get_option('log') == true
+    config_h.set10('THORVG_LOG_ENABLED', true)
+endif
+
 configure_file(
     output: 'config.h',
     configuration: config_h

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -37,3 +37,8 @@ option('test',
    type: 'boolean',
    value: false,
    description: 'Enable building unit tests')
+
+option('log',
+    type: 'boolean',
+    value: false,
+    description: 'Enable log message')

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -745,7 +745,13 @@ static bool _attrParseSvgNode(void* data, const char* key, const char* value)
         if (!strcmp(value, "none")) doc->preserveAspect = false;
     } else if (!strcmp(key, "style")) {
         return simpleXmlParseW3CAttribute(value, _parseStyleAttr, loader);
-    } else {
+    } 
+#ifdef THORVG_LOG_ENABLED
+    else if (!strcmp(key, "xmlns") || !strcmp(key, "xmlns:xlink") || strcmp (key, "xmlns:svg")) {
+        //No action
+    }
+#endif
+    else {
         return _parseStyleAttr(loader, key, value);
     }
     return true;
@@ -1043,6 +1049,9 @@ static SvgNode* _createMaskNode(SvgLoaderData* loader, SvgNode* parent, const ch
     loader->svgParse->node = _createNode(parent, SvgNodeType::Unknown);
 
     loader->svgParse->node->display = false;
+#ifdef THORVG_LOG_ENABLED
+    printf("[SVG] Unsuppoted elements used [Elements: mask]\n");
+#endif
 
     return loader->svgParse->node;
 }
@@ -2120,6 +2129,11 @@ static void _svgLoaderParserXmlOpen(SvgLoaderData* loader, const char* content, 
             loader->latestGradient->stops.push(stop);
         }
     }
+#ifdef THORVG_LOG_ENABLED
+    else {
+        printf("[SVG] Unsuppoted elements used [Elements: %s]\n", tagName);
+    }
+#endif
 }
 
 

--- a/src/loaders/svg/tvgXmlParser.cpp
+++ b/src/loaders/svg/tvgXmlParser.cpp
@@ -28,7 +28,40 @@
     #include <alloca.h>
 #endif
 
+#ifdef THORVG_LOG_ENABLED
+    #include <stdio.h>
+#endif
+
 #include "tvgXmlParser.h"
+
+#ifdef THORVG_LOG_ENABLED
+static string nodeTypeToString(SvgNodeType type)
+{
+    switch (type) {
+        case SvgNodeType::Doc: return "Doc";
+        case SvgNodeType::G: return "G";
+        case SvgNodeType::Defs: return "Defs";
+        case SvgNodeType::Animation: return "Animation";
+        case SvgNodeType::Arc: return "Arc";
+        case SvgNodeType::Circle: return "Circle";
+        case SvgNodeType::Ellipse: return "Ellipse";
+        case SvgNodeType::Image: return "Image";
+        case SvgNodeType::Line: return "Line";
+        case SvgNodeType::Path: return "Path";
+        case SvgNodeType::Polygon: return "Polygon";
+        case SvgNodeType::Polyline: return "Polyline";
+        case SvgNodeType::Rect: return "Rect";
+        case SvgNodeType::Text: return "Text";
+        case SvgNodeType::TextArea: return "TextArea";
+        case SvgNodeType::Tspan: return "Tspan";
+        case SvgNodeType::Use: return "Use";
+        case SvgNodeType::Video: return "Video";
+        case SvgNodeType::ClipPath: return "ClipPath";
+        default: return "Unknown";
+    }
+    return "Unknown";
+}
+#endif
 
 static const char* _simpleXmlFindWhiteSpace(const char* itr, const char* itrEnd)
 {
@@ -152,7 +185,11 @@ bool simpleXmlParseAttributes(const char* buf, unsigned bufLength, simpleXMLAttr
         memcpy(tval, value, valueEnd - value);
         tval[valueEnd - value] = '\0';
 
+#ifdef THORVG_LOG_ENABLED
+        if (!func((void*)data, tmpBuf, tval)) printf("[SVG] Unsuppoted attributes used [Elements type: %s][Attribute: %s]\n", nodeTypeToString(((SvgLoaderData*)data)->svgParse->node->type).c_str(), tmpBuf);
+#else
         func((void*)data, tmpBuf, tval);
+#endif
 
         itr = valueEnd + 1;
     }


### PR DESCRIPTION
- Description :
* Using printf is temporary. We are planning a proper way to print the log.
When parsing a Svg file, Loader print unsupported elements and attributes.

- Issue Tickets (if any) :
https://github.com/Samsung/thorvg/issues/152

- Tests or Samples (if any) :
[Enable log]
meson_option -> add 'debug' value in 'log' option

- Screen Shots (if any) :
