### PR TITLE
wasm: work with log option

### DIFF
--- a/src/lib/sw_engine/tvgSwImage.cpp
+++ b/src/lib/sw_engine/tvgSwImage.cpp
@@ -19,7 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-#include <math.h>
+#include <algorithm>
 #include "tvgSwCommon.h"
 
 /************************************************************************/

--- a/src/loaders/svg/tvgXmlParser.cpp
+++ b/src/loaders/svg/tvgXmlParser.cpp
@@ -21,7 +21,7 @@
  */
 
 #include <ctype.h>
-#include <cstring>
+#include <string>
 #ifdef _WIN32
     #include <malloc.h>
 #else

--- a/src/wasm/thorvgwasm.cpp
+++ b/src/wasm/thorvgwasm.cpp
@@ -55,6 +55,11 @@ public:
             return false;
         }
 
+        /* need to reset size to calculate scale in Picture.size internally
+           before calling updateSize */
+        mWidth = 0;
+        mHeight = 0;
+
         updateSize(width, height);
 
         if (mSwCanvas->push(unique_ptr<Picture>(mPicture)) != Result::Success) {

--- a/wasm_build.sh
+++ b/wasm_build.sh
@@ -8,7 +8,7 @@ fi
 
 if [ ! -d "./builddir_wasm" ]; then
     sed "s|EMSDK:|$1|g" wasm_cross.txt > /tmp/.wasm_cross.txt
-    meson -Dbindings=[''] -Db_lto=true -Ddefault_library=static --cross-file /tmp/.wasm_cross.txt builddir_wasm 
+    meson -Dbindings=[''] -Db_lto=true -Ddefault_library=static -Dlog=true --cross-file /tmp/.wasm_cross.txt builddir_wasm
     cp ./test/wasm_test.html builddir_wasm/src/index.html
 fi
 


### PR DESCRIPTION
The wasm is using the ThorVG output starting whith "SVG:" to show
unsupported element and attribute of svg file.
This patch updates wasm_build.sh to make ThorVG prints log,
and removes build errors.

  - Following commit needs to include 'algorithm'
    1ed6113 common sw_engine: code refactoring & stabilizing.

  - Following commit needs to include 'string'
    5481633 svg_loader XmlParser: Print unsupported elements, ...

- Description :

- Issue Tickets (if any) :

- Tests or Samples (if any) :

- Screen Shots (if any) :
