### PR TITLE
svg_loader SvgLoader: Print inefficient elements

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -2225,9 +2225,49 @@ static void _styleInherit(SvgStyleProperty* child, SvgStyleProperty* parent)
 }
 
 
+#ifdef THORVG_LOG_ENABLED
+static void _inefficientNodeCheck(SvgNode* node){
+    if (!node->display) printf("SVG: Inefficient elements used [Display is none][Node Type : %s]\n", _nodeTypeToString(node->type).c_str());
+    if (node->style->opacity == 0) printf("SVG: Inefficient elements used [Opacity is zero][Node Type : %s]\n", _nodeTypeToString(node->type).c_str());
+    if (node->style->fill.opacity == 0 && node->style->stroke.opacity == 0) printf("SVG: Inefficient elements used [Fill opacity and stroke opacity are zero][Node Type : %s]\n", _nodeTypeToString(node->type).c_str());
+
+    switch (node->type) {
+        case SvgNodeType::Path: {
+            if (!node->node.path.path || node->node.path.path->empty()) printf("SVG: Inefficient elements used [Empty path][Node Type : %s]\n", _nodeTypeToString(node->type).c_str());
+            break;
+        }
+        case SvgNodeType::Ellipse: {
+            if (node->node.ellipse.rx == 0 && node->node.ellipse.ry == 0) printf("SVG: Inefficient elements used [Size is zero][Node Type : %s]\n", _nodeTypeToString(node->type).c_str());
+            break;
+        }
+        case SvgNodeType::Polygon:
+        case SvgNodeType::Polyline: {
+            if (node->node.polygon.pointsCount < 2) printf("SVG: Inefficient elements used [Invalid Polygon][Node Type : %s]\n", _nodeTypeToString(node->type).c_str());
+            break;
+        }
+        case SvgNodeType::Circle: {
+            if (node->node.circle.r == 0) printf("SVG: Inefficient elements used [Size is zero][Node Type : %s]\n", _nodeTypeToString(node->type).c_str());
+            break;
+        }
+        case SvgNodeType::Rect: {
+            if (node->node.rect.w == 0 && node->node.rect.h) printf("SVG: Inefficient elements used [Size is zero][Node Type : %s]\n", _nodeTypeToString(node->type).c_str());
+            break;
+        }
+        case SvgNodeType::Line: {
+            if (node->node.line.x1 == node->node.line.x2 && node->node.line.y1 == node->node.line.y2) printf("SVG: Inefficient elements used [Size is zero][Node Type : %s]\n", _nodeTypeToString(node->type).c_str());
+            break;
+        }
+        default: break;
+    }
+}
+#endif
+
 static void _updateStyle(SvgNode* node, SvgStyleProperty* parentStyle)
 {
     _styleInherit(node->style, parentStyle);
+#ifdef THORVG_LOG_ENABLED
+    _inefficientNodeCheck(node);
+#endif
 
     auto child = node->child.data;
     for (uint32_t i = 0; i < node->child.count; ++i, ++child) {

--- a/src/loaders/svg/tvgSvgLoaderCommon.h
+++ b/src/loaders/svg/tvgSvgLoaderCommon.h
@@ -347,4 +347,8 @@ struct SvgLoaderData
     bool result = false;
 };
 
+#ifdef THORVG_LOG_ENABLED
+string _nodeTypeToString(SvgNodeType type);
+#endif
+
 #endif

--- a/src/loaders/svg/tvgXmlParser.cpp
+++ b/src/loaders/svg/tvgXmlParser.cpp
@@ -35,7 +35,7 @@
 #include "tvgXmlParser.h"
 
 #ifdef THORVG_LOG_ENABLED
-static string nodeTypeToString(SvgNodeType type)
+string _nodeTypeToString(SvgNodeType type)
 {
     switch (type) {
         case SvgNodeType::Doc: return "Doc";
@@ -186,7 +186,7 @@ bool simpleXmlParseAttributes(const char* buf, unsigned bufLength, simpleXMLAttr
         tval[valueEnd - value] = '\0';
 
 #ifdef THORVG_LOG_ENABLED
-        if (!func((void*)data, tmpBuf, tval)) printf("SVG: Unsupported attributes used [Elements type: %s][Attribute: %s]\n", nodeTypeToString(((SvgLoaderData*)data)->svgParse->node->type).c_str(), tmpBuf);
+        if (!func((void*)data, tmpBuf, tval)) printf("SVG: Unsupported attributes used [Elements type: %s][Attribute: %s]\n", _nodeTypeToString(((SvgLoaderData*)data)->svgParse->node->type).c_str(), tmpBuf);
 #else
         func((void*)data, tmpBuf, tval);
 #endif


### PR DESCRIPTION
- Description :
Opacity is 0
both Fill.Opacity and Stroke Opacity are 0
point is 0 in Path
declared display="none"
width or height of bounds becomes 0

- Issue Tickets (if any) :
https://github.com/Samsung/thorvg/issues/153
