### PR TITLE
sw_engine shape: expand the algorithm to draw arcs with negative angles

### DIFF
--- a/src/lib/tvgShape.cpp
+++ b/src/lib/tvgShape.cpp
@@ -153,14 +153,15 @@ Result Shape::appendArc(float cx, float cy, float radius, float startAngle, floa
     const float M_PI_HALF = M_PI * 0.5f;
 
     //just circle
-    if (sweep >= 360) return appendCircle(cx, cy, radius, radius);
+    if (sweep >= 360 || sweep <= -360) return appendCircle(cx, cy, radius, radius);
 
     startAngle = (startAngle * M_PI) / 180;
     sweep = sweep * M_PI / 180;
 
     auto nCurves = ceil(abs(sweep / M_PI_HALF));
+    auto sweepSign = (sweep < 0 ? -1 : 1);
     auto fract = fmod(sweep, M_PI_HALF);
-    fract = (fract < std::numeric_limits<float>::epsilon()) ? M_PI_HALF : fract;
+    fract = (abs(fract) < std::numeric_limits<float>::epsilon()) ? M_PI_HALF : fract;
 
     //Start from here
     Point start = {radius * cos(startAngle), radius * sin(startAngle)};
@@ -173,8 +174,7 @@ Result Shape::appendArc(float cx, float cy, float radius, float startAngle, floa
     }
 
     for (int i = 0; i < nCurves; ++i) {
-
-        auto endAngle = startAngle + ((i != nCurves - 1) ? M_PI_HALF : fract);
+        auto endAngle = startAngle + ((i != nCurves - 1) ? M_PI_HALF * sweepSign : fract);
         Point end = {radius * cos(endAngle), radius * sin(endAngle)};
 
         //variables needed to calculate bezier control points


### PR DESCRIPTION
- Description :
The _appendArc function allows to draw angles only in a clockwise direction.
The introduced improvement allows to change this direction by giving the 'sweep' argument
with a negative value.

- Tests or Samples:
https://github.com/mgrudzinska/thorvg/blob/mgrudzinska/arc_example/src/examples/Arc_fix_example.cpp


- Screen Shots:
results from the above example

current version of tvg:
![arc_bad](https://user-images.githubusercontent.com/67589014/102888410-087b2b80-4459-11eb-9d1c-e7637fec98f0.PNG)

with this commit:
![arc_ok](https://user-images.githubusercontent.com/67589014/102888418-0ca74900-4459-11eb-8bb8-4769ecf14c76.PNG)
