### PR TITLE
common sw_engine: code refactoring

### DIFF
--- a/src/lib/gl_engine/tvgGlRenderer.cpp
+++ b/src/lib/gl_engine/tvgGlRenderer.cpp
@@ -102,27 +102,27 @@ bool GlRenderer::postRender()
 }
 
 
-void* GlRenderer::addCompositor(TVG_UNUSED CompositeMethod method, TVG_UNUSED uint32_t x, TVG_UNUSED uint32_t y, TVG_UNUSED uint32_t w, TVG_UNUSED uint32_t h, TVG_UNUSED uint32_t opacity)
+Compositor* GlRenderer::addCompositor(TVG_UNUSED uint32_t x, TVG_UNUSED uint32_t y, TVG_UNUSED uint32_t w, TVG_UNUSED uint32_t h)
 {
     //TODO: Prepare frameBuffer & Setup render target for composition
     return nullptr;
 }
 
 
-bool GlRenderer::delCompositor(TVG_UNUSED void* cmp)
+bool GlRenderer::delCompositor(TVG_UNUSED Compositor* cmp)
 {
     //TODO: delete the given compositor and restore the context
     return false;
 }
 
 
-bool GlRenderer::renderImage(TVG_UNUSED void* data, TVG_UNUSED void* cmp)
+bool GlRenderer::renderImage(TVG_UNUSED void* data, TVG_UNUSED Compositor* cmp)
 {
     return false;
 }
 
 
-bool GlRenderer::renderShape(RenderData data, TVG_UNUSED void* cmp)
+bool GlRenderer::renderShape(RenderData data, TVG_UNUSED Compositor* cmp)
 {
     auto sdata = static_cast<GlShape*>(data);
     if (!sdata) return false;

--- a/src/lib/gl_engine/tvgGlRenderer.h
+++ b/src/lib/gl_engine/tvgGlRenderer.h
@@ -33,11 +33,11 @@ public:
     RenderData prepare(const Shape& shape, RenderData data, const RenderTransform* transform, uint32_t opacity, Array<RenderData>& clips, RenderUpdateFlag flags) override;
     RenderData prepare(const Picture& picture, RenderData data, const RenderTransform* transform, uint32_t opacity, Array<RenderData>& clips, RenderUpdateFlag flags) override;
     bool dispose(RenderData data) override;
-    void* addCompositor(CompositeMethod method, uint32_t x, uint32_t y, uint32_t w, uint32_t h, uint32_t opacity) override;
-    bool delCompositor(void* cmp) override;
+    Compositor* addCompositor(uint32_t x, uint32_t y, uint32_t w, uint32_t h) override;
+    bool delCompositor(Compositor* cmp) override;
     bool preRender() override;
-    bool renderShape(RenderData data, void* cmp) override;
-    bool renderImage(RenderData data, void* cmp) override;
+    bool renderShape(RenderData data, Compositor* cmp) override;
+    bool renderImage(RenderData data, Compositor* cmp) override;
     bool postRender() override;
     bool renderRegion(RenderData data, uint32_t* x, uint32_t* y, uint32_t* w, uint32_t* h) override;
     bool target(uint32_t* buffer, uint32_t stride, uint32_t w, uint32_t h);

--- a/src/lib/sw_engine/tvgSwCommon.h
+++ b/src/lib/sw_engine/tvgSwCommon.h
@@ -220,7 +220,7 @@ struct SwImage
     uint32_t     w, h;
 };
 
-struct SwCompositor
+struct SwBlender
 {
     uint32_t (*join)(uint8_t r, uint8_t g, uint8_t b, uint8_t a);
     uint32_t (*alpha)(uint32_t rgba);
@@ -228,7 +228,7 @@ struct SwCompositor
 
 struct SwSurface : Surface
 {
-    SwCompositor comp;
+    SwBlender blender;
 };
 
 static inline SwCoord TO_SWCOORD(float val)

--- a/src/lib/sw_engine/tvgSwFill.cpp
+++ b/src/lib/sw_engine/tvgSwFill.cpp
@@ -52,7 +52,7 @@ static bool _updateColorTable(SwFill* fill, const Fill* fdata, SwSurface* surfac
     auto g = ALPHA_MULTIPLY(pColors->g, pColors->a);
     auto b = ALPHA_MULTIPLY(pColors->b, pColors->a);
 
-    auto rgba = surface->comp.join(r, g, b, pColors->a);
+    auto rgba = surface->blender.join(r, g, b, pColors->a);
     auto inc = 1.0f / static_cast<float>(GRADIENT_STOP_SIZE);
     auto pos = 1.5f * inc;
     uint32_t i = 0;
@@ -75,7 +75,7 @@ static bool _updateColorTable(SwFill* fill, const Fill* fdata, SwSurface* surfac
         auto g = ALPHA_MULTIPLY(next->g, next->a);
         auto b = ALPHA_MULTIPLY(next->b, next->a);
 
-        auto rgba2 = surface->comp.join(r, g, b, next->a);
+        auto rgba2 = surface->blender.join(r, g, b, next->a);
 
         while (pos < next->offset && i < GRADIENT_STOP_SIZE) {
             auto t = (pos - curr->offset) * delta;

--- a/src/lib/sw_engine/tvgSwRenderer.h
+++ b/src/lib/sw_engine/tvgSwRenderer.h
@@ -26,7 +26,7 @@
 
 struct SwSurface;
 struct SwTask;
-struct SwComposite;
+struct SwCompositor;
 
 namespace tvg
 {
@@ -36,15 +36,15 @@ class SwRenderer : public RenderMethod
 public:
     RenderData prepare(const Shape& shape, RenderData data, const RenderTransform* transform, uint32_t opacity, Array<RenderData>& clips, RenderUpdateFlag flags) override;
     RenderData prepare(const Picture& picture, RenderData data, const RenderTransform* transform, uint32_t opacity, Array<RenderData>& clips, RenderUpdateFlag flags) override;
-    void* addCompositor(CompositeMethod method, uint32_t x, uint32_t y, uint32_t w, uint32_t h, uint32_t opacity) override;
-    bool delCompositor(void* cmp) override;
+    Compositor* addCompositor(uint32_t x, uint32_t y, uint32_t w, uint32_t h) override;
+    bool delCompositor(Compositor* cmp) override;
     bool dispose(RenderData data) override;
     bool preRender() override;
     bool postRender() override;
     bool renderRegion(RenderData data, uint32_t* x, uint32_t* y, uint32_t* w, uint32_t* h) override;
     bool clear() override;
-    bool renderShape(RenderData data, void* cmp) override;
-    bool renderImage(RenderData data, void* cmp) override;
+    bool renderShape(RenderData data, Compositor* cmp) override;
+    bool renderImage(RenderData data, Compositor* cmp) override;
     bool sync() override;
     bool target(uint32_t* buffer, uint32_t stride, uint32_t w, uint32_t h, uint32_t cs);
 
@@ -53,11 +53,11 @@ public:
     static bool term();
 
 private:
-    SwSurface*          surface = nullptr;           //active surface
-    SwComposite*        compositor = nullptr;        //active compositor
-    SwSurface*          mainSurface = nullptr;       //main (default) surface
-    Array<SwTask*>      tasks;                       //async task list
-    Array<SwComposite*> compositors;                 //compositor cache list
+    SwSurface*           surface = nullptr;           //active surface
+    SwCompositor*        compositor = nullptr;        //active compositor
+    SwSurface*           mainSurface = nullptr;       //main (default) surface
+    Array<SwTask*>       tasks;                       //async task list
+    Array<SwCompositor*> compositors;                 //compositor cache list
 
     SwRenderer(){};
     ~SwRenderer();

--- a/src/lib/tvgRender.h
+++ b/src/lib/tvgRender.h
@@ -39,6 +39,11 @@ struct Surface
 
 using RenderData = void*;
 
+struct Compositor {
+    CompositeMethod method;
+    uint32_t        opacity;
+};
+
 enum RenderUpdateFlag {None = 0, Path = 1, Color = 2, Gradient = 4, Stroke = 8, Transform = 16, Image = 32, All = 64};
 
 struct RenderTransform
@@ -57,18 +62,17 @@ struct RenderTransform
     RenderTransform(const RenderTransform* lhs, const RenderTransform* rhs);
 };
 
-class RenderMethod
+struct RenderMethod
 {
-public:
     virtual ~RenderMethod() {}
     virtual RenderData prepare(const Shape& shape, RenderData data, const RenderTransform* transform, uint32_t opacity, Array<RenderData>& clips, RenderUpdateFlag flags) = 0;
     virtual RenderData prepare(const Picture& picture, RenderData data, const RenderTransform* transform, uint32_t opacity, Array<RenderData>& clips, RenderUpdateFlag flags) = 0;
-    virtual void* addCompositor(CompositeMethod method, uint32_t x, uint32_t y, uint32_t w, uint32_t h, uint32_t opacity) = 0;
-    virtual bool delCompositor(void* cmp) = 0;
+    virtual Compositor* addCompositor(uint32_t x, uint32_t y, uint32_t w, uint32_t h) = 0;
+    virtual bool delCompositor(Compositor* cmp) = 0;
     virtual bool dispose(RenderData data) = 0;
     virtual bool preRender() = 0;
-    virtual bool renderShape(RenderData data, void* cmp) = 0;
-    virtual bool renderImage(RenderData data, void* cmp) = 0;
+    virtual bool renderShape(RenderData data, Compositor* cmp) = 0;
+    virtual bool renderImage(RenderData data, Compositor* cmp) = 0;
     virtual bool postRender() = 0;
     virtual bool renderRegion(RenderData data, uint32_t* x, uint32_t* y, uint32_t* w, uint32_t* h) = 0;
     virtual bool clear() = 0;

--- a/src/lib/tvgSceneImpl.h
+++ b/src/lib/tvgSceneImpl.h
@@ -63,14 +63,16 @@ struct Scene::Impl
 
     bool render(RenderMethod& renderer)
     {
-        void* cmp = nullptr;
+        Compositor* cmp = nullptr;
 
         //Half translucent. This condition requires intermediate composition.
         if (opacity < 255 && opacity > 0 && (paints.count > 1)) {
             uint32_t x, y, w, h;
             if (!bounds(renderer, &x, &y, &w, &h)) return false;
             //CompositeMethod::None is used for a default alpha blending
-            cmp = renderer.addCompositor(CompositeMethod::None, x, y, w, h, opacity);
+            cmp = renderer.addCompositor(x, y, w, h);
+            cmp->method = CompositeMethod::None;
+            cmp->opacity = opacity;
         }
 
         for (auto paint = paints.data; paint < (paints.data + paints.count); ++paint) {


### PR DESCRIPTION
Renamed internal interfaces.

We need both blender & compositor interfaces.

Renamed SwCompositor -> SwBlender which is for pixel joining methods.

Added (SwCompositor, Compositor) which is designed for compositing images.

- Description :

- Issue Tickets (if any) :

- Tests or Samples (if any) :

- Screen Shots (if any) :
