### PR TITLE
common paint: code refactoring.

### DIFF
--- a/src/lib/tvgCanvasImpl.h
+++ b/src/lib/tvgCanvasImpl.h
@@ -97,7 +97,7 @@ struct Canvas::Impl
         if (!renderer->preRender()) return Result::InsufficientCondition;
 
         for (auto paint = paints.data; paint < (paints.data + paints.count); ++paint) {
-            if (!(*paint)->pImpl->render(*renderer, 255)) return Result::InsufficientCondition;
+            if (!(*paint)->pImpl->render(*renderer)) return Result::InsufficientCondition;
         }
 
         if (!renderer->postRender()) return Result::InsufficientCondition;

--- a/src/lib/tvgPaint.h
+++ b/src/lib/tvgPaint.h
@@ -35,7 +35,7 @@ namespace tvg
 
         virtual bool dispose(RenderMethod& renderer) = 0;
         virtual void* update(RenderMethod& renderer, const RenderTransform* transform, uint32_t opacity, Array<RenderData>& clips, RenderUpdateFlag pFlag) = 0;   //Return engine data if it has.
-        virtual bool render(RenderMethod& renderer, uint32_t opacity) = 0;
+        virtual bool render(RenderMethod& renderer) = 0;
         virtual bool bounds(float* x, float* y, float* w, float* h) const = 0;
         virtual bool bounds(RenderMethod& renderer, uint32_t* x, uint32_t* y, uint32_t* w, uint32_t* h) const = 0;
         virtual Paint* duplicate() = 0;
@@ -172,7 +172,7 @@ namespace tvg
             return edata;
         }
 
-        bool render(RenderMethod& renderer, uint32_t opacity)
+        bool render(RenderMethod& renderer)
         {
             Compositor* cmp = nullptr;
 
@@ -183,12 +183,12 @@ namespace tvg
                 if (!cmpTarget->pImpl->bounds(renderer, &x, &y, &w, &h)) return false;
                 cmp = renderer.target(x, y, w, h);
                 renderer.beginComposite(cmp, CompositeMethod::None, 255);
-                cmpTarget->pImpl->render(renderer, 255);
+                cmpTarget->pImpl->render(renderer);
             }
 
             if (cmp) renderer.beginComposite(cmp, CompositeMethod::AlphaMask, cmpTarget->pImpl->opacity);
 
-            auto ret = smethod->render(renderer, ((opacity * this->opacity) / 255));
+            auto ret = smethod->render(renderer);
 
             if (cmp) renderer.endComposite(cmp);
 
@@ -252,9 +252,9 @@ namespace tvg
             return inst->update(renderer, transform, opacity, clips, flag);
         }
 
-        bool render(RenderMethod& renderer, uint32_t opacity) override
+        bool render(RenderMethod& renderer) override
         {
-            return inst->render(renderer, opacity);
+            return inst->render(renderer);
         }
 
         Paint* duplicate() override

--- a/src/lib/tvgPictureImpl.h
+++ b/src/lib/tvgPictureImpl.h
@@ -122,10 +122,10 @@ struct Picture::Impl
         return rdata;
     }
 
-    bool render(RenderMethod &renderer, uint32_t opacity)
+    bool render(RenderMethod &renderer)
     {
         if (pixels) return renderer.renderImage(rdata);
-        else if (paint) return paint->pImpl->render(renderer, opacity);
+        else if (paint) return paint->pImpl->render(renderer);
         return false;
     }
 

--- a/src/lib/tvgSceneImpl.h
+++ b/src/lib/tvgSceneImpl.h
@@ -31,6 +31,7 @@
 struct Scene::Impl
 {
     Array<Paint*> paints;
+    uint8_t opacity;            //for composition
 
     bool dispose(RenderMethod& renderer)
     {
@@ -47,6 +48,7 @@ struct Scene::Impl
     {
         /* Overriding opacity value. If this scene is half-translucent,
            It must do intermeidate composition with that opacity value. */
+        this->opacity = static_cast<uint8_t>(opacity);
         if (opacity > 0) opacity = 255;
 
         for (auto paint = paints.data; paint < (paints.data + paints.count); ++paint) {
@@ -58,7 +60,7 @@ struct Scene::Impl
         return nullptr;
     }
 
-    bool render(RenderMethod& renderer, uint32_t opacity)
+    bool render(RenderMethod& renderer)
     {
         Compositor* cmp = nullptr;
 
@@ -71,7 +73,7 @@ struct Scene::Impl
         }
 
         for (auto paint = paints.data; paint < (paints.data + paints.count); ++paint) {
-            if (!(*paint)->pImpl->render(renderer, opacity)) return false;
+            if (!(*paint)->pImpl->render(renderer)) return false;
         }
 
         if (cmp) renderer.endComposite(cmp);

--- a/src/lib/tvgShapeImpl.h
+++ b/src/lib/tvgShapeImpl.h
@@ -218,7 +218,7 @@ struct Shape::Impl
         return renderer.dispose(rdata);
     }
 
-    bool render(RenderMethod& renderer, TVG_UNUSED uint32_t opacity)
+    bool render(RenderMethod& renderer)
     {
         return renderer.renderShape(rdata);
     }


### PR DESCRIPTION
remove the opacity argument in the render method.

Considered again, this opacity value is not commonly used yet.
we can introduce it when it's necessary.

- Description :

- Issue Tickets (if any) :

- Tests or Samples (if any) :

- Screen Shots (if any) :
