### PR TITLE
sw_engine math: fixing matrix transformation

### DIFF
--- a/src/lib/sw_engine/tvgSwMath.cpp
+++ b/src/lib/sw_engine/tvgSwMath.cpp
@@ -422,8 +422,8 @@ SwPoint mathTransform(const Point* to, const Matrix* transform)
 {
     if (!transform) return {TO_SWCOORD(to->x), TO_SWCOORD(to->y)};
 
-    auto tx = round(to->x * transform->e11 + to->y * transform->e12 + transform->e13);
-    auto ty = round(to->x * transform->e21 + to->y * transform->e22 + transform->e23);
+    auto tx = to->x * transform->e11 + to->y * transform->e12 + transform->e13;
+    auto ty = to->x * transform->e21 + to->y * transform->e22 + transform->e23;
 
     return {TO_SWCOORD(tx), TO_SWCOORD(ty)};
 }


### PR DESCRIPTION
- Description :
Unnecessary rounding during matrix transformation has been removed.
The problem occured when scaling a shape with a dashed stroke.

- Issue Tickets (if any) :

- Tests or Samples (if any) :
https://github.com/mgrudzinska/thorvg/tree/mgrudzinska/Scaled_dashed_stroke_example
ScaledShape.cpp

- Screen Shots (if any) :
before changes:
![image](https://user-images.githubusercontent.com/67589014/105272654-1cba6180-5b9a-11eb-9149-da07473a0b1d.png)

after changes:
![image](https://user-images.githubusercontent.com/67589014/105272686-293eba00-5b9a-11eb-8fc4-535f5b9693e1.png)

