### PR TITLE
sw_engine renderer: rendering optimization of shapes without strokes

### DIFF
--- a/src/lib/sw_engine/tvgSwRenderer.cpp
+++ b/src/lib/sw_engine/tvgSwRenderer.cpp
@@ -318,15 +318,16 @@ bool SwRenderer::renderShape(RenderData data)
 
     if (auto fill = task->sdata->fill()) {
         rasterGradientShape(surface, &task->shape, fill->id());
-    } else{
+    } else {
         task->sdata->fillColor(&r, &g, &b, &a);
         a = static_cast<uint8_t>((opacity * (uint32_t) a) / 255);
         if (a > 0) rasterSolidShape(surface, &task->shape, r, g, b, a);
     }
 
-    task->sdata->strokeColor(&r, &g, &b, &a);
-    a = static_cast<uint8_t>((opacity * (uint32_t) a) / 255);
-    if (a > 0) rasterStroke(surface, &task->shape, r, g, b, a);
+    if (task->sdata->strokeColor(&r, &g, &b, &a) == Result::Success) {
+        a = static_cast<uint8_t>((opacity * (uint32_t) a) / 255);
+        if (a > 0) rasterStroke(surface, &task->shape, r, g, b, a);
+    }
 
     if (task->cmpStroking) endComposite(cmp);
 


### PR DESCRIPTION
For solid shapes without strokes, the value of 'a' was incorrectly assigned,
which resulted in unnecessary calls to raster functions.
The variable holding the value 'a' is now reset before being used again.
