### PR TITLE
canvas, capi: expose force update flag.

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -148,6 +148,7 @@ public:
     virtual Result push(std::unique_ptr<Paint> paint) noexcept;
     virtual Result clear(bool free = true) noexcept;
     virtual Result update(Paint* paint) noexcept;
+    virtual Result update(Paint* paint, bool force) noexcept;
     virtual Result draw() noexcept;
     virtual Result sync() noexcept;
 

--- a/inc/thorvg_capi.h
+++ b/inc/thorvg_capi.h
@@ -398,7 +398,7 @@ TVG_EXPORT Tvg_Result tvg_canvas_clear(Tvg_Canvas* canvas, bool free);
 * - TVG_RESULT_SUCCESS: if ok.
 * - TVG_RESULT_INVALID_PARAMETERS: if canvas is invalid]
 */
-TVG_EXPORT Tvg_Result tvg_canvas_update(Tvg_Canvas* canvas);
+TVG_EXPORT Tvg_Result tvg_canvas_update(Tvg_Canvas* canvas, bool force);
 
 
 /*!

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -95,17 +95,17 @@ TVG_EXPORT Tvg_Result tvg_canvas_clear(Tvg_Canvas* canvas, bool free)
 }
 
 
-TVG_EXPORT Tvg_Result tvg_canvas_update(Tvg_Canvas* canvas)
+TVG_EXPORT Tvg_Result tvg_canvas_update(Tvg_Canvas* canvas, bool force)
 {
     if (!canvas) return TVG_RESULT_INVALID_ARGUMENT;
-    return (Tvg_Result) reinterpret_cast<Canvas*>(canvas)->update(nullptr);
+    return (Tvg_Result) reinterpret_cast<Canvas*>(canvas)->update(nullptr, force);
 }
 
 
 TVG_EXPORT Tvg_Result tvg_canvas_update_paint(Tvg_Canvas* canvas, Tvg_Paint* paint)
 {
     if (!canvas || !paint) return TVG_RESULT_INVALID_ARGUMENT;
-    return (Tvg_Result) reinterpret_cast<Canvas*>(canvas)->update((Paint*) paint);
+    return (Tvg_Result) reinterpret_cast<Canvas*>(canvas)->update((Paint*) paint, false);
 }
 
 

--- a/src/examples/Capi.cpp
+++ b/src/examples/Capi.cpp
@@ -113,7 +113,7 @@ void testCapi()
     };
     tvg_gradient_set_color_stops(grad6, color_stops6, 2);
     tvg_shape_set_radial_gradient(shape1, grad6);
-    tvg_canvas_update(canvas);
+    tvg_canvas_update(canvas, false);
 
     tvg_shape_set_stroke_width(shape,3);
     tvg_shape_set_stroke_color(shape, 125, 0, 125, 255);

--- a/src/lib/sw_engine/tvgSwShape.cpp
+++ b/src/lib/sw_engine/tvgSwShape.cpp
@@ -465,6 +465,7 @@ void shapeDelOutline(SwShape* shape, uint32_t tid)
 void shapeReset(SwShape* shape)
 {
     rleReset(shape->rle);
+    rleReset(shape->strokeRle);
     shape->rect = false;
     _initBBox(shape->bbox);
 }

--- a/src/lib/tvgCanvas.cpp
+++ b/src/lib/tvgCanvas.cpp
@@ -67,6 +67,12 @@ Result Canvas::update(Paint* paint) noexcept
 }
 
 
+Result Canvas::update(Paint* paint, bool force) noexcept
+{
+    return pImpl->update(paint, force);
+}
+
+
 Result Canvas::sync() noexcept
 {
     if (pImpl->renderer->sync()) return Result::Success;

--- a/src/lib/tvgRender.h
+++ b/src/lib/tvgRender.h
@@ -44,7 +44,7 @@ struct Compositor {
     uint32_t        opacity;
 };
 
-enum RenderUpdateFlag {None = 0, Path = 1, Color = 2, Gradient = 4, Stroke = 8, Transform = 16, Image = 32, All = 64};
+enum RenderUpdateFlag {None = 0, Path = 1, Color = 2, Gradient = 4, Stroke = 8, Transform = 16, Image = 32, All = 63};
 
 struct RenderTransform
 {


### PR DESCRIPTION
Changes:
1. Force flag is exposed to capi bindings. It is necessary to improve of
stability of thorvg clients. In some cases (after buffer change) it is
necessary to re-render shapes.
2. Fixed issue with stroke rle reset

@API-Changes:
from: tvg_canvas_update(Tvg_Canvas* canvas);
to: tvg_canvas_update(Tvg_Canvas* canvas, bool force);
