### PR TITLE
svg_loader SvgLoader: Prevent memory leak

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -1535,6 +1535,9 @@ static SvgStyleGradient* _cloneGradient(SvgStyleGradient* from)
     return grad;
 error_grad_alloc:
     //LOG: allocation failed. out of memory
+    if (grad->transform) free(grad->transform);
+    if (grad->ref) delete grad->ref;
+    if (grad->id) delete grad->id;
     if (grad) free(grad);
     return nullptr;
 }


### PR DESCRIPTION
- Description :
When OOM of SvgLinear/RadialGradient occurs,
the allocated id, ref, transform may become a memory leak.
Therefore, add free memory.
