### PR TITLE
renderer: Fixed RenderUpdate::All flag fields.

### DIFF
--- a/src/lib/tvgRender.h
+++ b/src/lib/tvgRender.h
@@ -44,7 +44,7 @@ struct Compositor {
     uint32_t        opacity;
 };
 
-enum RenderUpdateFlag {None = 0, Path = 1, Color = 2, Gradient = 4, Stroke = 8, Transform = 16, Image = 32, All = 64};
+enum RenderUpdateFlag {None = 0, Path = 1, Color = 2, Gradient = 4, Stroke = 8, Transform = 16, Image = 32, All = 63};
 
 struct RenderTransform
 {


### PR DESCRIPTION
- Description :
All flag should have all bits set to 1. If flag = 64 rendering task don't update anything, because all checked bits in flag are not set.