### PR TITLE
sw_engine raster: removing unnecessary logical 'and' operation

### DIFF
--- a/src/lib/sw_engine/tvgSwRaster.cpp
+++ b/src/lib/sw_engine/tvgSwRaster.cpp
@@ -30,7 +30,7 @@
 
 static uint32_t _colorAlpha(uint32_t c)
 {
-    return (c >> 24) & 0xff;
+    return (c >> 24);
 }
 
 


### PR DESCRIPTION
Shifting the 32-bit number by 24 bits leaves only 8 bits,
so there is no need to mask them with 0xFF.
