### PR TITLE
sw canvas: Added forceUpdateAll flag in canvas.

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -43,6 +43,7 @@ class RenderMethod;
 class Scene;
 class Picture;
 class Canvas;
+class SwClass;
 
 
 enum class TVG_EXPORT Result { Success = 0, InvalidArguments, InsufficientCondition, FailedAllocation, MemoryCorruption, NonSupport, Unknown };
@@ -152,6 +153,8 @@ public:
     virtual Result sync() noexcept;
 
     _TVG_DECLARE_PRIVATE(Canvas);
+
+    friend class SwCanvas;
 };
 
 

--- a/src/lib/tvgCanvasImpl.h
+++ b/src/lib/tvgCanvasImpl.h
@@ -81,8 +81,6 @@ struct Canvas::Impl
         if (forceUpdateAll) force = true;
         auto flag = force ? RenderUpdateFlag::All : RenderUpdateFlag::None;
 
-        printf("[%s:%d][flag: %d]\n",__FILE__, __LINE__, flag);
-
         //Update single paint node
         if (paint) {
             paint->pImpl->update(*renderer, nullptr, 255, clips, flag);

--- a/src/lib/tvgCanvasImpl.h
+++ b/src/lib/tvgCanvasImpl.h
@@ -32,6 +32,7 @@ struct Canvas::Impl
 {
     Array<Paint*> paints;
     RenderMethod* renderer;
+    bool forceUpdateAll;
 
     Impl(RenderMethod* pRenderer):renderer(pRenderer)
     {
@@ -77,7 +78,10 @@ struct Canvas::Impl
         if (!renderer) return Result::InsufficientCondition;
 
         Array<RenderData> clips;
-	auto flag = force ? RenderUpdateFlag::All : RenderUpdateFlag::None;
+        if (forceUpdateAll) force = true;
+        auto flag = force ? RenderUpdateFlag::All : RenderUpdateFlag::None;
+
+        printf("[%s:%d][flag: %d]\n",__FILE__, __LINE__, flag);
 
         //Update single paint node
         if (paint) {
@@ -88,6 +92,7 @@ struct Canvas::Impl
                 (*paint)->pImpl->update(*renderer, nullptr, 255, clips, flag);
             }
         }
+
         return Result::Success;
     }
 
@@ -102,6 +107,8 @@ struct Canvas::Impl
         }
 
         if (!renderer->postRender()) return Result::InsufficientCondition;
+
+        if (forceUpdateAll) forceUpdateAll = false;
 
         return Result::Success;
     }

--- a/src/lib/tvgSwCanvas.cpp
+++ b/src/lib/tvgSwCanvas.cpp
@@ -66,6 +66,7 @@ Result SwCanvas::target(uint32_t* buffer, uint32_t stride, uint32_t w, uint32_t 
     if (!renderer) return Result::MemoryCorruption;
 
     if (!renderer->target(buffer, stride, w, h, cs)) return Result::InvalidArguments;
+    Canvas::pImpl->forceUpdateAll = true;
 
     return Result::Success;
 #endif


### PR DESCRIPTION
Force update flag value is set after target change. It is necessary
to rerender shapes (gen its RLE) when target buffer size was modified.