### PR TITLE
sw_engine common: improving the accuracy of calculations in the ALPHA…

### DIFF
--- a/src/lib/sw_engine/tvgSwCommon.h
+++ b/src/lib/sw_engine/tvgSwCommon.h
@@ -263,7 +263,7 @@ static inline uint32_t COLOR_INTERPOLATE(uint32_t c1, uint32_t a1, uint32_t c2, 
 
 static inline uint8_t ALPHA_MULTIPLY(uint32_t c, uint32_t a)
 {
-    return (c * a) >> 8;
+    return (c * a + (c * a >> 8) + 0x80) >> 8;
 }
 
 static inline SwCoord HALF_STROKE(float width)


### PR DESCRIPTION
…_MULTIPLY() fun.

When multiplying the alpha values the division by 256 was performed (in form
of arithmetic shift >> 8), while the exact result required division by 255.
An expression was added to correct the result.
