### PR TITLE
common: comparison of floats using abs function

### DIFF
--- a/src/lib/sw_engine/tvgSwRaster.cpp
+++ b/src/lib/sw_engine/tvgSwRaster.cpp
@@ -67,12 +67,12 @@ static void _inverse(const Matrix* transform, Matrix* invM)
 }
 
 
-static bool _identify(const Matrix* transform)
+static bool _identify(const Matrix* m)
 {
-    if (transform) {
-        if (transform->e11 != 1.0f || transform->e12 != 0.0f || transform->e13 != 0.0f ||
-            transform->e21 != 0.0f || transform->e22 != 1.0f || transform->e23 != 0.0f ||
-            transform->e31 != 0.0f || transform->e32 != 0.0f || transform->e33 != 1.0f) {
+    if (m) {
+        if (fabsf(m->e11 - 1) > FLT_EPSILON || fabsf(m->e12) > FLT_EPSILON || fabsf(m->e13) > FLT_EPSILON ||
+            fabsf(m->e21) > FLT_EPSILON || fabsf(m->e22 - 1) > FLT_EPSILON || fabsf(m->e23) > FLT_EPSILON ||
+            fabsf(m->e31) > FLT_EPSILON || fabsf(m->e32) > FLT_EPSILON || fabsf(m->e33 - 1) > FLT_EPSILON) {
             return false;
         }
     }

--- a/src/lib/tvgRender.cpp
+++ b/src/lib/tvgRender.cpp
@@ -36,9 +36,9 @@ void RenderTransform::override(const Matrix& m)
 {
     this->m = m;
 
-    if (m.e11 == 0.0f && m.e12 == 0.0f && m.e13 == 0.0f &&
-        m.e21 == 0.0f && m.e22 == 0.0f && m.e23 == 0.0f &&
-        m.e31 == 0.0f && m.e32 == 0.0f && m.e33 == 0.0f) {
+    if (fabsf(m.e11) < FLT_EPSILON && fabsf(m.e12) < FLT_EPSILON && fabsf(m.e13) < FLT_EPSILON &&
+        fabsf(m.e21) < FLT_EPSILON && fabsf(m.e22) < FLT_EPSILON && fabsf(m.e23) < FLT_EPSILON &&
+        fabsf(m.e31) < FLT_EPSILON && fabsf(m.e32) < FLT_EPSILON && fabsf(m.e33) < FLT_EPSILON ) {
         overriding = false;
     } else overriding = true;
 }


### PR DESCRIPTION
The function abs() was used to compare the elements of the matrix
with other values instead of the operators == and !=.
