### PR TITLE
common Scene: Fix translucent composition condition

### DIFF
--- a/src/lib/tvgSceneImpl.h
+++ b/src/lib/tvgSceneImpl.h
@@ -65,7 +65,7 @@ struct Scene::Impl
         Compositor* cmp = nullptr;
 
         //Half translucent. This condition requires intermediate composition.
-        if ((opacity < 255 && opacity > 0) && (paints.count > 1)) {
+        if ((opacity < 255 && opacity > 0) && (paints.count > 0)) {
             uint32_t x, y, w, h;
             if (!bounds(renderer, &x, &y, &w, &h)) return false;
             cmp = renderer.target(x, y, w, h);


### PR DESCRIPTION
- Description :
If a scene has another scene as a child and
the number of children is 1, the composition of the child does not work.
Therefore, fix that composition works as long as the number of children is not 0.

- Tests or Samples (if any) :
```cpp
    auto rootScene = tvg::Scene::gen();
    rootScene->opacity(255);

    //Create a Scene
    auto childScene = tvg::Scene::gen();
    childScene->opacity(175);              //Apply opacity to scene (0 - 255)
    childScene->reserve(2);

    //Prepare Circle
    auto shape1 = tvg::Shape::gen();
    shape1->appendCircle(400, 400, 250, 250);
    shape1->fill(255, 255, 0, 255);
    childScene->push(move(shape1));

    rootScene->push(move(childScene));

    canvas->push(move(rootScene));

```
