### PR TITLE
sw_engine raster: fixing rasterization of an image with InvMask

### DIFF
--- a/src/lib/sw_engine/tvgSwRaster.cpp
+++ b/src/lib/sw_engine/tvgSwRaster.cpp
@@ -418,7 +418,8 @@ static bool _translucentImageInvAlphaMask(SwSurface* surface, uint32_t *img, uin
             auto rX = static_cast<uint32_t>(roundf(x * invTransform->e11 + ey1));
             auto rY = static_cast<uint32_t>(roundf(x * invTransform->e21 + ey2));
             if (rX >= w || rY >= h) continue;
-            auto tmp = ALPHA_BLEND(img[rX + (rY * w)], ALPHA_MULTIPLY(opacity, surface->blender.alpha(*cmp)));  //TODO: need to use image's stride
+            auto ialpha = 255 - surface->blender.alpha(*cmp);
+            auto tmp = ALPHA_BLEND(img[rX + (rY * w)], ALPHA_MULTIPLY(opacity, ialpha));  //TODO: need to use image's stride
             *dst = tmp + ALPHA_BLEND(*dst, 255 - surface->blender.alpha(tmp));
         }
     }
@@ -498,7 +499,7 @@ static bool _translucentImageInvAlphaMask(SwSurface* surface, uint32_t *img, uin
         auto src = &sbuffer[y * w];   //TODO: need to use image's stride
         for (uint32_t x = 0; x < w2; ++x, ++dst, ++src, ++cmp) {
             auto ialpha = 255 - surface->blender.alpha(*cmp);
-            auto tmp = ALPHA_BLEND(*src, ialpha);
+            auto tmp = ALPHA_BLEND(*src, ALPHA_MULTIPLY(opacity, ialpha));
             *dst = tmp + ALPHA_BLEND(*dst, 255 - surface->blender.alpha(tmp));
         }
     }


### PR DESCRIPTION
In case of the image rasterization with an inverse mask the opacity
was omitted and the alpha value instead of the inverse alpha value was used.


The result of the InvMasking:
expected (see comment below):
![invMaskOK](https://user-images.githubusercontent.com/67589014/106975188-55d80180-6756-11eb-8790-0aafac9f525e.PNG)

current (wrong):
![invMaskWrong](https://user-images.githubusercontent.com/67589014/106975211-5ec8d300-6756-11eb-9b99-7535073714b2.PNG)
