### PR TITLE
sw_engine rle: fixing clipping with non overlaping figures

### DIFF
--- a/src/lib/sw_engine/tvgSwRle.cpp
+++ b/src/lib/sw_engine/tvgSwRle.cpp
@@ -917,7 +917,12 @@ void rleFree(SwRleData* rle)
 
 void updateRleSpans(SwRleData *rle, SwSpan* curSpans, uint32_t size)
 {
-    if (!rle->spans || !curSpans || size == 0) return;
+    if (size == 0) {
+        rle->size = 0;
+        return;
+    }
+
+    if (!rle->spans || !curSpans) return;
     rle->size = size;
     rle->spans = static_cast<SwSpan*>(realloc(rle->spans, rle->size * sizeof(SwSpan)));
 


### PR DESCRIPTION
For clip that did not overlap with the plotted source, the whole
source was plotted - the size of the rle data was not updated.

- Tests or Samples:
Modified ClipPath -  https://github.com/Samsung/thorvg/pull/238

- Screen Shots from modified ClipPath:
current:
![clip_wrong](https://user-images.githubusercontent.com/67589014/107132844-ecd1c480-68e2-11eb-9b0f-84d35f58d97d.PNG)

expected:
![clip_ok](https://user-images.githubusercontent.com/67589014/107132847-05da7580-68e3-11eb-92c4-500d05207d0e.PNG)
