### PR TITLE
sw_engine: stencil for overlapping strokes

### DIFF
--- a/src/examples/Stencil.cpp
+++ b/src/examples/Stencil.cpp
@@ -1,0 +1,153 @@
+#include "Common.h"
+
+/************************************************************************/
+/* Drawing Commands                                                     */
+/************************************************************************/
+
+void tvgDrawCmds(tvg::Canvas* canvas)
+{
+    if (!canvas) return;
+
+    auto shape1 = tvg::Shape::gen();
+    shape1->appendCircle(150, 150, 100, 100);
+    shape1->appendCircle(250, 250, 150, 150);
+    shape1->appendCircle(200, 200, 180, 50);
+    shape1->stroke(255, 0, 0, 100);
+    shape1->stroke(9.0);
+    if (canvas->push(move(shape1)) != tvg::Result::Success) return;
+
+    auto shape2 = tvg::Shape::gen();
+    shape2->fill(80, 80, 80, 255);
+    shape2->moveTo(599, 34);
+    shape2->lineTo(653, 143);
+    shape2->lineTo(774, 160);
+    shape2->lineTo(687, 244);
+    shape2->lineTo(707, 365);
+    shape2->lineTo(599, 309);
+    shape2->lineTo(497, 365);
+    shape2->lineTo(512, 245);
+    shape2->lineTo(426, 161);
+    shape2->lineTo(546, 143);
+    shape2->close();
+    shape2->appendRect(420, 200, 200, 150, 0, 0);
+    shape2->appendCircle(700, 100, 100, 100);
+    shape2->stroke(10);
+    shape2->stroke(255, 255, 255, 255);
+    if (canvas->push(move(shape2)) != tvg::Result::Success) return;
+
+    auto shape3 = tvg::Shape::gen();
+    shape3->fill(255, 100, 0, 255);
+    shape3->stroke(0, 255, 255, 100);
+    shape3->stroke(5.0);
+    shape3->appendCircle(200, 600, 200, 200);
+    shape3->appendCircle(300, 600, 200, 150);
+    shape3->appendRect(400, 600, 300, 150, 20, 20);
+
+    if (canvas->push(move(shape3)) != tvg::Result::Success) return;
+}
+
+
+/************************************************************************/
+/* Sw Engine Test Code                                                  */
+/************************************************************************/
+
+static unique_ptr<tvg::SwCanvas> swCanvas;
+
+void tvgSwTest(uint32_t* buffer)
+{
+    //Create a Canvas
+    swCanvas = tvg::SwCanvas::gen();
+    swCanvas->target(buffer, WIDTH, WIDTH, HEIGHT, tvg::SwCanvas::ARGB8888);
+
+    /* Push the shape into the Canvas drawing list
+       When this shape is into the canvas list, the shape could update & prepare
+       internal data asynchronously for coming rendering.
+       Canvas keeps this shape node unless user call canvas->clear() */
+    tvgDrawCmds(swCanvas.get());
+}
+
+void drawSwView(void* data, Eo* obj)
+{
+    if (swCanvas->draw() == tvg::Result::Success) {
+        swCanvas->sync();
+    }
+}
+
+
+/************************************************************************/
+/* GL Engine Test Code                                                  */
+/************************************************************************/
+
+static unique_ptr<tvg::GlCanvas> glCanvas;
+
+void initGLview(Evas_Object *obj)
+{
+    static constexpr auto BPP = 4;
+
+    //Create a Canvas
+    glCanvas = tvg::GlCanvas::gen();
+    glCanvas->target(nullptr, WIDTH * BPP, WIDTH, HEIGHT);
+
+    /* Push the shape into the Canvas drawing list
+       When this shape is into the canvas list, the shape could update & prepare
+       internal data asynchronously for coming rendering.
+       Canvas keeps this shape node unless user call canvas->clear() */
+    tvgDrawCmds(glCanvas.get());
+}
+
+void drawGLview(Evas_Object *obj)
+{
+    auto gl = elm_glview_gl_api_get(obj);
+    gl->glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+    gl->glClear(GL_COLOR_BUFFER_BIT);
+
+    if (glCanvas->draw() == tvg::Result::Success) {
+        glCanvas->sync();
+    }
+}
+
+
+/************************************************************************/
+/* Main Code                                                            */
+/************************************************************************/
+
+int main(int argc, char **argv)
+{
+    tvg::CanvasEngine tvgEngine = tvg::CanvasEngine::Sw;
+
+    if (argc > 1) {
+        if (!strcmp(argv[1], "gl")) tvgEngine = tvg::CanvasEngine::Gl;
+    }
+
+    //Initialize ThorVG Engine
+    if (tvgEngine == tvg::CanvasEngine::Sw) {
+        cout << "tvg engine: software" << endl;
+    } else {
+        cout << "tvg engine: opengl" << endl;
+    }
+
+    //Threads Count
+    auto threads = std::thread::hardware_concurrency();
+
+    //Initialize ThorVG Engine
+    if (tvg::Initializer::init(tvgEngine, threads) == tvg::Result::Success) {
+
+        elm_init(argc, argv);
+
+        if (tvgEngine == tvg::CanvasEngine::Sw) {
+            createSwView();
+        } else {
+            createGlView();
+        }
+
+        elm_run();
+        elm_shutdown();
+
+        //Terminate ThorVG Engine
+        tvg::Initializer::term(tvgEngine);
+
+    } else {
+        cout << "engine is not supported" << endl;
+    }
+    return 0;
+}

--- a/src/examples/meson.build
+++ b/src/examples/meson.build
@@ -33,6 +33,7 @@ source_file = [
     'ClipPath.cpp',
     'Masking.cpp',
     'InvMasking.cpp',
+    'Stencil.cpp',
 ]
 
 foreach current_file : source_file

--- a/src/lib/sw_engine/tvgSwCommon.h
+++ b/src/lib/sw_engine/tvgSwCommon.h
@@ -204,9 +204,11 @@ struct SwShape
 {
     SwOutline*   outline = nullptr;
     SwStroke*    stroke = nullptr;
+    uint8_t*     stencil = nullptr;
     SwFill*      fill = nullptr;
     SwRleData*   rle = nullptr;
     SwRleData*   strokeRle = nullptr;
+    SwRleData*   stencilRle = nullptr;
     SwBBox       bbox;   //keep it boundary without stroke region. Using for optimal filling.
 
     bool         rect;   //Fast Track: Othogonal rectangle?
@@ -294,8 +296,11 @@ bool shapeGenRle(SwShape* shape, const Shape* sdata, const SwSize& clip, bool an
 void shapeDelOutline(SwShape* shape, uint32_t tid);
 void shapeResetStroke(SwShape* shape, const Shape* sdata, const Matrix* transform);
 bool shapeGenStrokeRle(SwShape* shape, const Shape* sdata, unsigned tid, const Matrix* transform, const SwSize& clip, SwBBox& bbox);
+bool shapeGenStencilRle(SwShape* shape, const Shape* sdata, unsigned tid, const Matrix* transform, const SwSize& clip, SwBBox& bbox);
 void shapeFree(SwShape* shape);
 void shapeDelStroke(SwShape* shape);
+void shapeDelStencil(SwShape* shape);
+void shapeResetStencil(SwShape* shape);
 bool shapeGenFillColors(SwShape* shape, const Fill* fill, const Matrix* transform, SwSurface* surface, uint32_t opacity, bool ctable);
 void shapeResetFill(SwShape* shape);
 void shapeDelFill(SwShape* shape);
@@ -340,6 +345,7 @@ bool rasterSolidShape(SwSurface* surface, SwShape* shape, uint8_t r, uint8_t g, 
 bool rasterImage(SwSurface* surface, SwImage* image, const Matrix* transform, SwBBox& bbox, uint32_t opacity);
 bool rasterStroke(SwSurface* surface, SwShape* shape, uint8_t r, uint8_t g, uint8_t b, uint8_t a);
 bool rasterClear(SwSurface* surface);
+bool rasterStencil(SwSurface* surface, SwShape* shape);
 
 static inline void rasterRGBA32(uint32_t *dst, uint32_t val, uint32_t offset, int32_t len)
 {

--- a/src/lib/sw_engine/tvgSwRenderer.cpp
+++ b/src/lib/sw_engine/tvgSwRenderer.cpp
@@ -122,6 +122,15 @@ struct SwShapeTask : SwTask
                 shapeResetStroke(&shape, sdata, transform);
                 if (!shapeGenStrokeRle(&shape, sdata, tid, transform, clip, bbox)) goto err;
                 ++addStroking;
+
+                //Stroke stencil
+                if (!shape.rect) {
+                    shapeResetStencil(&shape);
+                    if (!shapeGenStencilRle(&shape, sdata, tid, transform, clip, bbox)) goto err;
+                    if (!rasterStencil(surface, &shape)) goto err;
+                } else {
+                    shapeDelStencil(&shape);
+                }
             } else {
                 shapeDelStroke(&shape);
             }


### PR DESCRIPTION
Issue: #26 
Example: #240 

Implementation of stroke stencil. In case of multiple shapes inside one Shape, only the outline stroke is visible.

Before:
![before_stencil](https://user-images.githubusercontent.com/37028026/107347134-c91aa400-6ac5-11eb-9f44-d1e3cbe4255f.png)
After:
![after_stencil](https://user-images.githubusercontent.com/37028026/107347143-ccae2b00-6ac5-11eb-9459-37311de01d05.png)
