### PR TITLE
SvgLoader: Mask style implementation

### DIFF
--- a/src/loaders/svg/tvgSvgLoaderCommon.h
+++ b/src/loaders/svg/tvgSvgLoaderCommon.h
@@ -65,6 +65,7 @@ enum class SvgLengthType
 enum class SvgCompositeFlags
 {
     ClipPath = 0x01,
+    AlphaMask = 0x02,
 };
 
 enum class SvgFillFlags

--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -273,6 +273,16 @@ void _applyProperty(SvgNode* node, Shape* vg, float vx, float vy, float vw, floa
                 vg->composite(move(comp), CompositeMethod::ClipPath);
             }
         }
+        //Composite Alpha Mask 
+        if (((int)style->comp.flags & (int)SvgCompositeFlags::AlphaMask)) {
+            auto compNode = style->comp.node;
+            if (compNode->child.count > 0) {
+                auto comp = Shape::gen();
+                auto child = compNode->child.data;
+                for (uint32_t i = 0; i < compNode->child.count; ++i, ++child) _appendChildShape(*child, comp.get(), vx, vy, vw, vh);
+                vg->composite(move(comp), CompositeMethod::AlphaMask);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Support case when style is defined as <mask> attribute.

[Example SVG file]
```
<svg version="1.1" id="Layer_1" viewBox="0 0 64 64" enable-background="new 0 0 64 64" xml:space="preserve"
  xmlns="http://www.w3.org/2000/svg">
  <defs>
    <mask id="myMask">
      <circle id="maskID" cx="40" cy="40" r="10" fill="white" fill-opacity="1" />
    </mask>
  </defs>
  <rect x="0" y="0" width="64" height="64" style="fill: skyblue; mask: url(#myMask);"/>
</svg>
```

- Description :

- Issue Tickets (if any) :

- Tests or Samples (if any) :

- Screen Shots (if any) :
