### PR TITLE
common Task: Prevent data race condition

### DIFF
--- a/src/lib/tvgTaskScheduler.h
+++ b/src/lib/tvgTaskScheduler.h
@@ -74,6 +74,7 @@ private:
 
     void prepare()
     {
+        lock_guard<mutex> lock(mtx);
         ready = false;
         pending = true;
     }


### PR DESCRIPTION
- Description :
The static analyzer warns of a data race condition
for the 'ready' variable. So use lock to prevent it.

