### PR TITLE
canvas: fix crash issue.

### DIFF
--- a/src/lib/tvgCanvasImpl.h
+++ b/src/lib/tvgCanvasImpl.h
@@ -32,6 +32,7 @@ struct Canvas::Impl
 {
     Array<Paint*> paints;
     RenderMethod* renderer;
+    bool refresh;   //if all paints should be updated by force.
 
     Impl(RenderMethod* pRenderer):renderer(pRenderer)
     {
@@ -70,12 +71,18 @@ struct Canvas::Impl
         return Result::Success;
     }
 
+    void needRefresh()
+    {
+        refresh = true;
+    }
+
     Result update(Paint* paint, bool force)
     {
         if (!renderer) return Result::InsufficientCondition;
 
         Array<RenderData> clips;
-        auto flag = force ? RenderUpdateFlag::All : RenderUpdateFlag::None;
+        auto flag = RenderUpdateFlag::None;
+        if (refresh | force) flag = RenderUpdateFlag::All;
 
         //Update single paint node
         if (paint) {
@@ -86,6 +93,9 @@ struct Canvas::Impl
                 (*paint)->pImpl->update(*renderer, nullptr, 255, clips, flag);
             }
         }
+
+        refresh = false;
+
         return Result::Success;
     }
 

--- a/src/lib/tvgGlCanvas.cpp
+++ b/src/lib/tvgGlCanvas.cpp
@@ -68,6 +68,9 @@ Result GlCanvas::target(uint32_t* buffer, uint32_t stride, uint32_t w, uint32_t 
 
     if (!renderer->target(buffer, stride, w, h)) return Result::Unknown;
 
+    //Paints must be updated again with this new target.
+    Canvas::pImpl->needRefresh();
+
     return Result::Success;
 #endif
     return Result::NonSupport;

--- a/src/lib/tvgSwCanvas.cpp
+++ b/src/lib/tvgSwCanvas.cpp
@@ -67,6 +67,9 @@ Result SwCanvas::target(uint32_t* buffer, uint32_t stride, uint32_t w, uint32_t 
 
     if (!renderer->target(buffer, stride, w, h, cs)) return Result::InvalidArguments;
 
+    //Paints must be updated again with this new target.
+    Canvas::pImpl->needRefresh();
+
     return Result::Success;
 #endif
     return Result::NonSupport;


### PR DESCRIPTION
When canvas target size is changed, it need to update all retained paints again
so that they cannot redraw onto out of buffer boundary.

- Description :

- Issue Tickets (if any) :

- Tests or Samples (if any) :

- Screen Shots (if any) :
