### PR TITLE
sw_engine Math: Prevent overflow due to cast

### DIFF
--- a/src/lib/sw_engine/tvgSwMath.cpp
+++ b/src/lib/sw_engine/tvgSwMath.cpp
@@ -376,7 +376,7 @@ SwFixed mathLength(const SwPoint& pt)
     v.x = _downscale(v.x);
 
     if (shift > 0) return (v.x + (static_cast<SwFixed>(1) << (shift -1))) >> shift;
-    return static_cast<SwFixed>((uint32_t)v.x << -shift);
+    return static_cast<SwFixed>((SwFixed)v.x << -shift);
 }
 
 


### PR DESCRIPTION
- Description :
v.x is SwCoord(signed long) type.
When casting this to uint32_t, overflow may occur.
To prevent that, cast to SwFixed(signed long long) instead of uint32_t.
