### PR TITLE
sw_engine fill: fixing the infinite loop condition

### DIFF
--- a/src/lib/sw_engine/tvgSwFill.cpp
+++ b/src/lib/sw_engine/tvgSwFill.cpp
@@ -263,7 +263,8 @@ void fillFetchLinear(const SwFill* fill, uint32_t* dst, uint32_t y, uint32_t x, 
         }
     //we have to fallback to float math
     } else {
-        while (dst < dst + len) {
+        uint32_t counter = 0;
+        while (counter++ < len) {
             *dst = _pixel(fill, t / GRADIENT_STOP_SIZE);
             ++dst;
             t += inc;


### PR DESCRIPTION
Fixed in the fillFetchLinear() function.