### PR TITLE
canvas: replacement of the bitwise OR operator with the logical one

### DIFF
--- a/src/lib/tvgCanvasImpl.h
+++ b/src/lib/tvgCanvasImpl.h
@@ -82,7 +82,7 @@ struct Canvas::Impl
 
         Array<RenderData> clips;
         auto flag = RenderUpdateFlag::None;
-        if (refresh | force) flag = RenderUpdateFlag::All;
+        if (refresh || force) flag = RenderUpdateFlag::All;
 
         //Update single paint node
         if (paint) {


### PR DESCRIPTION
Bitwise logical operators do not perform short-circuiting.
