### PR TITLE
svgloader: fixing SVG image display when viewBox size is not given

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -744,7 +744,7 @@ static bool _attrParseSvgNode(void* data, const char* key, const char* value)
         if (!strcmp(value, "none")) doc->preserveAspect = false;
     } else if (!strcmp(key, "style")) {
         return simpleXmlParseW3CAttribute(value, _parseStyleAttr, loader);
-    } 
+    }
 #ifdef THORVG_LOG_ENABLED
     else if (!strcmp(key, "xmlns") || !strcmp(key, "xmlns:xlink") || !strcmp (key, "xmlns:svg")) {
         //No action
@@ -2607,8 +2607,14 @@ bool SvgLoader::header()
         h = vh = loaderData.doc->node.doc.vh;
 
         //Override size
-        if (loaderData.doc->node.doc.w > 0) w = loaderData.doc->node.doc.w;
-        if (loaderData.doc->node.doc.h > 0) h = loaderData.doc->node.doc.h;
+        if (loaderData.doc->node.doc.w > 0) {
+            w = loaderData.doc->node.doc.w;
+            if (vw < FLT_EPSILON) vw = w;
+        }
+        if (loaderData.doc->node.doc.h > 0) {
+            h = loaderData.doc->node.doc.h;
+            if (vh < FLT_EPSILON) vh = h;
+        }
 
         preserveAspect = loaderData.doc->node.doc.preserveAspect;
     } else {


### PR DESCRIPTION
When the viewBox is not given its dimensions should be determined
by the height and width parameters

example:
```
<svg height="80" width="80">
<path d="M 10 10 h 60 v 60 h -60 z" fill="none" stroke="#FF0000"stroke-width="6"/>
</svg>
```
current result:
![SVG_view_bad](https://user-images.githubusercontent.com/67589014/109894312-86e01f00-7c8d-11eb-8618-e8417eafb2f2.PNG)

after changes:
![SVG_view_ok](https://user-images.githubusercontent.com/67589014/109894322-8d6e9680-7c8d-11eb-97f4-f46d204490ad.PNG)

