### PR TITLE
svgloader: fixing linear gradient transformation

### DIFF
--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -77,17 +77,15 @@ unique_ptr<LinearGradient> _applyLinearGradientProperty(SvgStyleGradient* g, con
     }
 
     if (g->transform) {
-         float cy = ((float) rh) * 0.5 + ry;
-         float cx = ((float) rw) * 0.5 + rx;
+        //Calc start point
+        auto x = g->linear->x1;
+        g->linear->x1 = x * g->transform->e11 + g->linear->y1 * g->transform->e12 + g->transform->e13;
+        g->linear->y1 = x * g->transform->e21 + g->linear->y1 * g->transform->e22 + g->transform->e23;
 
-         //= T(x - cx, y - cy) x g->transform x T(cx, cy)
-         //Calc start point
-         g->linear->x1 = (g->transform->e11 * cx) + (g->transform->e12 * cy) + g->linear->x1 + g->transform->e13 - cx;
-         g->linear->y1 = (g->transform->e21 * cx) + (g->transform->e22 * cy) + g->linear->y1 + g->transform->e23 - cy;
-
-         //Calc end point
-         g->linear->x2 = (g->transform->e11 * cx) + (g->transform->e12 * cy) + g->linear->x2 + g->transform->e13 - cx;
-         g->linear->y2 = (g->transform->e21 * cx) + (g->transform->e22 * cy) + g->linear->y2 + g->transform->e23 - cy;
+        //Calc end point
+        x = g->linear->x2;
+        g->linear->x2 = x * g->transform->e11 + g->linear->y2 * g->transform->e12 + g->transform->e13;
+        g->linear->y2 = x * g->transform->e21 + g->linear->y2 * g->transform->e22 + g->transform->e23;
     }
 
     fillGrad->linear(g->linear->x1, g->linear->y1, g->linear->x2, g->linear->y2);
@@ -276,7 +274,7 @@ void _applyProperty(SvgNode* node, Shape* vg, float vx, float vy, float vw, floa
                 vg->composite(move(comp), CompositeMethod::ClipPath);
             }
         }
-        //Composite Alpha Mask 
+        //Composite Alpha Mask
         if (((int)style->comp.flags & (int)SvgCompositeFlags::AlphaMask)) {
             auto compNode = style->comp.node;
             if (compNode->child.count > 0) {


### PR DESCRIPTION
Gradient stop points were incorrectly transformed when building
the scene in the SVG loader.

example:
```
<svg viewBox="0 0 200 200" height="200" width="200">
<defs>
<linearGradient id="grad" gradientTransform="matrix(0 1 -1 0 0 0)" x1="0" y1="0" x2="1" y2="0">
<stop offset="0" stop-color="#FF0000"/>
<stop offset="1" stop-color="#0000FF"/>
</linearGradient>
</defs>
<path d="M 10 10 h 180 v 180 h -180 z" fill="url(#grad)"/>
</svg>
```

current result:
![SVG_grad_bad](https://user-images.githubusercontent.com/67589014/109894825-74b2b080-7c8e-11eb-8dcd-6640d78e2474.PNG)

after changes:
![SVG_grad_ok](https://user-images.githubusercontent.com/67589014/109894841-7a0ffb00-7c8e-11eb-93f0-09ece7da5e2b.PNG)
