### PR TITLE
capi: fix incorrect composite api.

### DIFF
--- a/inc/thorvg_capi.h
+++ b/inc/thorvg_capi.h
@@ -579,15 +579,16 @@ TVG_EXPORT Tvg_Paint* tvg_paint_duplicate(Tvg_Paint* paint);
 TVG_EXPORT Tvg_Result tvg_paint_get_bounds(const Tvg_Paint* paint, float* x, float* y, float* w, float* h);
 
 /*!
-* \fn TVG_EXPORT Tvg_Result tvg_paint_set_composite_method(const Tvg_Paint* paint, Tvg_Composite_Method method)
-* \brief The function set composition method
-* \param[in] paint Tvg_Paint pointer
+* \fn TVG_EXPORT Tvg_Result tvg_paint_set_composite_method(Tvg_Paint* paint, Tvg_Paint* target, Tvg_Composite_Method method)
+* \brief The function set composition method.
+* \param[in] paint Tvg_Paint composition source
+* \param[in] target Tvg_Paint composition target
 * \param[in] method Tvg_Composite_Method used composite method
 * \return Tvg_Result return value
 * - TVG_RESULT_SUCCESS: if ok.
 * - TVG_RESULT_INVALID_PARAMETERS: if paint is invalid
 */
-TVG_EXPORT Tvg_Result tvg_paint_set_composite_method(const Tvg_Paint* paint, Tvg_Composite_Method method);
+TVG_EXPORT Tvg_Result tvg_paint_set_composite_method(Tvg_Paint* paint, Tvg_Paint* target, Tvg_Composite_Method method);
 
 /************************************************************************/
 /* Shape API                                                            */

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -191,10 +191,10 @@ TVG_EXPORT Tvg_Result tvg_paint_get_bounds(const Tvg_Paint* paint, float* x, flo
    return (Tvg_Result) reinterpret_cast<const Paint*>(paint)->bounds(x, y, w, h);
 }
 
-TVG_EXPORT Tvg_Result tvg_paint_set_composite_method(const Tvg_Paint* paint, Tvg_Composite_Method method)
+TVG_EXPORT Tvg_Result tvg_paint_set_composite_method(Tvg_Paint* paint, Tvg_Paint* target, Tvg_Composite_Method method)
 {
    if (!paint) return TVG_RESULT_INVALID_ARGUMENT;
-   return (Tvg_Result) reinterpret_cast<const Paint*>(paint)->composite(unique_ptr<Paint>((Paint*)(paint)), (CompositeMethod)method);
+   return (Tvg_Result) reinterpret_cast<const Paint*>(paint)->composite(unique_ptr<Paint>((Paint*)(target)), (CompositeMethod)method);
 }
 
 /************************************************************************/


### PR DESCRIPTION
Api prototype is completely wrong, now it's corrected.

- Description :

- Issue Tickets (if any) :

- Tests or Samples (if any) :

- Screen Shots (if any) :
