### PR TITLE
svg_loader SvgPath: Remove unnecessary optimization code for small arc draw

### DIFF
--- a/src/loaders/svg/tvgSvgPath.cpp
+++ b/src/loaders/svg/tvgSvgPath.cpp
@@ -90,13 +90,6 @@ void _pathAppendArcTo(Array<PathCommand>* cmds, Array<Point>* pts, Point* cur, P
     //Correction of out-of-range radii, see F6.6.1 (step 2)
     rx = fabsf(rx);
     ry = fabsf(ry);
-    if ((rx < 0.5f) || (ry < 0.5f)) {
-        Point p = {x, y};
-        cmds->push(PathCommand::LineTo);
-        pts->push(p);
-        *cur = p;
-        return;
-    }
 
     angle = angle * M_PI / 180.0f;
     cosPhi = cosf(angle);


### PR DESCRIPTION
- Description :
This condition(optimization) is not a step suggested by arc implementation.
https://www.w3.org/TR/SVG11/implnote.html#ArcCorrectionOutOfRangeRadii (Step2)
This code is useful if the arc is too small to represent.
However, scaling often occurs in vectors, which can create unnecessary problems.

- Tests or Samples (if any) :
example path
```html
<path d="M32.41,20.49a.41.41,0,1,1-.41-.42A.41.41,0,0,1,32.41,20.49Z" transform="translate(0)" fill="#020202"/>
```
