### PR TITLE
sw_engine shape/image: substituting logical 'and' with 'or'

### DIFF
--- a/src/lib/sw_engine/tvgSwImage.cpp
+++ b/src/lib/sw_engine/tvgSwImage.cpp
@@ -68,7 +68,7 @@ static bool _updateBBox(const SwOutline* outline, SwBBox& bbox, const SwSize& cl
     bbox.max.x = min(bbox.max.x, clip.w);
     bbox.max.y = min(bbox.max.y, clip.h);
 
-    if (xMax - xMin < 1 && yMax - yMin < 1) return false;
+    if (xMax - xMin < 1 || yMax - yMin < 1) return false;
 
     return true;
 }

--- a/src/lib/sw_engine/tvgSwShape.cpp
+++ b/src/lib/sw_engine/tvgSwShape.cpp
@@ -193,7 +193,7 @@ static bool _updateBBox(const SwOutline* outline, SwBBox& bbox)
     bbox.min.y = yMin >> 6;
     bbox.max.y = (yMax + 63) >> 6;
 
-    if (xMax - xMin < 1 && yMax - yMin < 1) return false;
+    if (xMax - xMin < 1 || yMax - yMin < 1) return false;
 
     return true;
 }


### PR DESCRIPTION
In the case when the height or width of the bounding box is 0
it is not necessary to calculate Rle.
