### PR TITLE
svg_loader: limiting the ploted area of svg to viewBox

### DIFF
--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -363,7 +363,14 @@ unique_ptr<Scene> _sceneBuildHelper(const SvgNode* node, float vx, float vy, flo
                     scene->push(_sceneBuildHelper(*child, vx, vy, vw, vh));
                 } else {
                     auto shape = _shapeBuildHelper(*child, vx, vy, vw, vh);
-                    if (shape) scene->push(move(shape));
+                    // clipping the viewBox
+                    if (shape) {
+                        auto viewBoxClip = Shape::gen();
+                        viewBoxClip->appendRect(vx, vy, vw, vh, 0, 0);
+                        viewBoxClip->fill(0, 0, 0, 255);
+                        shape->composite(move(viewBoxClip), tvg::CompositeMethod::ClipPath);
+                        scene->push(move(shape));
+                    }
                 }
             }
             //Apply composite node


### PR DESCRIPTION
The 'viewBox' element given in the svg file determines
the coordinates of the plotted area.

- Tests or Samples:
<svg viewBox="0 0 200 200" height="200" width="200">
    <rect x="0" y="0" width="150" height="150" fill="#FF0000"/>
    <circle cx="150" cy="150" r="100" fill="#0000FF"/>
</svg>

- Screen Shots:

current:
![view_bad](https://user-images.githubusercontent.com/67589014/110244750-8632db80-7f60-11eb-8e05-2c4438b15b29.PNG)

expected:
![view_ok](https://user-images.githubusercontent.com/67589014/110244752-8a5ef900-7f60-11eb-838e-4e0ed62d6df8.PNG)

