### PR TITLE
svg_loader: ommiting xml entities in the svg file

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -36,6 +36,18 @@ typedef SvgNode* (*FactoryMethod)(SvgLoaderData* loader, SvgNode* parent, const 
 typedef SvgStyleGradient* (*GradientFactoryMethod)(SvgLoaderData* loader, const char* buf, unsigned bufLength);
 
 
+static void _ommitXMLEntities(string& filePath)
+{
+    string entity = "&quot;";
+    size_t entitySize = entity.size();
+    size_t pos = 0;
+
+    while ((pos = filePath.find(entity)) != string::npos) {
+        filePath.erase(pos++, entitySize);
+    }
+}
+
+
 static char* _skipSpace(const char* str, const char* end)
 {
     while (((end != nullptr && str < end) || (end == nullptr && *str != '\0')) && isspace(*str))
@@ -2649,6 +2661,8 @@ bool SvgLoader::open(const string& path)
         f.close();
 
         if (filePath.empty()) return false;
+
+        _ommitXMLEntities(filePath);
 
         this->content = filePath.c_str();
         this->size = filePath.size();

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -36,18 +36,6 @@ typedef SvgNode* (*FactoryMethod)(SvgLoaderData* loader, SvgNode* parent, const 
 typedef SvgStyleGradient* (*GradientFactoryMethod)(SvgLoaderData* loader, const char* buf, unsigned bufLength);
 
 
-static void _ommitXMLEntities(string& filePath)
-{
-    string entity = "&quot;";
-    size_t entitySize = entity.size();
-    size_t pos = 0;
-
-    while ((pos = filePath.find(entity)) != string::npos) {
-        filePath.erase(pos++, entitySize);
-    }
-}
-
-
 static char* _skipSpace(const char* str, const char* end)
 {
     while (((end != nullptr && str < end) || (end == nullptr && *str != '\0')) && isspace(*str))
@@ -2661,8 +2649,6 @@ bool SvgLoader::open(const string& path)
         f.close();
 
         if (filePath.empty()) return false;
-
-        _ommitXMLEntities(filePath);
 
         this->content = filePath.c_str();
         this->size = filePath.size();

--- a/src/loaders/svg/tvgXmlParser.cpp
+++ b/src/loaders/svg/tvgXmlParser.cpp
@@ -207,11 +207,10 @@ bool simpleXmlParseAttributes(const char* buf, unsigned bufLength, simpleXMLAttr
     if (!buf || !func) return false;
 
     while (itr < itrEnd) {
-        const char* p = itr;
+        const char* p = _skipWhiteSpacesAndXmlEntities(itr, itrEnd);
         const char *key, *keyEnd, *value, *valueEnd;
         char* tval;
 
-        p = _skipWhiteSpacesAndXmlEntities(p, itrEnd);
         if (p == itrEnd) return true;
 
         key = p;

--- a/src/loaders/svg/tvgXmlParser.cpp
+++ b/src/loaders/svg/tvgXmlParser.cpp
@@ -89,6 +89,69 @@ static const char* _simpleXmlUnskipWhiteSpace(const char* itr, const char* itrSt
 }
 
 
+static const char* _simpleXmlSkipXmlEntities(const char* itr, const char* itrEnd)
+{
+    auto p = itr;
+    while (*itr == '&' && itr < itrEnd) {
+        for (int i = 0; i < NUMBER_OF_XML_ENTITIES; ++i) {
+            if (strncmp(itr, xmlEntity[i], xmlEntityLength[i]) == 0) {
+                itr += xmlEntityLength[i];
+                break;
+            }
+        }
+        if (itr == p) break;
+        p = itr;
+    }
+    return itr;
+}
+
+
+static const char* _simpleXmlUnskipXmlEntities(const char* itr, const char* itrStart)
+{
+    auto p = itr;
+    while (*(itr - 1) == ';' && itr > itrStart) {
+        for (int i = 0; i < NUMBER_OF_XML_ENTITIES; ++i) {
+            if (itr - xmlEntityLength[i] > itrStart &&
+                strncmp(itr - xmlEntityLength[i], xmlEntity[i], xmlEntityLength[i]) == 0) {
+                itr -= xmlEntityLength[i];
+                break;
+            }
+        }
+        if (itr == p) break;
+        p = itr;
+    }
+    return itr;
+}
+
+
+static const char* _skipWhiteSpacesAndXmlEntities(const char* itr, const char* itrEnd)
+{
+    itr = _simpleXmlSkipWhiteSpace(itr, itrEnd);
+    auto p = itr;
+    while (true) {
+        if (p != (itr = _simpleXmlSkipXmlEntities(itr, itrEnd))) p = itr;
+        else break;
+        if (p != (itr = _simpleXmlSkipWhiteSpace(itr, itrEnd))) p = itr;
+        else break;
+    }
+    return itr;
+}
+
+
+static const char* _unskipWhiteSpacesAndXmlEntities(const char* itr, const char* itrStart)
+{
+    itr = _simpleXmlUnskipWhiteSpace(itr, itrStart);
+    auto p = itr;
+    while (true) {
+        if (p != (itr = _simpleXmlUnskipXmlEntities(itr, itrStart))) p = itr;
+        else break;
+        if (p != (itr = _simpleXmlUnskipWhiteSpace(itr, itrStart))) p = itr;
+        else break;
+    }
+    return itr;
+}
+
+
 static const char* _simpleXmlFindStartTag(const char* itr, const char* itrEnd)
 {
     return (const char*)memchr(itr, '<', itrEnd - itr);
@@ -144,10 +207,11 @@ bool simpleXmlParseAttributes(const char* buf, unsigned bufLength, simpleXMLAttr
     if (!buf || !func) return false;
 
     while (itr < itrEnd) {
-        const char* p = _simpleXmlSkipWhiteSpace(itr, itrEnd);
+        const char* p = itr;
         const char *key, *keyEnd, *value, *valueEnd;
         char* tval;
 
+        p = _skipWhiteSpacesAndXmlEntities(p, itrEnd);
         if (p == itrEnd) return true;
 
         key = p;
@@ -163,9 +227,9 @@ bool simpleXmlParseAttributes(const char* buf, unsigned bufLength, simpleXMLAttr
             if (!value) return false;
             value++;
         }
-        for (; value < itrEnd; value++) {
-            if (!isspace((unsigned char)*value)) break;
-        }
+        keyEnd = _simpleXmlUnskipXmlEntities(keyEnd, key);
+
+        value = _skipWhiteSpacesAndXmlEntities(value, itrEnd);
         if (value == itrEnd) return false;
 
         if ((*value == '"') || (*value == '\'')) {
@@ -176,20 +240,28 @@ bool simpleXmlParseAttributes(const char* buf, unsigned bufLength, simpleXMLAttr
             valueEnd = _simpleXmlFindWhiteSpace(value, itrEnd);
         }
 
+        itr = valueEnd + 1;
+
+        value = _skipWhiteSpacesAndXmlEntities(value, itrEnd);
+        valueEnd = _unskipWhiteSpacesAndXmlEntities(valueEnd, value);
+
         memcpy(tmpBuf, key, keyEnd - key);
         tmpBuf[keyEnd - key] = '\0';
 
         tval = tmpBuf + (keyEnd - key) + 1;
-        memcpy(tval, value, valueEnd - value);
-        tval[valueEnd - value] = '\0';
+        int i = 0;
+        while (value < valueEnd) {
+            value = _simpleXmlSkipXmlEntities(value, valueEnd);
+            tval[i++] = *value;
+            value++;
+        }
+        tval[i] = '\0';
 
 #ifdef THORVG_LOG_ENABLED
         if (!func((void*)data, tmpBuf, tval)) printf("SVG: Unsupported attributes used [Elements type: %s][Attribute: %s]\n", simpleXmlNodeTypeToString(((SvgLoaderData*)data)->svgParse->node->type).c_str(), tmpBuf);
 #else
         func((void*)data, tmpBuf, tval);
 #endif
-
-        itr = valueEnd + 1;
     }
     return true;
 }
@@ -290,8 +362,8 @@ bool simpleXmlParse(const char* buf, unsigned bufLength, bool strip, simpleXMLCb
                     }
 
                     if ((strip) && (type != SimpleXMLType::Error) && (type != SimpleXMLType::CData)) {
-                        start = _simpleXmlSkipWhiteSpace(start, end);
-                        end = _simpleXmlUnskipWhiteSpace(end, start + 1);
+                        start = _skipWhiteSpacesAndXmlEntities(start, end);
+                        end = _unskipWhiteSpacesAndXmlEntities(end, start);
                     }
 
                     CB(type, start, end);
@@ -307,7 +379,8 @@ bool simpleXmlParse(const char* buf, unsigned bufLength, bool strip, simpleXMLCb
             const char *p, *end;
 
             if (strip) {
-                p = _simpleXmlSkipWhiteSpace(itr, itrEnd);
+                p = itr;
+                p = _skipWhiteSpacesAndXmlEntities(p, itrEnd);
                 if (p) {
                     CB(SimpleXMLType::Ignored, itr, p);
                     itr = p;
@@ -318,7 +391,7 @@ bool simpleXmlParse(const char* buf, unsigned bufLength, bool strip, simpleXMLCb
             if (!p) p = itrEnd;
 
             end = p;
-            if (strip) end = _simpleXmlUnskipWhiteSpace(end, itr);
+            if (strip) end = _unskipWhiteSpacesAndXmlEntities(end, itr);
 
             if (itr != end) CB(SimpleXMLType::Data, itr, end);
 
@@ -393,7 +466,7 @@ const char* simpleXmlFindAttributesTag(const char* buf, unsigned bufLength)
             //User skip tagname and already gave it the attributes.
             if (*itr == '=') return buf;
         } else {
-            itr = _simpleXmlSkipWhiteSpace(itr + 1, itrEnd);
+            itr = _simpleXmlUnskipXmlEntities(itr, buf);
             if (itr == itrEnd) return nullptr;
             return itr;
         }

--- a/src/loaders/svg/tvgXmlParser.h
+++ b/src/loaders/svg/tvgXmlParser.h
@@ -25,6 +25,10 @@
 
 #include "tvgSvgLoaderCommon.h"
 
+#define NUMBER_OF_XML_ENTITIES 8
+const char* const xmlEntity[] = {"&quot;", "&nbsp;", "&apos;", "&amp;", "&lt;", "&gt;", "&#035;", "&#039;"};
+const int xmlEntityLength[] = {6, 6, 6, 5, 4, 4, 6, 6};
+
 enum class SimpleXMLType
 {
     Open = 0,     //!< \<tag attribute="value"\>


### PR DESCRIPTION
SVG files created using 'sketch' may contain xml entities,
which are not understandable by the svg loader.
For now only '&quot;' is ommitted.


- Tests or Samples :
<svg viewBox="0 0 500 300" width="500" height="300">
    <defs>
        <rect id="mask_path" x="50" y="100" width="400" height="100" />
    </defs>
    <rect fill="#FF0000" x="0" y="0" width="500" height="300" />
    <mask id="mask" fill="white">
        <use xlink:href="#mask_path" />
    </mask>
    <circle fill="#0000FF" mask="url(&quot;#mask&quot;)" cx="250" cy="150" r="200" />
</svg>

- Screen Shots:
current:
<img width="515" alt="xml_bad" src="https://user-images.githubusercontent.com/67589014/110258385-a6838a00-7fa2-11eb-9ea1-2103852eba26.png">

expected:
<img width="519" alt="xml_ok" src="https://user-images.githubusercontent.com/67589014/110258391-ab483e00-7fa2-11eb-897d-ad06082cd267.png">
