### PR TITLE
svg_loader: applying AlphaMask during scene building

### DIFF
--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -378,6 +378,16 @@ unique_ptr<Scene> _sceneBuildHelper(const SvgNode* node, float vx, float vy, flo
                         scene->composite(move(comp), CompositeMethod::ClipPath);
                     }
                 }
+                //Composite AlphaMask
+                if (((int)node->style->comp.flags & (int)SvgCompositeFlags::AlphaMask)) {
+                    auto compNode = node->style->comp.node;
+                    if (compNode->child.count > 0) {
+                        auto comp = Shape::gen();
+                        auto child = compNode->child.data;
+                        for (uint32_t i = 0; i < compNode->child.count; ++i, ++child) _appendChildShape(*child, comp.get(), vx, vy, vw, vh);
+                        scene->composite(move(comp), CompositeMethod::AlphaMask);
+                    }
+                }
             }
             scene->opacity(node->style->opacity);
         }


### PR DESCRIPTION
The AlphaMask composition case was omitted in the _sceneBuilderHelper().

- Tests or Samples :
```
<svg width="800" height="500" viewBox="0 0 800 500" >
  <defs>
    <mask id="Mask">
      <rect x="20" y="250" width="400" height="125" fill="#FFFFFF"  />
    </mask>
    <rect id="Rect" x="0" y="250" width="800" height="250" />
  </defs>

  <rect x="0" y="0" width="800" height="500" fill="#00FFFF" />
  <rect x="0" y="100" width="800" height="300" fill="#FF0000" />
  <use xlink:href="#Rect" fill="#00FF00" mask="url(#Mask)" />
</svg>
```

- Screen Shots:

current:
![bad_mask](https://user-images.githubusercontent.com/67589014/110819920-eee6c480-828e-11eb-8ace-c158e9d6990f.PNG)

expected:
![ok_mask](https://user-images.githubusercontent.com/67589014/110820000-fdcd7700-828e-11eb-96f8-46f20d790853.PNG)

