### PR TITLE
common shape: revise Shape::reset() api.

### DIFF
--- a/src/lib/tvgShape.cpp
+++ b/src/lib/tvgShape.cpp
@@ -52,7 +52,8 @@ unique_ptr<Shape> Shape::gen() noexcept
 
 Result Shape::reset() noexcept
 {
-    pImpl->reset();
+    pImpl->path.reset();
+    pImpl->flag = RenderUpdateFlag::Path;
 
     return Result::Success;
 }

--- a/src/lib/tvgShapeImpl.h
+++ b/src/lib/tvgShapeImpl.h
@@ -352,24 +352,6 @@ struct Shape::Impl
         return true;
     }
 
-    void reset()
-    {
-        path.reset();
-
-        if (fill) {
-            delete(fill);
-            fill = nullptr;
-        }
-        if (stroke) {
-            delete(stroke);
-            stroke = nullptr;
-        }
-
-        color[0] = color[1] = color[2] = color[3] = 0;
-
-        flag = RenderUpdateFlag::All;
-    }
-
     Paint* duplicate()
     {
         auto ret = Shape::gen();


### PR DESCRIPTION
reset Path is useful rather than reset all properties.

- Description :

- Issue Tickets (if any) :

- Tests or Samples (if any) :

- Screen Shots (if any) :
