### PR TITLE
paint: clip was substracted from the array for any composite method

### DIFF
--- a/src/lib/tvgPaint.h
+++ b/src/lib/tvgPaint.h
@@ -170,7 +170,7 @@ namespace tvg
                 edata = smethod->update(renderer, outTransform, opacity, clips, newFlag);
             }
 
-            if (cmpData) clips.pop();
+            if (cmpData && cmpMethod == CompositeMethod::ClipPath) clips.pop();
 
             return edata;
         }


### PR DESCRIPTION
Only ClipPath composite method should cause clips subtraction.

- Tests or Samples:
modified ClipPath.cpp:

```
    auto scene = tvg::Scene::gen();
    scene->reserve(2);

    auto star1 = tvg::Shape::gen();
    tvgDrawStar(star1.get());
    star1->fill(255, 255, 0, 255);
    star1->stroke(255 ,0, 0, 255);
    star1->stroke(10);

    //Move Star1
    star1->translate(-10, -10);

    auto clipStar = tvg::Shape::gen();
    clipStar->appendCircle(200, 230, 110, 110);
    clipStar->fill(255, 255, 255, 255); // clip object must have alpha.
    clipStar->translate(10, 10);

    star1->composite(move(clipStar), tvg::CompositeMethod::AlphaMask);    //CHANGED

    auto star2 = tvg::Shape::gen();
    tvgDrawStar(star2.get());
    star2->fill(0, 255, 255, 255);
    star2->stroke(0 ,255, 0, 255);
    star2->stroke(10);
    star2->opacity(100);

    //Move Star2
    star2->translate(10, 40);

    auto clip = tvg::Shape::gen();
    clip->appendCircle(200, 230, 130, 130);
    clip->fill(255, 255, 255, 255); // clip object must have alpha.
    clip->translate(10, 10);

    scene->push(move(star1));
    scene->push(move(star2));

    //Clipping scene to shape
    scene->composite(move(clip), tvg::CompositeMethod::ClipPath);

    canvas->push(move(scene));
```

- Screen Shots:
current:
![clip_mask_bad](https://user-images.githubusercontent.com/67589014/111084236-b1de3480-8511-11eb-956d-ee7c4b529cf9.PNG)

after changes:
![clip_mask_ok](https://user-images.githubusercontent.com/67589014/111084239-b7d41580-8511-11eb-8284-367e21dc9d24.PNG)
