### PR TITLE
svg_loader: limiting the ploted area of svg to viewBox

### DIFF
--- a/src/lib/tvgPictureImpl.h
+++ b/src/lib/tvgPictureImpl.h
@@ -68,6 +68,7 @@ struct Picture::Impl
             //Scale
             auto scale = sx < sy ? sx : sy;
             paint->scale(scale);
+            if (paint->pImpl->cmpTarget) paint->pImpl->cmpTarget->scale(scale);
             //Align
             auto vx = loader->vx * scale;
             auto vy = loader->vy * scale;
@@ -76,6 +77,7 @@ struct Picture::Impl
             if (vw > vh) vy -= (h - vh) * 0.5f;
             else vx -= (w - vw) * 0.5f;
             paint->translate(-vx, -vy);
+            if (paint->pImpl->cmpTarget) paint->pImpl->cmpTarget->translate(-vx, -vy);
         } else {
             //Align
             auto vx = loader->vx * sx;
@@ -87,6 +89,7 @@ struct Picture::Impl
 
             Matrix m = {sx, 0, -vx, 0, sy, -vy, 0, 0, 1};
             paint->transform(m);
+            if (paint->pImpl->cmpTarget) paint->pImpl->cmpTarget->transform(m);
         }
         resizing = false;
     }

--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -401,5 +401,14 @@ unique_ptr<Scene> SvgSceneBuilder::build(SvgNode* node)
 {
     if (!node || (node->type != SvgNodeType::Doc)) return nullptr;
 
-    return _sceneBuildHelper(node, node->node.doc.vx, node->node.doc.vy, node->node.doc.vw, node->node.doc.vh);
+    auto scene = _sceneBuildHelper(node, node->node.doc.vx, node->node.doc.vy, node->node.doc.vw, node->node.doc.vh);
+
+    if (scene && node->node.doc.vw > 0 && node->node.doc.vh > 0) {
+        auto viewBoxClip = Shape::gen();
+        viewBoxClip->appendRect(node->node.doc.vx, node->node.doc.vy, node->node.doc.vw, node->node.doc.vh, 0, 0);
+        viewBoxClip->fill(255, 255, 255, 255);
+        scene->composite(move(viewBoxClip), tvg::CompositeMethod::ClipPath);
+    }
+
+    return scene;
 }


### PR DESCRIPTION
The 'viewBox' element given in the svg file determines
the coordinates of the plotted area. Thi final scene
clipped in the Svg loader.

