### PR TITLE
sw_engine rleClipPath: Modify clippath spans creation size.

### DIFF
--- a/src/lib/sw_engine/tvgSwRle.cpp
+++ b/src/lib/sw_engine/tvgSwRle.cpp
@@ -923,8 +923,9 @@ void updateRleSpans(SwRleData *rle, const SwSpan* curSpans, uint32_t size)
     }
 
     if (!rle->spans || !curSpans) return;
+    rle->alloc = size * 2;
+    rle->spans = static_cast<SwSpan*>(realloc(rle->spans, rle->alloc * sizeof(SwSpan)));
     rle->size = size;
-    rle->spans = static_cast<SwSpan*>(realloc(rle->spans, rle->size * sizeof(SwSpan)));
 
     if (!rle->spans) return;
 


### PR DESCRIPTION
- Description :
When updating rle for clipped area, realloc size should be larger than spans size.
so this patch prevents the problem while realloc.

- Issue Tickets (if any) :
https://github.com/Samsung/thorvg/issues/291

- Tests or Samples (if any) :
Test ./Stress.cpp

