### PR TITLE
common shape: Fixed appendArc for negative values.

### DIFF
--- a/src/lib/tvgShape.cpp
+++ b/src/lib/tvgShape.cpp
@@ -163,7 +163,7 @@ Result Shape::appendArc(float cx, float cy, float radius, float startAngle, floa
     auto nCurves = ceil(abs(sweep / M_PI_HALF));
     auto sweepSign = (sweep < 0 ? -1 : 1);
     auto fract = fmodf(sweep, M_PI_HALF);
-    fract = (fabsf(fract) < std::numeric_limits<float>::epsilon()) ? M_PI_HALF : fract;
+    fract = (fabsf(fract) < std::numeric_limits<float>::epsilon()) ? M_PI_HALF * sweepSign : fract;
 
     //Start from here
     Point start = {radius * cos(startAngle), radius * sin(startAngle)};


### PR DESCRIPTION
Description:
Fixed appendArc API for -90 angles. In that case it was drawn in wrong
direction.

@Examples

```cpp
  float x = 40.0, y = 40.0;
  auto shape1 = tvg::Shape::gen();

  //OK
  shape1->appendArc(x + 50, y, 25, 0, -91, false);
  //NOK
  shape1->appendArc(x + 100, y, 25, 0, -90, false);
  //OK
  shape1->appendArc(x + 150, y, 25, 0, -89, false);
```
- Screen Shots (if any) :
![Screenshot from 2021-03-16 12-10-13](https://user-images.githubusercontent.com/4451022/111299775-9e85b300-8650-11eb-950a-18ace7e1cb79.png)
