### PR TITLE
initializer: add reference counting for the engines initialization.

### DIFF
--- a/src/lib/sw_engine/tvgSwRenderer.cpp
+++ b/src/lib/sw_engine/tvgSwRenderer.cpp
@@ -27,8 +27,8 @@
 /************************************************************************/
 /* Internal Class Implementation                                        */
 /************************************************************************/
-static bool initEngine = false;
-static uint32_t rendererCnt = 0;
+static int32_t initEngineCnt = false;
+static int32_t rendererCnt = 0;
 
 
 struct SwTask : Task
@@ -229,7 +229,8 @@ SwRenderer::~SwRenderer()
     if (surface) delete(surface);
 
     --rendererCnt;
-    if (!initEngine) _termEngine();
+
+    if (rendererCnt == 0 && initEngineCnt == 0) _termEngine();
 }
 
 
@@ -546,12 +547,9 @@ RenderData SwRenderer::prepare(const Shape& sdata, RenderData data, const Render
 
 bool SwRenderer::init(uint32_t threads)
 {
-    if (rendererCnt > 0) return false;
-    if (initEngine) return true;
+    if ((initEngineCnt++) > 0) return true;
 
     if (!mpoolInit(threads)) return false;
-
-    initEngine = true;
 
     return true;
 }
@@ -559,9 +557,9 @@ bool SwRenderer::init(uint32_t threads)
 
 bool SwRenderer::term()
 {
-    if (!initEngine) return true;
+    if ((--initEngineCnt) > 0) return true;
 
-    initEngine = false;
+    initEngineCnt = 0;
 
    _termEngine();
 

--- a/src/lib/tvgInitializer.cpp
+++ b/src/lib/tvgInitializer.cpp
@@ -35,7 +35,7 @@
 /************************************************************************/
 /* Internal Class Implementation                                        */
 /************************************************************************/
-static bool initialized = false;
+
 
 /************************************************************************/
 /* External Class Implementation                                        */
@@ -43,8 +43,6 @@ static bool initialized = false;
 
 Result Initializer::init(CanvasEngine engine, uint32_t threads) noexcept
 {
-    if (initialized) return Result::InsufficientCondition;
-
     auto nonSupport = true;
 
     if (static_cast<uint32_t>(engine) & static_cast<uint32_t>(CanvasEngine::Sw)) {
@@ -67,16 +65,12 @@ Result Initializer::init(CanvasEngine engine, uint32_t threads) noexcept
 
     TaskScheduler::init(threads);
 
-    initialized = true;
-
     return Result::Success;
 }
 
 
 Result Initializer::term(CanvasEngine engine) noexcept
 {
-    if (!initialized) return Result::InsufficientCondition;
-
     auto nonSupport = true;
 
     if (static_cast<uint32_t>(engine) & static_cast<uint32_t>(CanvasEngine::Sw)) {
@@ -98,8 +92,6 @@ Result Initializer::term(CanvasEngine engine) noexcept
     TaskScheduler::term();
 
     if (!LoaderMgr::term()) return Result::Unknown;
-
-    initialized = false;
 
     return Result::Success;
 }


### PR DESCRIPTION
Introduced the reference counting for the backend engines so that
tvg prevents unpaired engine initialization/termination calls by user mistake.

@Issues: 296

- Description :

- Issue Tickets (if any) :

- Tests or Samples (if any) :

- Screen Shots (if any) :
