### PR TITLE
meson: revise png loader meson script.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -20,6 +20,10 @@ if get_option('loaders').contains('svg') == true
     config_h.set10('THORVG_SVG_LOADER_SUPPORT', true)
 endif
 
+if get_option('loaders').contains('png') == true
+    config_h.set10('THORVG_PNG_LOADER_SUPPORT', true)
+endif
+
 if get_option('vectors').contains('avx') == true
     config_h.set10('THORVG_AVX_VECTOR_SUPPORT', true)
 endif
@@ -31,10 +35,6 @@ endif
 if get_option('log') == true
     config_h.set10('THORVG_LOG_ENABLED', true)
     message('Enable Log')
-endif
-
-if get_option('png') == true
-    config_h.set10('THORVG_PNG_LOADER_SUPPORT', true)
 endif
 
 configure_file(

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -6,7 +6,7 @@ option('engines',
 
 option('loaders',
    type: 'array',
-   choices: ['', 'svg'],
+   choices: ['', 'svg', 'png'],
    value: ['svg'],
    description: 'Enable Vector File Loader in thorvg')
 
@@ -32,11 +32,6 @@ option('examples',
     type: 'boolean',
     value: false,
     description: 'Enable building examples')
-
-option('png',
-   type: 'boolean',
-   value: false,
-   description: 'Enable libpng based png loading')
 
 option('test',
    type: 'boolean',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -8,7 +8,7 @@ option('loaders',
    type: 'array',
    choices: ['', 'svg', 'png'],
    value: ['svg'],
-   description: 'Enable Vector File Loader in thorvg')
+   description: 'Enable File Loaders in thorvg')
 
 option('vectors',
    type: 'array',

--- a/src/loaders/meson.build
+++ b/src/loaders/meson.build
@@ -5,8 +5,9 @@ if get_option('loaders').contains('svg') == true
     message('Enable SVG Loader')
 endif
 
-if get_option('png') == true
+if get_option('loaders').contains('png') == true
     subdir('png')
+    message('Enable PNG Loader')
 endif
 
 subdir('raw')

--- a/src/loaders/png/meson.build
+++ b/src/loaders/png/meson.build
@@ -3,7 +3,10 @@ source_file = [
    'tvgPngLoader.cpp',
 ]
 
+png_dep = meson.get_compiler('cpp').find_library('libpng')
+
 subloader_dep += [declare_dependency(
     include_directories : include_directories('.'),
+    dependencies : png_dep,
     sources : source_file
 )]

--- a/src/meson.build
+++ b/src/meson.build
@@ -19,12 +19,6 @@ subdir('bindings')
 thread_dep = meson.get_compiler('cpp').find_library('pthread')
 thorvg_lib_dep = [common_dep, loader_dep, binding_dep, thread_dep]
 
-if get_option('png') == true
-    message('Enable libpng based png loading')
-    png_dep = meson.get_compiler('cpp').find_library('libpng')
-    thorvg_lib_dep += png_dep
-endif
-
 thorvg_lib = library(
 	'thorvg',
 	include_directories    : headers,


### PR DESCRIPTION
We hate spagettie code, not even build script.
this revise it to keep the build script consistency.

Enable png loader by this:
$meson . build -Dexamples=true -Dloaders="svg, png"

- Description :

- Issue Tickets (if any) :

- Tests or Samples (if any) :

- Screen Shots (if any) :
