### PR TITLE
sw_engine: removed unnecessary function parameter

### DIFF
--- a/src/lib/sw_engine/tvgSwCommon.h
+++ b/src/lib/sw_engine/tvgSwCommon.h
@@ -331,7 +331,7 @@ void imageFree(SwImage* image);
 bool fillGenColorTable(SwFill* fill, const Fill* fdata, const Matrix* transform, SwSurface* surface, uint32_t opacity, bool ctable);
 void fillReset(SwFill* fill);
 void fillFree(SwFill* fill);
-void fillFetchLinear(const SwFill* fill, uint32_t* dst, uint32_t y, uint32_t x, uint32_t offset, uint32_t len);
+void fillFetchLinear(const SwFill* fill, uint32_t* dst, uint32_t y, uint32_t x, uint32_t len);
 void fillFetchRadial(const SwFill* fill, uint32_t* dst, uint32_t y, uint32_t x, uint32_t len);
 
 SwRleData* rleRender(SwRleData* rle, const SwOutline* outline, const SwBBox& renderRegion, bool antiAlias);

--- a/src/lib/sw_engine/tvgSwFill.cpp
+++ b/src/lib/sw_engine/tvgSwFill.cpp
@@ -226,7 +226,7 @@ void fillFetchRadial(const SwFill* fill, uint32_t* dst, uint32_t y, uint32_t x, 
 }
 
 
-void fillFetchLinear(const SwFill* fill, uint32_t* dst, uint32_t y, uint32_t x, uint32_t offset, uint32_t len)
+void fillFetchLinear(const SwFill* fill, uint32_t* dst, uint32_t y, uint32_t x, uint32_t len)
 {
     //Rotation
     float rx = x + 0.5f;
@@ -236,11 +236,9 @@ void fillFetchLinear(const SwFill* fill, uint32_t* dst, uint32_t y, uint32_t x, 
 
     if (abs(inc) < FLT_EPSILON) {
         auto color = _fixedPixel(fill, static_cast<int32_t>(t * FIXPT_SIZE));
-        rasterRGBA32(dst, color, offset, len);
+        rasterRGBA32(dst, color, 0, len);
         return;
     }
-
-    dst += offset;
 
     auto vMax = static_cast<float>(INT32_MAX >> (FIXPT_BITS + 1));
     auto vMin = -vMax;

--- a/src/lib/sw_engine/tvgSwRaster.cpp
+++ b/src/lib/sw_engine/tvgSwRaster.cpp
@@ -611,7 +611,7 @@ static bool _rasterLinearGradientRect(SwSurface* surface, const SwBBox& region, 
 
         for (uint32_t y = 0; y < h; ++y) {
             auto dst = &buffer[y * surface->stride];
-            fillFetchLinear(fill, tmpBuf, region.min.y + y, region.min.x, 0, w);
+            fillFetchLinear(fill, tmpBuf, region.min.y + y, region.min.x, w);
             for (uint32_t x = 0; x < w; ++x) {
                 dst[x] = tmpBuf[x] + ALPHA_BLEND(dst[x], 255 - surface->blender.alpha(tmpBuf[x]));
             }
@@ -626,7 +626,7 @@ static bool _rasterLinearGradientRect(SwSurface* surface, const SwBBox& region, 
 
             if (method == CompositeMethod::AlphaMask) {
                 for (uint32_t y = 0; y < h; ++y) {
-                    fillFetchLinear(fill, sbuffer, region.min.y + y, region.min.x, 0, w);
+                    fillFetchLinear(fill, sbuffer, region.min.y + y, region.min.x, w);
                     auto dst = buffer;
                     auto cmp = cbuffer;
                     auto src = sbuffer;
@@ -639,7 +639,7 @@ static bool _rasterLinearGradientRect(SwSurface* surface, const SwBBox& region, 
                 }
             } else if (method == CompositeMethod::InvAlphaMask) {
                 for (uint32_t y = 0; y < h; ++y) {
-                    fillFetchLinear(fill, sbuffer, region.min.y + y, region.min.x, 0, w);
+                    fillFetchLinear(fill, sbuffer, region.min.y + y, region.min.x, w);
                     auto dst = buffer;
                     auto cmp = cbuffer;
                     auto src = sbuffer;
@@ -653,7 +653,7 @@ static bool _rasterLinearGradientRect(SwSurface* surface, const SwBBox& region, 
             }
         } else {
             for (uint32_t y = 0; y < h; ++y) {
-                fillFetchLinear(fill, buffer + y * surface->stride, region.min.y + y, region.min.x, 0, w);
+                fillFetchLinear(fill, buffer + y * surface->stride, region.min.y + y, region.min.x, w);
             }
         }
     }
@@ -706,7 +706,7 @@ static bool _rasterLinearGradientRle(SwSurface* surface, const SwRleData* rle, c
     if (fill->translucent) {
         for (uint32_t i = 0; i < rle->size; ++i) {
             auto dst = &surface->buffer[span->y * surface->stride + span->x];
-            fillFetchLinear(fill, buf, span->y, span->x, 0, span->len);
+            fillFetchLinear(fill, buf, span->y, span->x, span->len);
             if (span->coverage == 255) {
                 for (uint32_t i = 0; i < span->len; ++i) {
                     dst[i] = buf[i] + ALPHA_BLEND(dst[i], 255 - surface->blender.alpha(buf[i]));
@@ -727,7 +727,7 @@ static bool _rasterLinearGradientRle(SwSurface* surface, const SwRleData* rle, c
 
             if (method == CompositeMethod::AlphaMask) {
                 for (uint32_t i = 0; i < rle->size; ++i, ++span) {
-                    fillFetchLinear(fill, buf, span->y, span->x, 0, span->len);
+                    fillFetchLinear(fill, buf, span->y, span->x, span->len);
                     auto dst = &surface->buffer[span->y * surface->stride + span->x];
                     auto cmp = &cbuffer[span->y * surface->stride + span->x];
                     auto src = buf;
@@ -738,7 +738,7 @@ static bool _rasterLinearGradientRle(SwSurface* surface, const SwRleData* rle, c
                 }
             } else if (method == CompositeMethod::InvAlphaMask) {
                 for (uint32_t i = 0; i < rle->size; ++i, ++span) {
-                    fillFetchLinear(fill, buf, span->y, span->x, 0, span->len);
+                    fillFetchLinear(fill, buf, span->y, span->x, span->len);
                     auto dst = &surface->buffer[span->y * surface->stride + span->x];
                     auto cmp = &cbuffer[span->y * surface->stride + span->x];
                     auto src = buf;
@@ -751,9 +751,9 @@ static bool _rasterLinearGradientRle(SwSurface* surface, const SwRleData* rle, c
         } else {
             for (uint32_t i = 0; i < rle->size; ++i) {
                 if (span->coverage == 255) {
-                    fillFetchLinear(fill, surface->buffer + span->y * surface->stride, span->y, span->x, span->x, span->len);
+                    fillFetchLinear(fill, surface->buffer + span->y * surface->stride + span->x, span->y, span->x, span->len);
                 } else {
-                    fillFetchLinear(fill, buf, span->y, span->x, 0, span->len);
+                    fillFetchLinear(fill, buf, span->y, span->x, span->len);
                     auto ialpha = 255 - span->coverage;
                     auto dst = &surface->buffer[span->y * surface->stride + span->x];
                     for (uint32_t i = 0; i < span->len; ++i) {


### PR DESCRIPTION
In the fillFetchLinear function the offset parameter was removed.
The destination address may be shifted directly in the dst parameter,
it doesn't need to be passed separately.
