### PR TITLE
sw_engine raster: ++ precise alpha multiplying

### DIFF
--- a/src/lib/sw_engine/tvgSwCommon.h
+++ b/src/lib/sw_engine/tvgSwCommon.h
@@ -274,7 +274,7 @@ static inline uint32_t COLOR_INTERPOLATE(uint32_t c1, uint32_t a1, uint32_t c2, 
 
 static inline uint8_t ALPHA_MULTIPLY(uint32_t c, uint32_t a)
 {
-    return (c * a) >> 8;
+    return ((c * a + 0xff) >> 8);
 }
 
 static inline SwCoord HALF_STROKE(float width)

--- a/src/lib/sw_engine/tvgSwRaster.cpp
+++ b/src/lib/sw_engine/tvgSwRaster.cpp
@@ -851,9 +851,11 @@ bool rasterGradientShape(SwSurface* surface, SwShape* shape, unsigned id)
 
 bool rasterSolidShape(SwSurface* surface, SwShape* shape, uint8_t r, uint8_t g, uint8_t b, uint8_t a)
 {
-    r = ALPHA_MULTIPLY(r, a);
-    g = ALPHA_MULTIPLY(g, a);
-    b = ALPHA_MULTIPLY(b, a);
+    if (a < 255) {
+        r = ALPHA_MULTIPLY(r, a);
+        g = ALPHA_MULTIPLY(g, a);
+        b = ALPHA_MULTIPLY(b, a);
+    }
 
     auto color = surface->blender.join(r, g, b, a);
     auto translucent = _translucent(surface, a);
@@ -872,9 +874,11 @@ bool rasterSolidShape(SwSurface* surface, SwShape* shape, uint8_t r, uint8_t g, 
 
 bool rasterStroke(SwSurface* surface, SwShape* shape, uint8_t r, uint8_t g, uint8_t b, uint8_t a)
 {
-    r = ALPHA_MULTIPLY(r, a);
-    g = ALPHA_MULTIPLY(g, a);
-    b = ALPHA_MULTIPLY(b, a);
+    if (a < 255) {
+        r = ALPHA_MULTIPLY(r, a);
+        g = ALPHA_MULTIPLY(g, a);
+        b = ALPHA_MULTIPLY(b, a);
+    }
 
     auto color = surface->blender.join(r, g, b, a);
     auto translucent = _translucent(surface, a);


### PR DESCRIPTION
previously alpha multiplying operation doesn't have perfect precision,
could loss 1 pixel since it divides 255 values by 256.

This improved operation comply with both precision & performance.

- Description :

- Issue Tickets (if any) :

- Tests or Samples (if any) :

- Screen Shots (if any) :
