### PR TITLE
loaders svg: set default color for composition paint.

### DIFF
--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -281,15 +281,13 @@ static void _applyProperty(SvgNode* node, Shape* vg, float vx, float vy, float v
         auto compNode = style->comp.node;
         if (compNode->child.count > 0) {
             auto comp = Shape::gen();
+            comp->fill(0, 0, 0, 255);
             auto child = compNode->child.data;
             auto valid = false;    //Composite only when valid shapes are existed
             for (uint32_t i = 0; i < compNode->child.count; ++i, ++child) {
                 if (_appendChildShape(*child, comp.get(), vx, vy, vw, vh)) valid = true;
             }
-            if (valid) {
-                if (style->comp.method == CompositeMethod::ClipPath) comp->fill(0, 0, 0, 255);
-                vg->composite(move(comp), style->comp.method);
-            }
+            if (valid) vg->composite(move(comp), style->comp.method);
         }
     }
 }
@@ -382,15 +380,13 @@ static unique_ptr<Scene> _sceneBuildHelper(const SvgNode* node, float vx, float 
                 auto compNode = node->style->comp.node;
                 if (compNode->child.count > 0) {
                     auto comp = Shape::gen();
+                    comp->fill(0, 0, 0, 255);
                     auto child = compNode->child.data;
                     auto valid = false;      //Composite only when valid shapes are existed
                     for (uint32_t i = 0; i < compNode->child.count; ++i, ++child) {
                         if (_appendChildShape(*child, comp.get(), vx, vy, vw, vh)) valid = true;
                     }
-                    if (valid) {
-                        if (node->style->comp.method == CompositeMethod::ClipPath) comp->fill(0, 0, 0, 255);
-                        scene->composite(move(comp), node->style->comp.method);
-                    }
+                    if (valid) scene->composite(move(comp), node->style->comp.method);
                 }
             }
             scene->opacity(node->style->opacity);


### PR DESCRIPTION
not only clippath but alpha compositions might also have any valid color.
Set it default and let it override values while appending shapes if it's necessary.

- Description :

- Issue Tickets (if any) :

- Tests or Samples (if any) :

- Screen Shots (if any) :
