### PR TITLE
sw_engine: fixing overlapping masks

### DIFF
--- a/src/lib/tvgPaint.cpp
+++ b/src/lib/tvgPaint.cpp
@@ -167,7 +167,7 @@ bool Paint::Impl::render(RenderMethod& renderer)
     /* Note: only ClipPath is processed in update() step.
         Create a composition image. */
     if (cmpTarget && cmpMethod != CompositeMethod::ClipPath) {
-        auto region = cmpTarget->pImpl->bounds(renderer);
+        auto region = smethod->bounds(renderer);
         if (region.w == 0 || region.h == 0) return false;
         cmp = renderer.target(region);
         renderer.beginComposite(cmp, CompositeMethod::None, 255);


### PR DESCRIPTION
The buffer to which the mask is rastered is only partially cleared.
If the object to which the mask is applied overlaps an area where
another mask was used, an erroneous image is generated. The buffer
clearing area has been increased to the size of the object to which
the mask is applied.

before:
![mask_overlap](https://user-images.githubusercontent.com/67589014/114327766-a7c44b80-9b3a-11eb-9764-c30f5de65910.PNG)

after:
![mask_overlap_ok](https://user-images.githubusercontent.com/67589014/114327770-abf06900-9b3a-11eb-87ed-353b98109c69.PNG)

