### PR TITLE
capi: svgPath parse and append to shape paint

### DIFF
--- a/inc/thorvg_capi.h
+++ b/inc/thorvg_capi.h
@@ -1289,7 +1289,7 @@ TVG_EXPORT Tvg_Result tvg_scene_push(Tvg_Paint* scene, Tvg_Paint* paint);
 
 /*!
 * \fn TVG_EXPORT Tvg_Result tvg_scene_clear(Tvg_Paint* scene)
-* \brief The function claers paints inserted in scene
+* \brief The function clears paints inserted in scene
 * \see tvg_canvas_clear
 * \param scene Tvg_Paint pointer
 * \return Tvg_Result return value
@@ -1297,6 +1297,18 @@ TVG_EXPORT Tvg_Result tvg_scene_push(Tvg_Paint* scene, Tvg_Paint* paint);
 * - TVG_RESULT_INVALID_PARAMETERS: if paint is invalid
 */
 TVG_EXPORT Tvg_Result tvg_scene_clear(Tvg_Paint* scene);
+
+
+/*!
+* \fn TVG_EXPORT Tvg_Result tvg_svg_path_append_to_shape(Tvg_Paint* paint, const char* svgPath)
+* \brief The function parse and append SVG path specified by svgPath into paint
+* \param[in] paint Tvg_Paint pointer
+* \param[in] svgPath char pointer
+* \return Tvg_Result return value
+* - TVG_RESULT_SUCCESS: if ok.
+* - TVG_RESULT_INVALID_PARAMETERS: if paint is invalid
+*/
+TVG_EXPORT Tvg_Result tvg_svg_path_append_to_shape(Tvg_Paint* paint, const char* svgPath);
 
 
 #ifdef __cplusplus

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -24,6 +24,9 @@
 #include <thorvg.h>
 #include "thorvg_capi.h"
 
+#include "tvgSvgLoaderCommon.h"
+#include "tvgSvgPath.h"
+
 using namespace std;
 using namespace tvg;
 
@@ -553,6 +556,23 @@ TVG_EXPORT Tvg_Result tvg_scene_clear(Tvg_Paint* scene)
 {
     if (!scene) return TVG_RESULT_INVALID_ARGUMENT;
     return (Tvg_Result) reinterpret_cast<Scene*>(scene)->clear();
+}
+
+/************************************************************************/
+/* SVG Loader                                                           */
+/************************************************************************/
+TVG_EXPORT Tvg_Result tvg_svg_path_append_to_shape(Tvg_Paint* paint, const char* svgPath)
+{
+   Array<PathCommand> cmds;
+   Array<Point> pts;
+
+   if (!paint) return TVG_RESULT_INVALID_ARGUMENT;
+
+   if (svgPathToTvgPath(svgPath, cmds, pts))
+      {
+         return (Tvg_Result) reinterpret_cast<Shape*>(paint)->appendPath(cmds.data, cmds.count, pts.data, pts.count);
+      }
+   return TVG_RESULT_INVALID_ARGUMENT;
 }
 
 


### PR DESCRIPTION
This is a binding for parsing and appending svgPath into paint.

I am open if you decide to move the function from tvgCapi.cpp into general cpp and create just short binding in `bindings/capi` or create separate binding for `svgPathToTvgPath`.