### PR TITLE
sw_engine: fixing masking behavior

### DIFF
--- a/src/lib/sw_engine/tvgSwCommon.h
+++ b/src/lib/sw_engine/tvgSwCommon.h
@@ -355,7 +355,7 @@ bool rasterSolidShape(SwSurface* surface, SwShape* shape, uint8_t r, uint8_t g, 
 bool rasterImage(SwSurface* surface, SwImage* image, const Matrix* transform, const SwBBox& bbox, uint32_t opacity);
 bool rasterStroke(SwSurface* surface, SwShape* shape, uint8_t r, uint8_t g, uint8_t b, uint8_t a);
 bool rasterGradientStroke(SwSurface* surface, SwShape* shape, unsigned id);
-bool rasterClear(SwSurface* surface);
+bool rasterSetValue(SwSurface* surface, uint32_t value);
 
 static inline void rasterRGBA32(uint32_t *dst, uint32_t val, uint32_t offset, int32_t len)
 {

--- a/src/lib/sw_engine/tvgSwRaster.cpp
+++ b/src/lib/sw_engine/tvgSwRaster.cpp
@@ -1047,15 +1047,15 @@ bool rasterGradientStroke(SwSurface* surface, SwShape* shape, unsigned id)
 }
 
 
-bool rasterClear(SwSurface* surface)
+bool rasterSetValue(SwSurface* surface, uint32_t value)
 {
     if (!surface || !surface->buffer || surface->stride <= 0 || surface->w <= 0 || surface->h <= 0) return false;
 
     if (surface->w == surface->stride) {
-        rasterRGBA32(surface->buffer, 0x00000000, 0, surface->w * surface->h);
+        rasterRGBA32(surface->buffer, value, 0, surface->w * surface->h);
     } else {
         for (uint32_t i = 0; i < surface->h; i++) {
-            rasterRGBA32(surface->buffer + surface->stride * i, 0x00000000, 0, surface->w);
+            rasterRGBA32(surface->buffer + surface->stride * i, value, 0, surface->w);
         }
     }
     return true;

--- a/src/lib/sw_engine/tvgSwRenderer.h
+++ b/src/lib/sw_engine/tvgSwRenderer.h
@@ -49,7 +49,7 @@ public:
     bool sync() override;
     bool target(uint32_t* buffer, uint32_t stride, uint32_t w, uint32_t h, uint32_t cs);
 
-    Compositor* target(const RenderRegion& region) override;
+    Compositor* target(const RenderRegion& region, const RenderRegion* fillRegion, uint8_t fillValue) override;
     bool beginComposite(Compositor* cmp, CompositeMethod method, uint32_t opacity) override;
     bool endComposite(Compositor* cmp) override;
 

--- a/src/lib/tvgPaint.cpp
+++ b/src/lib/tvgPaint.cpp
@@ -102,6 +102,7 @@ Paint* Paint::Impl::duplicate()
     }
 
     ret->pImpl->opacity = opacity;
+    ret->pImpl->cmpOpacity = cmpOpacity;
 
     if (cmpTarget) ret->pImpl->cmpTarget = cmpTarget->duplicate();
 
@@ -169,7 +170,8 @@ bool Paint::Impl::render(RenderMethod& renderer)
     if (cmpTarget && cmpMethod != CompositeMethod::ClipPath) {
         auto region = cmpTarget->pImpl->bounds(renderer);
         if (region.w == 0 || region.h == 0) return false;
-        cmp = renderer.target(region);
+        auto fillRegion = smethod->bounds(renderer);
+        cmp = renderer.target(region, &fillRegion, cmpTarget->pImpl->cmpOpacity);
         renderer.beginComposite(cmp, CompositeMethod::None, 255);
         cmpTarget->pImpl->render(renderer);
     }

--- a/src/lib/tvgPaint.h
+++ b/src/lib/tvgPaint.h
@@ -49,6 +49,7 @@ namespace tvg
         Paint* cmpTarget = nullptr;
         CompositeMethod cmpMethod = CompositeMethod::None;
         uint8_t opacity = 255;
+        uint8_t cmpOpacity = 0;
         PaintType type;
 
         ~Impl() {
@@ -96,6 +97,20 @@ namespace tvg
             if (cmpTarget) delete(cmpTarget);
             cmpTarget = target;
             cmpMethod = method;
+
+            if (cmpMethod == CompositeMethod::AlphaMask) {
+                cmpTarget->pImpl->cmpOpacity = cmpTarget->pImpl->opacity;
+                cmpTarget->pImpl->opacity  = 255;
+                if (cmpTarget->pImpl->type == PaintType::Shape)
+                {
+                    uint8_t o;
+                    static_cast<Shape*>(cmpTarget)->fillColor(nullptr, nullptr, nullptr, &o);
+                    static_cast<Shape*>(cmpTarget)->fill(0, 0, 0, 255);
+                    cmpTarget->pImpl->cmpOpacity = o * cmpTarget->pImpl->cmpOpacity / 255;
+                }
+                cmpTarget->pImpl->cmpOpacity = 255 - cmpTarget->pImpl->cmpOpacity;
+            }
+
             return true;
         }
 

--- a/src/lib/tvgRender.h
+++ b/src/lib/tvgRender.h
@@ -97,7 +97,7 @@ public:
     virtual bool clear() = 0;
     virtual bool sync() = 0;
 
-    virtual Compositor* target(const RenderRegion& region) = 0;
+    virtual Compositor* target(const RenderRegion& region, const RenderRegion* fillRegion, uint8_t fillValue) = 0;
     virtual bool beginComposite(Compositor* cmp, CompositeMethod method, uint32_t opacity) = 0;
     virtual bool endComposite(Compositor* cmp) = 0;
 };

--- a/src/lib/tvgSceneImpl.h
+++ b/src/lib/tvgSceneImpl.h
@@ -77,7 +77,7 @@ struct Scene::Impl
         Compositor* cmp = nullptr;
 
         if (needComposition(opacity)) {
-            cmp = renderer.target(bounds(renderer));
+            cmp = renderer.target(bounds(renderer), nullptr, 0);
             renderer.beginComposite(cmp, CompositeMethod::None, opacity);
         }
 


### PR DESCRIPTION
Masking with the opacity shouldn't change the target itself.
The mask's opacity < 255 causes the masked part to appear.

before (left - Mask, right - invMask):
![mask_notok](https://user-images.githubusercontent.com/67589014/114479425-cee55080-9c00-11eb-9650-f2b0adc779c0.PNG)


after (left - Mask, right - invMask):
![mask_ok](https://user-images.githubusercontent.com/67589014/114479412-c7be4280-9c00-11eb-89cd-02e33b7ea926.PNG)
