### PR TITLE
examples: ignoring pictures other than svgs in Stress.cpp

### DIFF
--- a/src/examples/Stress.cpp
+++ b/src/examples/Stress.cpp
@@ -38,6 +38,10 @@ static double t1, t2, t3, t4;
 
 void svgDirCallback(const char* name, const char* path, void* data)
 {
+    //ignore if not svgs.
+    const char *ext = name + strlen(name) - 3;
+    if (strcmp(ext, "svg")) return;
+
     auto picture = tvg::Picture::gen();
 
     char buf[PATH_MAX];


### PR DESCRIPTION
The picture->size() function does not work for raw/png pictures.
As a consequence enabling both, the svg and png file loaders,
resulted in the unintended behavior of the example.

![unint](https://user-images.githubusercontent.com/67589014/114545408-3977aa00-9c5c-11eb-8ee2-0edab33a7626.PNG)
