### PR TITLE
loader svg: displaying SVG images without the specified viewBox attri…

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -2574,7 +2574,7 @@ void SvgLoader::run(unsigned tid)
         _updateComposite(loaderData.doc, loaderData.doc);
         if (defs) _updateComposite(loaderData.doc, defs);
     }
-    root = svgSceneBuild(loaderData.doc);
+    root = svgSceneBuild(loaderData.doc, vx, vy, vw, vh);
 };
 
 

--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -398,14 +398,9 @@ static unique_ptr<Scene> _sceneBuildHelper(const SvgNode* node, float vx, float 
 /* External Class Implementation                                        */
 /************************************************************************/
 
-unique_ptr<Scene> svgSceneBuild(SvgNode* node)
+unique_ptr<Scene> svgSceneBuild(SvgNode* node, float vx, float vy, float vw, float vh)
 {
     if (!node || (node->type != SvgNodeType::Doc)) return nullptr;
-
-    auto vx = node->node.doc.vx;
-    auto vy = node->node.doc.vy;
-    auto vw = node->node.doc.vw;
-    auto vh = node->node.doc.vh;
 
     unique_ptr<Scene> root;
     auto docNode = _sceneBuildHelper(node, vx, vy, vw, vh);

--- a/src/loaders/svg/tvgSvgSceneBuilder.h
+++ b/src/loaders/svg/tvgSvgSceneBuilder.h
@@ -25,6 +25,6 @@
 
 #include "tvgCommon.h"
 
-unique_ptr<Scene> svgSceneBuild(SvgNode* node);
+unique_ptr<Scene> svgSceneBuild(SvgNode* node, float vx, float vy, float vw, float vh);
 
 #endif //_TVG_SVG_SCENE_BUILDER_H_


### PR DESCRIPTION
…bute

If no viewBox attribute is given, the height and width attributes are used
to establish the viewBox size. However, this information was not available
inside the scene builder, even though it was needed.


before:
![v2_bad](https://user-images.githubusercontent.com/67589014/114679643-a5195000-9d0c-11eb-9779-6c5d0a48c6fc.PNG)

after:
![v2_ok](https://user-images.githubusercontent.com/67589014/114679653-a9456d80-9d0c-11eb-8cc0-b2998ce70e75.PNG)
