### PR TITLE
common_shape: Fixed possible memory leak.

### DIFF
--- a/src/lib/tvgShapeImpl.h
+++ b/src/lib/tvgShapeImpl.h
@@ -206,6 +206,7 @@ struct Shape::Impl
     RenderData rdata = nullptr;         //engine data
     Shape *shape = nullptr;
     uint32_t flag = RenderUpdateFlag::None;
+    RenderMethod *renderer = nullptr;
 
     Impl(Shape* s) : shape(s)
     {
@@ -213,8 +214,10 @@ struct Shape::Impl
 
     ~Impl()
     {
+        if (renderer && rdata) renderer->dispose(rdata);
         if (fill) delete(fill);
         if (stroke) delete(stroke);
+        rdata = nullptr;
     }
 
     bool dispose(RenderMethod& renderer)
@@ -226,6 +229,7 @@ struct Shape::Impl
 
     bool render(RenderMethod& renderer)
     {
+        this->renderer = &renderer;
         return renderer.renderShape(rdata);
     }
 


### PR DESCRIPTION
Description:
If rendering engine integrated with ThorVG use tvg::canvas::clear with
free == false, then render data is not disposed. It can cause memory
leaks. In this commit check was added to verify if render data is still
available during shape destruction. In that case dispose of render data
is called.

Notes: 
Stability was checked on existing examples. No crash was observed.
