### PR TITLE
common: fix a potential memory leak after clear()

### DIFF
--- a/src/lib/tvgCanvasImpl.h
+++ b/src/lib/tvgCanvasImpl.h
@@ -59,11 +59,9 @@ struct Canvas::Impl
         if (!renderer || !renderer->clear()) return Result::InsufficientCondition;
 
         //free paints
-        if (free) {
-            for (auto paint = paints.data; paint < (paints.data + paints.count); ++paint) {
-                (*paint)->pImpl->dispose(*renderer);
-                delete(*paint);
-            }
+        for (auto paint = paints.data; paint < (paints.data + paints.count); ++paint) {
+            (*paint)->pImpl->dispose(*renderer);
+            if (free) delete(*paint);
         }
 
         paints.clear();

--- a/src/lib/tvgPictureImpl.h
+++ b/src/lib/tvgPictureImpl.h
@@ -44,13 +44,16 @@ struct Picture::Impl
     {
     }
 
+    ~Impl()
+    {
+        if (paint) delete(paint);
+    }
+
     bool dispose(RenderMethod& renderer)
     {
         bool ret = true;
         if (paint) {
             ret = paint->pImpl->dispose(renderer);
-            delete(paint);
-            paint = nullptr;
         }
         else if (pixels) {
             ret =  renderer.dispose(rdata);

--- a/src/lib/tvgSceneImpl.h
+++ b/src/lib/tvgSceneImpl.h
@@ -34,13 +34,18 @@ struct Scene::Impl
     Array<Paint*> paints;
     uint8_t opacity;            //for composition
 
+    ~Impl()
+    {
+        for (auto paint = paints.data; paint < (paints.data + paints.count); ++paint) {
+            delete(*paint);
+        }
+    }
+
     bool dispose(RenderMethod& renderer)
     {
         for (auto paint = paints.data; paint < (paints.data + paints.count); ++paint) {
             (*paint)->pImpl->dispose(renderer);
-            delete(*paint);
         }
-        paints.clear();
 
         return true;
     }


### PR DESCRIPTION
Paints must clear canvas engine data if they were dismissed from the canvas,

Canvas::clear(free = false) must retain all the paints through the paints hierarchy
so that it keeps the consistency of all dangled paints lifecycle.

Previously, it just keeps the immediate paints lives of canvas, but not them of scene nor picture.

This patch changes a policy which was not considered seriously,

Now it keeps the all paints lives through the tree-hieararchy.

Instead, Scene will add clear() to manange its children lifecycle.

- Description :

- Issue Tickets (if any) :

- Tests or Samples (if any) :

- Screen Shots (if any) :
