### PR TITLE
loader SvgLoader: Fix wrong debug log

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -1675,7 +1675,7 @@ static bool _attrParseUseNode(void* data, const char* key, const char* value)
 
 static SvgNode* _createUseNode(SvgLoaderData* loader, SvgNode* parent, const char* buf, unsigned bufLength)
 {
-    loader->svgParse->node = _createNode(parent, SvgNodeType::G);
+    loader->svgParse->node = _createNode(parent, SvgNodeType::Use);
 
     if (!loader->svgParse->node) return nullptr;
 
@@ -2298,7 +2298,7 @@ static void _styleInherit(SvgStyleProperty* child, const SvgStyleProperty* paren
 
 #ifdef THORVG_LOG_ENABLED
 static void _inefficientNodeCheck(SvgNode* node){
-    if (!node->display) printf("SVG: Inefficient elements used [Display is none][Node Type : %s]\n", simpleXmlNodeTypeToString(node->type).c_str());
+    if (!node->display && node->type != SvgNodeType:ClipPath) printf("SVG: Inefficient elements used [Display is none][Node Type : %s]\n", simpleXmlNodeTypeToString(node->type).c_str());
     if (node->style->opacity == 0) printf("SVG: Inefficient elements used [Opacity is zero][Node Type : %s]\n", simpleXmlNodeTypeToString(node->type).c_str());
     if (node->style->fill.opacity == 0 && node->style->stroke.opacity == 0) printf("SVG: Inefficient elements used [Fill opacity and stroke opacity are zero][Node Type : %s]\n", simpleXmlNodeTypeToString(node->type).c_str());
 

--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -33,7 +33,7 @@ static bool _appendShape(SvgNode* node, Shape* shape, float vx, float vy, float 
 
 static inline bool _isGroupType(SvgNodeType type)
 {
-    if (type == SvgNodeType::Doc || type == SvgNodeType::G || type == SvgNodeType::ClipPath) return true;
+    if (type == SvgNodeType::Doc || type == SvgNodeType::G || type == SvgNodeType::Use || type == SvgNodeType::ClipPath) return true;
     return false;
 }
 
@@ -274,7 +274,7 @@ static void _applyProperty(SvgNode* node, Shape* vg, float vx, float vy, float v
     //Apply node opacity
     if (style->opacity < 255) vg->opacity(style->opacity);
 
-    if (node->type == SvgNodeType::G) return;
+    if (node->type == SvgNodeType::G || node->type == SvgNodeType::Use) return;
 
     //Apply the stroke style property
     vg->stroke(style->stroke.width);


### PR DESCRIPTION
- Description :
1.
Modify that attribute information used for use type
looks like it was used for g type.

2.
Fix clippath node looking like setting "none"
(clippath's display = false is intentional)


