### PR TITLE
sw_engine raster: optimize alpha masking

### DIFF
--- a/src/lib/sw_engine/tvgSwCommon.h
+++ b/src/lib/sw_engine/tvgSwCommon.h
@@ -135,6 +135,14 @@ struct SwBBox
     {
         min.x = min.y = max.x = max.y = 0;
     }
+
+    void intersect(const SwBBox& rhs)
+    {
+        min.x = (min.x > rhs.min.x) ? min.x : rhs.min.x;
+        min.y = (min.y > rhs.min.y) ? min.y : rhs.min.y;
+        max.x = (max.x < rhs.max.x) ? max.x : rhs.max.x;
+        max.y = (max.y < rhs.max.y) ? max.y : rhs.max.y;
+    }
 };
 
 struct SwFill

--- a/src/lib/sw_engine/tvgSwRaster.cpp
+++ b/src/lib/sw_engine/tvgSwRaster.cpp
@@ -167,7 +167,9 @@ static bool _rasterTranslucentRect(SwSurface* surface, const SwBBox& region, uin
 {
     if (surface->compositor) {
         if (surface->compositor->method == CompositeMethod::AlphaMask) {
-            return _translucentRectAlphaMask(surface, region, color);
+            auto intersected = region;
+            intersected.intersect(surface->compositor->bbox);
+            return _translucentRectAlphaMask(surface, intersected, color);
         }
         if (surface->compositor->method == CompositeMethod::InvAlphaMask) {
             return _translucentRectInvAlphaMask(surface, region, color);
@@ -456,7 +458,9 @@ static bool _rasterTranslucentImage(SwSurface* surface, const uint32_t *img, uin
 {
     if (surface->compositor) {
         if (surface->compositor->method == CompositeMethod::AlphaMask) {
-            return _translucentImageAlphaMask(surface, img, w, h, opacity, region, invTransform);
+            auto intersected = region;
+            intersected.intersect(surface->compositor->bbox);
+            return _translucentImageAlphaMask(surface, img, w, h, opacity, intersected, invTransform);
         }
         if (surface->compositor->method == CompositeMethod::InvAlphaMask) {
             return _translucentImageInvAlphaMask(surface, img, w, h, opacity, region, invTransform);
@@ -546,7 +550,9 @@ static bool _rasterTranslucentImage(SwSurface* surface, uint32_t *img, uint32_t 
 {
     if (surface->compositor) {
         if (surface->compositor->method == CompositeMethod::AlphaMask) {
-            return _translucentImageAlphaMask(surface, img, w, h, opacity, region);
+            auto intersected = region;
+            intersected.intersect(surface->compositor->bbox);
+            return _translucentImageAlphaMask(surface, img, w, h, opacity, intersected);
         }
         if (surface->compositor->method == CompositeMethod::InvAlphaMask) {
             return _translucentImageInvAlphaMask(surface, img, w, h, opacity, region);


### PR DESCRIPTION
in case of alpha masking, out of mask region is invalid,
we can skip the masking composition step for the out of masking boundary
by intersecting the target/masking region before the rasterazation.

- Description :

- Issue Tickets (if any) :

- Tests or Samples (if any) :

- Screen Shots (if any) :
