### PR TITLE
common paint: changed result in composite API

### DIFF
--- a/src/lib/tvgPaint.cpp
+++ b/src/lib/tvgPaint.cpp
@@ -298,7 +298,7 @@ Paint* Paint::duplicate() const noexcept
 Result Paint::composite(std::unique_ptr<Paint> target, CompositeMethod method) const noexcept
 {
     if (pImpl->composite(target.release(), method)) return Result::Success;
-    return Result::InsufficientCondition;
+    return Result::InvalidArguments;
 }
 
 


### PR DESCRIPTION
A possible error is due to erroneous arguments, so
InvalidArgument is return instead of InsufficientCondition
