### PR TITLE
sw_engine: Added sanity checks.

### DIFF
--- a/src/lib/sw_engine/tvgSwRenderer.cpp
+++ b/src/lib/sw_engine/tvgSwRenderer.cpp
@@ -328,6 +328,8 @@ bool SwRenderer::renderImage(RenderData data)
 bool SwRenderer::renderShape(RenderData data)
 {
     auto task = static_cast<SwShapeTask*>(data);
+    if (!task) return false;
+
     task->done();
 
     if (task->opacity == 0) return true;
@@ -513,6 +515,7 @@ bool SwRenderer::dispose(RenderData data)
 
 void* SwRenderer::prepareCommon(SwTask* task, const RenderTransform* transform, uint32_t opacity, const Array<RenderData>& clips, RenderUpdateFlag flags)
 {
+    if (!surface) return task;
     if (flags == RenderUpdateFlag::None) return task;
 
     //Finish previous task if it has duplicated request.


### PR DESCRIPTION
This commit fixes crash when update target surface is not created yet.

- Tests
```c
void testCapi()
{
    Tvg_Paint* scene1 = tvg_scene_new();
    canvas = tvg_swcanvas_create();
    Tvg_Paint* scene2 = tvg_scene_new();
    tvg_canvas_push(canvas, scene2);

    Tvg_Paint* shape1 = tvg_shape_new();
    tvg_scene_push(scene1, shape1);

    tvg_paint_set_opacity(shape1, 255);
    Tvg_Paint* shape2 = tvg_shape_new();

    tvg_canvas_push(canvas, shape2);

    tvg_swcanvas_set_target(canvas, buffer, WIDTH, WIDTH, HEIGHT, TVG_COLORSPACE_ARGB8888);

    tvg_shape_append_circle(shape1, 50, 50, 100, 100);
    tvg_shape_set_stroke_width(shape1, 10);
    tvg_shape_set_stroke_color(shape1, 255, 0, 0, 0);

    tvg_canvas_update_paint(canvas, shape1);

    tvg_canvas_draw(canvas);
    tvg_canvas_sync(canvas);
}
```
