### PR TITLE
loader SvgLoader: Fix memory leak

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -2436,6 +2436,9 @@ static void _freeNodeStyle(SvgStyleProperty* style)
 {
     if (!style) return;
 
+    //style->comp.node has only the addresses of node. Therefore, style->comp.node is released from _freeNode.
+    delete style->comp.url;
+
     _freeGradientStyle(style->fill.paint.gradient);
     delete style->fill.paint.url;
     _freeGradientStyle(style->stroke.paint.gradient);


### PR DESCRIPTION
- Description :
Add memory release for style->comp.url, which is the leaking memory.

- Tests or Samples (if any) :
[Valgrind Test Result]
```
==21595== 32 bytes in 1 blocks are definitely lost in loss record 29 of 152
==21595==    at 0x4C3217F: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==21595==    by 0x5C248C6: _idFromUrl(char const*) (tvgSvgLoader.cpp:272)
==21595==    by 0x5C24DE1: _handleClipPathAttr(SvgLoaderData*, SvgNode*, char const*) (tvgSvgLoader.cpp:860)
==21595==    by 0x5C260CC: _attrParseGNode(void*, char const*, char const*) (tvgSvgLoader.cpp:953)
==21595==    by 0x5C2ABA9: simpleXmlParseAttributes(char const*, unsigned int, bool (*)(void*, char const*, char const*), void const*) (tvgXmlParser.cpp:272)
==21595==    by 0x5C26F6E: _createGNode(SvgLoaderData*, SvgNode*, char const*, unsigned int) (tvgSvgLoader.cpp:1063)
==21595==    by 0x5C27A04: _svgLoaderParserXmlOpen(SvgLoaderData*, char const*, unsigned int, bool) (tvgSvgLoader.cpp:2168)
==21595==    by 0x5C27CE9: _svgLoaderParser(void*, SimpleXMLType, char const*, unsigned int) (tvgSvgLoader.cpp:2226)
==21595==    by 0x5C2AC8C: simpleXmlParse(char const*, unsigned int, bool, bool (*)(void*, SimpleXMLType, char const*, unsigned int), void const*) (tvgXmlParser.cpp:378)
==21595==    by 0x5C27E09: SvgLoader::run(unsigned int) (tvgSvgLoader.cpp:2571)
==21595==    by 0x5C1A7C1: operator() (tvgTaskScheduler.h:68)
==21595==    by 0x5C1A7C1: tvg::TaskSchedulerImpl::run(unsigned int) (tvgTaskScheduler.cpp:138)
==21595==    by 0x5EED6DE: ??? (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.25)
```
