### PR TITLE
sw_engine: fix invalid data sharing at multi-threading.

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -1115,6 +1115,18 @@ public:
     };
 
     /**
+     * @brief Enumeration specifying the methods of Memory Pool behavior policy.
+     *
+     * @BETA_API
+     */
+    enum MempoolPolicy
+    {
+        Default = 0, ///< Default behavior that ThorVG is designed to.
+        Shareable,   ///< Memory Pool is shared among the SwCanvases.
+        Individual   ///< Allocate designated memory pool that is only used by current instance.
+    };
+
+    /**
      * @brief Sets the target buffer for the rasterization.
      *
      * The buffer of a desirable size should be allocated and owned by the caller.
@@ -1133,6 +1145,31 @@ public:
      * @warning Do not access @p buffer during Canvas::draw() - Canvas::sync(). It should not be accessed while TVG is writing on it. 
     */
     Result target(uint32_t* buffer, uint32_t stride, uint32_t w, uint32_t h, Colorspace cs) noexcept;
+
+    /**
+     * @brief Set sw engine memory pool behavior policy.
+     *
+     * Basically ThorVG draws a lot of shapes, it allocates/deallocates a few chunk of memory
+     * while processing rendering. It internally uses one shared memory pool
+     * which can be reused among the canvases in order to avoid memory overhead.
+     *
+     * Thus ThorVG suggests memory pool policy to satisfy user demands,
+     * if it needs to guarantee the thread-safety of the internal data access.
+     *
+     * @param[in] policy Use the shared cache memory. The default value is @c true
+     *
+     * @retval Result::Success When succeed.
+     * @retval Result::InsufficientCondition If the canvas has any paints.
+     * @retval Result::NonSupport In case the software engine is not supported.
+     *
+     * @note When @c policy is set as @c MempoolPolicy::Individual, current instance of canvas uses its own individual
+     *       memory data that is not shared with others. This is necessary when the canvas is accessed on a worker-thread.
+     *
+     * @warning It's not allowed after pushing any paints.
+     *
+     * @BETA_API
+    */
+    Result mempool(MempoolPolicy policy) noexcept;
 
     /**
      * @brief Creates a new SwCanvas object.

--- a/src/lib/sw_engine/tvgSwCommon.h
+++ b/src/lib/sw_engine/tvgSwCommon.h
@@ -254,6 +254,13 @@ struct SwCompositor : Compositor
     bool valid;
 };
 
+struct SwMpool
+{
+    SwOutline* outline = nullptr;
+    SwOutline* strokeOutline = nullptr;
+    unsigned allocSize = 0;
+};
+
 static inline SwCoord TO_SWCOORD(float val)
 {
     return SwCoord(val * 64);
@@ -299,13 +306,12 @@ SwPoint mathTransform(const Point* to, const Matrix* transform);
 bool mathUpdateOutlineBBox(const SwOutline* outline, const SwBBox& clipRegion, SwBBox& renderRegion);
 
 void shapeReset(SwShape* shape);
-bool shapeGenOutline(SwShape* shape, const Shape* sdata, unsigned tid, const Matrix* transform);
-bool shapePrepare(SwShape* shape, const Shape* sdata, unsigned tid, const Matrix* transform, const SwBBox& clipRegion, SwBBox& renderRegion);
+bool shapePrepare(SwShape* shape, const Shape* sdata, const Matrix* transform, const SwBBox& clipRegion, SwBBox& renderRegion, SwMpool* mpool, unsigned tid);
 bool shapePrepared(const SwShape* shape);
 bool shapeGenRle(SwShape* shape, const Shape* sdata, bool antiAlias, bool hasComposite);
-void shapeDelOutline(SwShape* shape, uint32_t tid);
+void shapeDelOutline(SwShape* shape, SwMpool* mpool, uint32_t tid);
 void shapeResetStroke(SwShape* shape, const Shape* sdata, const Matrix* transform);
-bool shapeGenStrokeRle(SwShape* shape, const Shape* sdata, unsigned tid, const Matrix* transform, const SwBBox& clipRegion, SwBBox& renderRegion);
+bool shapeGenStrokeRle(SwShape* shape, const Shape* sdata, const Matrix* transform, const SwBBox& clipRegion, SwBBox& renderRegion, SwMpool* mpool, unsigned tid);
 void shapeFree(SwShape* shape);
 void shapeDelStroke(SwShape* shape);
 bool shapeGenFillColors(SwShape* shape, const Fill* fill, const Matrix* transform, SwSurface* surface, uint32_t opacity, bool ctable);
@@ -317,15 +323,14 @@ void shapeDelStrokeFill(SwShape* shape);
 
 void strokeReset(SwStroke* stroke, const Shape* shape, const Matrix* transform);
 bool strokeParseOutline(SwStroke* stroke, const SwOutline& outline);
-SwOutline* strokeExportOutline(SwStroke* stroke, unsigned tid);
+SwOutline* strokeExportOutline(SwStroke* stroke, SwMpool* mpool, unsigned tid);
 void strokeFree(SwStroke* stroke);
 
-bool imagePrepare(SwImage* image, const Picture* pdata, unsigned tid, const Matrix* transform, const SwBBox& clipRegion, SwBBox& renderRegion);
+bool imagePrepare(SwImage* image, const Picture* pdata, const Matrix* transform, const SwBBox& clipRegion, SwBBox& renderRegion, SwMpool* mpool, unsigned tid);
 bool imagePrepared(const SwImage* image);
 bool imageGenRle(SwImage* image, TVG_UNUSED const Picture* pdata, const SwBBox& renderRegion, bool antiAlias);
-void imageDelOutline(SwImage* image, uint32_t tid);
+void imageDelOutline(SwImage* image, SwMpool* mpool, uint32_t tid);
 void imageReset(SwImage* image);
-bool imageGenOutline(SwImage* image, const Picture* pdata, unsigned tid, const Matrix* transform);
 void imageFree(SwImage* image);
 
 bool fillGenColorTable(SwFill* fill, const Fill* fdata, const Matrix* transform, SwSurface* surface, uint32_t opacity, bool ctable);
@@ -341,13 +346,13 @@ void rleClipPath(SwRleData *rle, const SwRleData *clip);
 void rleClipRect(SwRleData *rle, const SwBBox* clip);
 void rleAlphaMask(SwRleData *rle, const SwRleData *clip);
 
-bool mpoolInit(uint32_t threads);
-bool mpoolTerm();
-bool mpoolClear();
-SwOutline* mpoolReqOutline(unsigned idx);
-void mpoolRetOutline(unsigned idx);
-SwOutline* mpoolReqStrokeOutline(unsigned idx);
-void mpoolRetStrokeOutline(unsigned idx);
+SwMpool* mpoolInit(uint32_t threads);
+bool mpoolTerm(SwMpool* mpool);
+bool mpoolClear(SwMpool* mpool);
+SwOutline* mpoolReqOutline(SwMpool* mpool, unsigned idx);
+void mpoolRetOutline(SwMpool* mpool, unsigned idx);
+SwOutline* mpoolReqStrokeOutline(SwMpool* mpool, unsigned idx);
+void mpoolRetStrokeOutline(SwMpool* mpool, unsigned idx);
 
 bool rasterCompositor(SwSurface* surface);
 bool rasterGradientShape(SwSurface* surface, SwShape* shape, unsigned id);

--- a/src/lib/sw_engine/tvgSwRenderer.h
+++ b/src/lib/sw_engine/tvgSwRenderer.h
@@ -27,6 +27,7 @@
 struct SwSurface;
 struct SwTask;
 struct SwCompositor;
+struct SwMpool;
 
 namespace tvg
 {
@@ -48,6 +49,7 @@ public:
     bool clear() override;
     bool sync() override;
     bool target(uint32_t* buffer, uint32_t stride, uint32_t w, uint32_t h, uint32_t cs);
+    bool mempool(bool shared);
 
     Compositor* target(const RenderRegion& region) override;
     bool beginComposite(Compositor* cmp, CompositeMethod method, uint32_t opacity) override;
@@ -61,9 +63,12 @@ private:
     SwSurface*           surface = nullptr;           //active surface
     Array<SwTask*>       tasks;                       //async task list
     Array<SwSurface*>    compositors;                 //render targets cache list
+    SwMpool*             mpool;                       //private memory pool
     RenderRegion         vport;                       //viewport
 
-    SwRenderer(){};
+    bool                 sharedMpool = true;          //memory-pool behavior policy
+
+    SwRenderer();
     ~SwRenderer();
 
     RenderData prepareCommon(SwTask* task, const RenderTransform* transform, uint32_t opacity, const Array<RenderData>& clips, RenderUpdateFlag flags);

--- a/src/lib/sw_engine/tvgSwStroke.cpp
+++ b/src/lib/sw_engine/tvgSwStroke.cpp
@@ -907,7 +907,7 @@ bool strokeParseOutline(SwStroke* stroke, const SwOutline& outline)
 }
 
 
-SwOutline* strokeExportOutline(SwStroke* stroke, unsigned tid)
+SwOutline* strokeExportOutline(SwStroke* stroke, SwMpool* mpool, unsigned tid)
 {
     uint32_t count1, count2, count3, count4;
 
@@ -917,7 +917,7 @@ SwOutline* strokeExportOutline(SwStroke* stroke, unsigned tid)
     auto ptsCnt = count1 + count3;
     auto cntrsCnt = count2 + count4;
 
-    auto outline = mpoolReqStrokeOutline(tid);
+    auto outline = mpoolReqStrokeOutline(mpool, tid);
     if (outline->reservedPtsCnt < ptsCnt) {
         outline->pts = static_cast<SwPoint*>(realloc(outline->pts, sizeof(SwPoint) * ptsCnt));
         outline->types = static_cast<uint8_t*>(realloc(outline->types, sizeof(uint8_t) * ptsCnt));

--- a/src/lib/tvgSwCanvas.cpp
+++ b/src/lib/tvgSwCanvas.cpp
@@ -58,6 +58,25 @@ SwCanvas::~SwCanvas()
 }
 
 
+Result SwCanvas::mempool(MempoolPolicy policy) noexcept
+{
+#ifdef THORVG_SW_RASTER_SUPPORT
+    //We know renderer type, avoid dynamic_cast for performance.
+    auto renderer = static_cast<SwRenderer*>(Canvas::pImpl->renderer);
+    if (!renderer) return Result::MemoryCorruption;
+
+    //It can't change the policy during the running.
+    if (Canvas::pImpl->paints.count > 0) return Result::InsufficientCondition;
+
+    if (policy == MempoolPolicy::Individual) renderer->mempool(false);
+    else renderer->mempool(true);
+
+    return Result::Success;
+#endif
+    return Result::NonSupport;
+}
+
+
 Result SwCanvas::target(uint32_t* buffer, uint32_t stride, uint32_t w, uint32_t h, Colorspace cs) noexcept
 {
 #ifdef THORVG_SW_RASTER_SUPPORT


### PR DESCRIPTION
We have encountered that multi-threading usage that user creates,
multiple canvases owned by multiple user threads.

Current sw_engine memory pool has been considered only for multi-threads,
spawned by tvg task scheduler.

In this case it's safe but when user threads introduced, it can occur race-condition.

Thus, Here is a renewal policy that non-threading tvg(initialized threads with zero),
takes care of multiple user threads, each of canvases should have each own memory pool
to guarantee mutual-exclusion.

Instead, when tvg threads of task scheduler are enabled, we don't gurantee user threads safety.

All in all, if user calls multiple threads, they should initalize tvg thread zero.

- Description :

- Issue Tickets (if any) :

- Tests or Samples (if any) :

- Screen Shots (if any) :
