### PR TITLE
sw_engine: rearrange the blending mechanism.

### DIFF
--- a/src/lib/sw_engine/tvgSwCommon.h
+++ b/src/lib/sw_engine/tvgSwCommon.h
@@ -117,7 +117,7 @@ struct SwSpan
 {
     int16_t x, y;
     uint16_t len;
-    uint8_t coverage;
+    uint16_t coverage;
 };
 
 struct SwRleData
@@ -279,9 +279,9 @@ static inline uint32_t COLOR_INTERPOLATE(uint32_t c1, uint32_t a1, uint32_t c2, 
     return (c1 |= t);
 }
 
-static inline uint8_t ALPHA_MULTIPLY(uint32_t c, uint32_t a)
+static inline uint32_t ALPHA_MULTIPLY(uint32_t c, uint32_t a)
 {
-    return ((c * a + 0xff) >> 8);
+    return ((c * a) >> 8);
 }
 
 static inline SwCoord HALF_STROKE(float width)

--- a/src/lib/sw_engine/tvgSwRle.cpp
+++ b/src/lib/sw_engine/tvgSwRle.cpp
@@ -170,10 +170,9 @@ static void _horizLine(RleWorker& rw, SwCoord x, SwCoord y, SwCoord area, SwCoor
     if (rw.outline->fillRule == FillRule::EvenOdd) {
         coverage &= 511;
         if (coverage > 256) coverage = 512 - coverage;
-        else if (coverage == 256) coverage = 255;
     } else {
         //normal non-zero winding rule
-        if (coverage >= 256) coverage = 255;
+        if (coverage > 256) coverage = 256;
     }
 
     //span has ushort coordinates. check limit overflow
@@ -187,7 +186,7 @@ static void _horizLine(RleWorker& rw, SwCoord x, SwCoord y, SwCoord area, SwCoor
     }
 
     if (coverage > 0) {
-        if (!rw.antiAlias) coverage = 255;
+        if (!rw.antiAlias) coverage = 256;
         auto count = rw.spansCnt;
         auto span = rw.spans + count - 1;
 
@@ -649,7 +648,7 @@ SwSpan* _intersectSpansRegion(const SwRleData *clip, const SwRleData *targetRle,
             out->x = sx1 > cx1 ? sx1 : cx1;
             out->len = (sx2 < cx2 ? sx2 : cx2) - out->x;
             out->y = spans->y;
-            out->coverage = (uint8_t)(((spansCorverage * clipSpansCoverage) + 0xff) >> 8);
+            out->coverage = (uint16_t)((spansCorverage * clipSpansCoverage) >> 8);
             ++out;
             --spanCnt;
         }


### PR DESCRIPTION
Revised the blending mechanism by rearrange alpha value range from 0 to 256.
This is more clear than previous 255 alpha value range approach
because tvg uses bit-operation for faster results.
In the sequence, it divides alpha values by 256, it'd have chance to lose the value by 1
during 255 / 256. And then accumulated result brings the a bit different coloring.