### PR TITLE
Mgrudzinska/transl grad mask refact2

### DIFF
--- a/src/lib/sw_engine/tvgSwRaster.cpp
+++ b/src/lib/sw_engine/tvgSwRaster.cpp
@@ -596,7 +596,7 @@ static bool _rasterImage(SwSurface* surface, const uint32_t *img, uint32_t w, ui
 /* Gradient                                                             */
 /************************************************************************/
 
-static bool _rasterTranslucentLinearGradientRect(SwSurface* surface, const SwBBox& region, const SwFill* fill)
+static bool _translucentLinearGradientRect(SwSurface* surface, const SwBBox& region, const SwFill* fill)
 {
     if (fill->linear.len < FLT_EPSILON) return false;
 
@@ -607,49 +607,85 @@ static bool _rasterTranslucentLinearGradientRect(SwSurface* surface, const SwBBo
     auto sbuffer = static_cast<uint32_t*>(alloca(w * sizeof(uint32_t)));
     if (!sbuffer) return false;
 
-    if (surface->compositor) {
-        auto method = surface->compositor->method;
-        auto cbuffer = surface->compositor->image.data + (region.min.y * surface->stride) + region.min.x;
-
-        if (method == CompositeMethod::AlphaMask) {
-            for (uint32_t y = 0; y < h; ++y) {
-                fillFetchLinear(fill, sbuffer, region.min.y + y, region.min.x, w);
-                auto dst = buffer;
-                auto cmp = cbuffer;
-                auto src = sbuffer;
-                for (uint32_t x = 0; x < w; ++x, ++dst, ++cmp, ++src) {
-                    auto tmp = ALPHA_BLEND(*src, surface->blender.alpha(*cmp));
-                    *dst = tmp + ALPHA_BLEND(*dst, 255 - surface->blender.alpha(tmp));
-                }
-                buffer += surface->stride;
-                cbuffer += surface->stride;
-            }
-            return true;
-        } else if (method == CompositeMethod::InvAlphaMask) {
-            for (uint32_t y = 0; y < h; ++y) {
-                fillFetchLinear(fill, sbuffer, region.min.y + y, region.min.x, w);
-                auto dst = buffer;
-                auto cmp = cbuffer;
-                auto src = sbuffer;
-                for (uint32_t x = 0; x < w; ++x, ++dst, ++cmp, ++src) {
-                    auto tmp = ALPHA_BLEND(*src, 255 - surface->blender.alpha(*cmp));
-                    *dst = tmp + ALPHA_BLEND(*dst, 255 - surface->blender.alpha(tmp));
-                }
-                buffer += surface->stride;
-                cbuffer += surface->stride;
-            }
-            return true;
-        }
-    }
-
+    auto dst = buffer;
     for (uint32_t y = 0; y < h; ++y) {
-        auto dst = &buffer[y * surface->stride];
         fillFetchLinear(fill, sbuffer, region.min.y + y, region.min.x, w);
         for (uint32_t x = 0; x < w; ++x) {
             dst[x] = sbuffer[x] + ALPHA_BLEND(dst[x], 255 - surface->blender.alpha(sbuffer[x]));
         }
+        dst += surface->stride;
     }
     return true;
+}
+
+
+static bool _translucentLinearGradientRectAlphaMask(SwSurface* surface, const SwBBox& region, const SwFill* fill)
+{
+    if (fill->linear.len < FLT_EPSILON) return false;
+
+    auto buffer = surface->buffer + (region.min.y * surface->stride) + region.min.x;
+    auto h = static_cast<uint32_t>(region.max.y - region.min.y);
+    auto w = static_cast<uint32_t>(region.max.x - region.min.x);
+    auto cbuffer = surface->compositor->image.data + (region.min.y * surface->stride) + region.min.x;
+
+    auto sbuffer = static_cast<uint32_t*>(alloca(w * sizeof(uint32_t)));
+    if (!sbuffer) return false;
+
+    for (uint32_t y = 0; y < h; ++y) {
+        fillFetchLinear(fill, sbuffer, region.min.y + y, region.min.x, w);
+        auto dst = buffer;
+        auto cmp = cbuffer;
+        auto src = sbuffer;
+        for (uint32_t x = 0; x < w; ++x, ++dst, ++cmp, ++src) {
+            auto tmp = ALPHA_BLEND(*src, surface->blender.alpha(*cmp));
+            *dst = tmp + ALPHA_BLEND(*dst, 255 - surface->blender.alpha(tmp));
+        }
+        buffer += surface->stride;
+        cbuffer += surface->stride;
+    }
+    return true;
+}
+
+
+static bool _translucentLinearGradientRectInvAlphaMask(SwSurface* surface, const SwBBox& region, const SwFill* fill)
+{
+    if (fill->linear.len < FLT_EPSILON) return false;
+
+    auto buffer = surface->buffer + (region.min.y * surface->stride) + region.min.x;
+    auto h = static_cast<uint32_t>(region.max.y - region.min.y);
+    auto w = static_cast<uint32_t>(region.max.x - region.min.x);
+    auto cbuffer = surface->compositor->image.data + (region.min.y * surface->stride) + region.min.x;
+
+    auto sbuffer = static_cast<uint32_t*>(alloca(w * sizeof(uint32_t)));
+    if (!sbuffer) return false;
+
+    for (uint32_t y = 0; y < h; ++y) {
+        fillFetchLinear(fill, sbuffer, region.min.y + y, region.min.x, w);
+        auto dst = buffer;
+        auto cmp = cbuffer;
+        auto src = sbuffer;
+        for (uint32_t x = 0; x < w; ++x, ++dst, ++cmp, ++src) {
+            auto tmp = ALPHA_BLEND(*src, 255 - surface->blender.alpha(*cmp));
+            *dst = tmp + ALPHA_BLEND(*dst, 255 - surface->blender.alpha(tmp));
+        }
+        buffer += surface->stride;
+        cbuffer += surface->stride;
+    }
+    return true;
+}
+
+
+static bool _rasterTranslucentLinearGradientRect(SwSurface* surface, const SwBBox& region, const SwFill* fill)
+{
+    if (surface->compositor) {
+        if (surface->compositor->method == CompositeMethod::AlphaMask) {
+            return _translucentLinearGradientRectAlphaMask(surface, region, fill);
+        }
+        if (surface->compositor->method == CompositeMethod::InvAlphaMask) {
+            return _translucentLinearGradientRectInvAlphaMask(surface, region, fill);
+        }
+    }
+    return _translucentLinearGradientRect(surface, region, fill);
 }
 
 

--- a/src/lib/sw_engine/tvgSwRaster.cpp
+++ b/src/lib/sw_engine/tvgSwRaster.cpp
@@ -928,7 +928,7 @@ static bool _rasterOpaqueLinearGradientRle(SwSurface* surface, const SwRleData* 
 
     auto span = rle->spans;
 
-    for (uint32_t i = 0; i < rle->size; ++i) {
+    for (uint32_t i = 0; i < rle->size; ++i, ++span) {
         if (span->coverage == 255) {
             fillFetchLinear(fill, surface->buffer + span->y * surface->stride + span->x, span->y, span->x, span->len);
         } else {
@@ -939,7 +939,96 @@ static bool _rasterOpaqueLinearGradientRle(SwSurface* surface, const SwRleData* 
                 dst[i] = ALPHA_BLEND(buf[i], span->coverage) + ALPHA_BLEND(dst[i], ialpha);
             }
         }
-        ++span;
+    }
+    return true;
+}
+
+
+static bool _translucentRadialGradientRle(SwSurface* surface, const SwRleData* rle, const SwFill* fill)
+{
+    if (fill->radial.a < FLT_EPSILON) return false;
+
+    auto span = rle->spans;
+    auto buffer = static_cast<uint32_t*>(alloca(surface->w * sizeof(uint32_t)));
+    if (!buffer) return false;
+
+    for (uint32_t i = 0; i < rle->size; ++i, ++span) {
+        auto dst = &surface->buffer[span->y * surface->stride + span->x];
+        fillFetchRadial(fill, buffer, span->y, span->x, span->len);
+        if (span->coverage == 255) {
+            for (uint32_t i = 0; i < span->len; ++i) {
+                dst[i] = buffer[i] + ALPHA_BLEND(dst[i], 255 - surface->blender.alpha(buffer[i]));
+            }
+        } else {
+           for (uint32_t i = 0; i < span->len; ++i) {
+                auto tmp = ALPHA_BLEND(buffer[i], span->coverage);
+                dst[i] = tmp + ALPHA_BLEND(dst[i], 255 - surface->blender.alpha(tmp));
+            }
+        }
+    }
+    return true;
+}
+
+
+static bool _translucentRadialGradientRleAlphaMask(SwSurface* surface, const SwRleData* rle, const SwFill* fill)
+{
+    if (fill->radial.a < FLT_EPSILON) return false;
+
+    auto span = rle->spans;
+    auto cbuffer = surface->compositor->image.data;
+    auto buffer = static_cast<uint32_t*>(alloca(surface->w * sizeof(uint32_t)));
+    if (!buffer) return false;
+
+    for (uint32_t i = 0; i < rle->size; ++i, ++span) {
+        fillFetchRadial(fill, buffer, span->y, span->x, span->len);
+        auto dst = &surface->buffer[span->y * surface->stride + span->x];
+        auto cmp = &cbuffer[span->y * surface->stride + span->x];
+        auto src = buffer;
+        if (span->coverage == 255) {
+            for (uint32_t x = 0; x < span->len; ++x, ++dst, ++cmp, ++src) {
+                auto tmp = ALPHA_BLEND(*src, surface->blender.alpha(*cmp));
+                *dst = tmp + ALPHA_BLEND(*dst, 255 - surface->blender.alpha(tmp));
+            }
+        } else {
+            auto ialpha = 255 - span->coverage;
+            for (uint32_t x = 0; x < span->len; ++x, ++dst, ++cmp, ++src) {
+                auto tmp = ALPHA_BLEND(*src, surface->blender.alpha(*cmp));
+                tmp = ALPHA_BLEND(tmp, span->coverage) + ALPHA_BLEND(*dst, ialpha);
+                *dst = tmp + ALPHA_BLEND(*dst, 255 - surface->blender.alpha(tmp));
+            }
+        }
+    }
+    return true;
+}
+
+
+static bool _translucentRadialGradientRleInvAlphaMask(SwSurface* surface, const SwRleData* rle, const SwFill* fill)
+{
+    if (fill->radial.a < FLT_EPSILON) return false;
+
+    auto span = rle->spans;
+    auto cbuffer = surface->compositor->image.data;
+    auto buffer = static_cast<uint32_t*>(alloca(surface->w * sizeof(uint32_t)));
+    if (!buffer) return false;
+
+    for (uint32_t i = 0; i < rle->size; ++i, ++span) {
+        fillFetchRadial(fill, buffer, span->y, span->x, span->len);
+        auto dst = &surface->buffer[span->y * surface->stride + span->x];
+        auto cmp = &cbuffer[span->y * surface->stride + span->x];
+        auto src = buffer;
+        if (span->coverage == 255) {
+            for (uint32_t x = 0; x < span->len; ++x, ++dst, ++cmp, ++src) {
+                auto tmp = ALPHA_BLEND(*src, 255 - surface->blender.alpha(*cmp));
+                *dst = tmp + ALPHA_BLEND(*dst, 255 - surface->blender.alpha(tmp));
+            }
+        } else {
+            auto ialpha = 255 - span->coverage;
+            for (uint32_t x = 0; x < span->len; ++x, ++dst, ++cmp, ++src) {
+                auto tmp = ALPHA_BLEND(*src, 255 - surface->blender.alpha(*cmp));
+                tmp = ALPHA_BLEND(tmp, span->coverage) + ALPHA_BLEND(*dst, ialpha);
+                *dst = tmp + ALPHA_BLEND(*dst, 255 - surface->blender.alpha(tmp));
+            }
+        }
     }
     return true;
 }
@@ -947,78 +1036,17 @@ static bool _rasterOpaqueLinearGradientRle(SwSurface* surface, const SwRleData* 
 
 static bool _rasterTranslucentRadialGradientRle(SwSurface* surface, const SwRleData* rle, const SwFill* fill)
 {
-    if (fill->radial.a < FLT_EPSILON) return false;
-
-    auto buf = static_cast<uint32_t*>(alloca(surface->w * sizeof(uint32_t)));
-    if (!buf) return false;
-
-    auto span = rle->spans;
+    if (!rle) return false;
 
     if (surface->compositor) {
-        auto method = surface->compositor->method;
-        auto cbuffer = surface->compositor->image.data;
-
-        if (method == CompositeMethod::AlphaMask) {
-            for (uint32_t i = 0; i < rle->size; ++i, ++span) {
-                fillFetchRadial(fill, buf, span->y, span->x, span->len);
-                auto dst = &surface->buffer[span->y * surface->stride + span->x];
-                auto cmp = &cbuffer[span->y * surface->stride + span->x];
-                auto src = buf;
-                if (span->coverage == 255) {
-                    for (uint32_t x = 0; x < span->len; ++x, ++dst, ++cmp, ++src) {
-                        auto tmp = ALPHA_BLEND(*src, surface->blender.alpha(*cmp));
-                        *dst = tmp + ALPHA_BLEND(*dst, 255 - surface->blender.alpha(tmp));
-                    }
-                } else {
-                    auto ialpha = 255 - span->coverage;
-                    for (uint32_t x = 0; x < span->len; ++x, ++dst, ++cmp, ++src) {
-                        auto tmp = ALPHA_BLEND(*src, surface->blender.alpha(*cmp));
-                        tmp = ALPHA_BLEND(tmp, span->coverage) + ALPHA_BLEND(*dst, ialpha);
-                        *dst = tmp + ALPHA_BLEND(*dst, 255 - surface->blender.alpha(tmp));
-                    }
-                }
-            }
-            return true;
-        } else if (method == CompositeMethod::InvAlphaMask) {
-            for (uint32_t i = 0; i < rle->size; ++i, ++span) {
-                fillFetchRadial(fill, buf, span->y, span->x, span->len);
-                auto dst = &surface->buffer[span->y * surface->stride + span->x];
-                auto cmp = &cbuffer[span->y * surface->stride + span->x];
-                auto src = buf;
-                if (span->coverage == 255) {
-                   for (uint32_t x = 0; x < span->len; ++x, ++dst, ++cmp, ++src) {
-                        auto tmp = ALPHA_BLEND(*src, 255 - surface->blender.alpha(*cmp));
-                        *dst = tmp + ALPHA_BLEND(*dst, 255 - surface->blender.alpha(tmp));
-                    }
-                } else {
-                    auto ialpha = 255 - span->coverage;
-                    for (uint32_t x = 0; x < span->len; ++x, ++dst, ++cmp, ++src) {
-                        auto tmp = ALPHA_BLEND(*src, 255 - surface->blender.alpha(*cmp));
-                        tmp = ALPHA_BLEND(tmp, span->coverage) + ALPHA_BLEND(*dst, ialpha);
-                        *dst = tmp + ALPHA_BLEND(*dst, 255 - surface->blender.alpha(tmp));
-                    }
-                }
-            }
-            return true;
+        if (surface->compositor->method == CompositeMethod::AlphaMask) {
+            return _translucentRadialGradientRleAlphaMask(surface, rle, fill);
+        }
+        if (surface->compositor->method == CompositeMethod::InvAlphaMask) {
+            return _translucentRadialGradientRleInvAlphaMask(surface, rle, fill);
         }
     }
-
-    for (uint32_t i = 0; i < rle->size; ++i) {
-        auto dst = &surface->buffer[span->y * surface->stride + span->x];
-        fillFetchRadial(fill, buf, span->y, span->x, span->len);
-        if (span->coverage == 255) {
-            for (uint32_t i = 0; i < span->len; ++i) {
-                dst[i] = buf[i] + ALPHA_BLEND(dst[i], 255 - surface->blender.alpha(buf[i]));
-            }
-        } else {
-            for (uint32_t i = 0; i < span->len; ++i) {
-                auto tmp = ALPHA_BLEND(buf[i], span->coverage);
-                dst[i] = tmp + ALPHA_BLEND(dst[i], 255 - surface->blender.alpha(tmp));
-            }
-        }
-        ++span;
-    }
-    return true;
+    return _translucentRadialGradientRle(surface, rle, fill);
 }
 
 
@@ -1031,7 +1059,7 @@ static bool _rasterOpaqueRadialGradientRle(SwSurface* surface, const SwRleData* 
 
     auto span = rle->spans;
 
-    for (uint32_t i = 0; i < rle->size; ++i) {
+    for (uint32_t i = 0; i < rle->size; ++i, ++span) {
         auto dst = &surface->buffer[span->y * surface->stride + span->x];
         if (span->coverage == 255) {
             fillFetchRadial(fill, dst, span->y, span->x, span->len);
@@ -1042,7 +1070,6 @@ static bool _rasterOpaqueRadialGradientRle(SwSurface* surface, const SwRleData* 
                 dst[i] = ALPHA_BLEND(buf[i], span->coverage) + ALPHA_BLEND(dst[i], ialpha);
             }
         }
-        ++span;
     }
     return true;
 }


### PR DESCRIPTION
These refactoring is done to preserve the convention used for all other rastering functs.

I moved some parts of the code and close them in functions. There are no other important changes .

small changes:
- the name buf is changed to buffer
- ++span is moved next to ++i in for loop)
- in the _translucentLinearGradientRect I took the dst variable outside the for loop and because of that I could use addition instead of multiplication. the same is done for _translucentRadialGradientRect.

this PR is like #391 but for:
- linear rect
- radial rect
- radial rle 
functions (in 3 commits).