### PR TITLE
common scene: fixing the initial values of variables in the bounds ge…

### DIFF
--- a/src/lib/tvgSceneImpl.h
+++ b/src/lib/tvgSceneImpl.h
@@ -100,7 +100,6 @@ struct Scene::Impl
         uint32_t y2 = 0;
 
         for (auto paint = paints.data; paint < (paints.data + paints.count); ++paint) {
-
             auto region = (*paint)->pImpl->bounds(renderer);
 
             //Merge regions
@@ -119,8 +118,8 @@ struct Scene::Impl
 
         auto x1 = FLT_MAX;
         auto y1 = FLT_MAX;
-        auto x2 = 0.0f;
-        auto y2 = 0.0f;
+        auto x2 = -FLT_MAX;
+        auto y2 = -FLT_MAX;
 
         for (auto paint = paints.data; paint < (paints.data + paints.count); ++paint) {
             auto x = FLT_MAX;


### PR DESCRIPTION
fixing the initial values of variables in the bounds getter

The values of the most bottom right corner of the scene bounding box
should be initialized with the biggest negative values.

code:
```
    float x, y, w, h;
    
    auto shape1 = tvg::Shape::gen();
    shape1->appendRect(-300, 100, 200, 100, 0, 0);          //x, y, w, h, rx, ry

    shape1->bounds(&x, &y, &w, &h); 
    printf("shape: %f %f %f %f \n", x, y, w, h);

    auto scene1 = tvg::Scene::gen();
    scene1->push(move(shape1));

    scene1->bounds(&x, &y, &w, &h);
    printf("scene: %f %f %f %f \n", x, y, w, h);
```

before:
shape: -300 100 200 100 
scene: -300 100 300 100   // problem - the width should be 200 instead of 300

after:
shape: -300 100 200 100 
scene: -300 100 200 100