### PR TITLE
common Initializer: Fix init count

### DIFF
--- a/src/lib/tvgInitializer.cpp
+++ b/src/lib/tvgInitializer.cpp
@@ -63,8 +63,7 @@ Result Initializer::init(CanvasEngine engine, uint32_t threads) noexcept
 
     if (nonSupport) return Result::NonSupport;
 
-    if (_initCnt > 0) return Result::Success;
-    ++_initCnt;
+    if (_initCnt++ > 0) return Result::Success;
 
     if (!LoaderMgr::init()) return Result::Unknown;
 
@@ -96,8 +95,7 @@ Result Initializer::term(CanvasEngine engine) noexcept
 
     if (nonSupport) return Result::NonSupport;
 
-    --_initCnt;
-    if (_initCnt > 0) return Result::Success;
+    if (--_initCnt > 0) return Result::Success;
 
     TaskScheduler::term();
 


### PR DESCRIPTION
Calling init repeatedly doesn't increment count.
This leads to unwanted termination due to mismatch of the pair.