### PR TITLE
svg_loader: the viewBox clipping composite layer added independently …

### DIFF
--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -402,25 +402,18 @@ unique_ptr<Scene> svgSceneBuild(SvgNode* node, float vx, float vy, float vw, flo
 {
     if (!node || (node->type != SvgNodeType::Doc)) return nullptr;
 
-    unique_ptr<Scene> root;
     auto docNode = _sceneBuildHelper(node, vx, vy, vw, vh);
-    float x, y, w, h;
 
-    if (docNode->bounds(&x, &y, &w, &h) != Result::Success) return nullptr;
+    auto viewBoxClip = Shape::gen();
+    viewBoxClip->appendRect(vx, vy ,vw, vh, 0, 0);
+    viewBoxClip->fill(0, 0, 0, 255);
 
-    if (x < vx || y < vy || w > vh || h > vh) {
-        auto viewBoxClip = Shape::gen();
-        viewBoxClip->appendRect(vx, vy ,vw, vh, 0, 0);
-        viewBoxClip->fill(0, 0, 0, 255);
+    auto compositeLayer = Scene::gen();
+    compositeLayer->composite(move(viewBoxClip), CompositeMethod::ClipPath);
+    compositeLayer->push(move(docNode));
 
-        auto compositeLayer = Scene::gen();
-        compositeLayer->composite(move(viewBoxClip), CompositeMethod::ClipPath);
-        compositeLayer->push(move(docNode));
+    auto root = Scene::gen();
+    root->push(move(compositeLayer));
 
-        root = Scene::gen();
-        root->push(move(compositeLayer));
-    } else {
-        root = move(docNode);
-    }
     return root;
 }


### PR DESCRIPTION
…of the shapes bounds

For now the bounding box of all the shapes was established and if it was larger
than the viewBox of the SVG, the clipping layer was added. The bounds api
returns the rectangle that encloses the shapes before any transformations.
So comparing it with the viewBox doesn't make sense. The comparison is removed
and the clipping layer is always added.


Example illustrating the problem: The shape bounds and the viewBox are exactly the same,
so the clipping layer is not added. But the shape is later transformed and goes outside the viewBox,
so it should be clipped.

code:
```
<svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
<path d="M 0 0 h 200 v 200 h -200 z" fill="#F00" stroke-width="0" transform="translate(100,100)" />
</svg>
```

before:
![before](https://user-images.githubusercontent.com/67589014/119837637-13a01f00-bf03-11eb-9800-56317764bb3f.PNG)

after:
![after](https://user-images.githubusercontent.com/67589014/119837653-1733a600-bf03-11eb-8bd1-7b877bfcecab.PNG)


