### PR TITLE
capi: include <stdint.h> into thorvg_capi.h

### DIFF
--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -19,6 +19,7 @@
 #ifndef __THORVG_CAPI_H__
 #define __THORVG_CAPI_H__
 
+#include <stdint.h>
 #include <stdbool.h>
 
 #ifdef TVG_EXPORT


### PR DESCRIPTION
Included <stdint.h> into thorvg_capi.h to eliminate "uint8_t/uint32_t has not been declared"