### PR TITLE
common gradient: Fix possible crash in color setter

### DIFF
--- a/src/lib/tvgFill.cpp
+++ b/src/lib/tvgFill.cpp
@@ -43,11 +43,13 @@ Fill::~Fill()
 
 Result Fill::colorStops(const ColorStop* colorStops, uint32_t cnt) noexcept
 {
+    if ((!colorStops && cnt > 0) || (colorStops && cnt == 0)) return Result::InvalidArguments;
+
     if (cnt == 0) {
         if (pImpl->colorStops) {
             free(pImpl->colorStops);
             pImpl->colorStops = nullptr;
-            pImpl->cnt = cnt;
+            pImpl->cnt = 0;
         }
         return Result::Success;
     }


### PR DESCRIPTION
Memcpy is not allowed on nullptr. If colorStops is invalid colors are cleared.