### PR TITLE
svg_loader: initializing uninitialized variables

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -1069,8 +1069,14 @@ static SvgNode* _createSvgNode(SvgLoaderData* loader, SvgNode* parent, const cha
     if (!loader->svgParse->node) return nullptr;
     SvgDocNode* doc = &(loader->svgParse->node->node.doc);
 
+    loader->svgParse->global.w = 0;
+    loader->svgParse->global.h = 0;
+
     doc->preserveAspect = true;
     simpleXmlParseAttributes(buf, bufLength, _attrParseSvgNode, loader);
+
+    if (loader->svgParse->global.w == 0) loader->svgParse->global.w = loader->svgParse->node->node.doc.w;
+    if (loader->svgParse->global.h == 0) loader->svgParse->global.h = loader->svgParse->node->node.doc.h;
 
     return loader->svgParse->node;
 }


### PR DESCRIPTION
The 'loader->svgParse->global' variable was uninitialized when no viewBox attribute
was set. If gradient was applied, the division by zero occured and no gradient was drawn.

before:
![before](https://user-images.githubusercontent.com/67589014/120942140-24cd0500-c727-11eb-9947-a0d1f9ad9d21.PNG)


after:
![after](https://user-images.githubusercontent.com/67589014/120942143-28608c00-c727-11eb-9b86-2126eb293161.PNG)
