### PR TITLE
sw_engine: fixing the composition for canvas width != canvas stride

### DIFF
--- a/src/lib/sw_engine/tvgSwRenderer.cpp
+++ b/src/lib/sw_engine/tvgSwRenderer.cpp
@@ -455,7 +455,7 @@ Compositor* SwRenderer::target(const RenderRegion& region)
         if (!cmp->compositor) goto err;
 
         //SwImage, Optimize Me: Surface size from MainSurface(WxH) to Parameter W x H
-        cmp->compositor->image.data = (uint32_t*) malloc(sizeof(uint32_t) * surface->w * surface->h);
+        cmp->compositor->image.data = (uint32_t*) malloc(sizeof(uint32_t) * surface->stride * surface->h);
         if (!cmp->compositor->image.data) goto err;
         compositors.push(cmp);
     }
@@ -475,7 +475,7 @@ Compositor* SwRenderer::target(const RenderRegion& region)
     cmp->compositor->bbox.min.y = y;
     cmp->compositor->bbox.max.x = x + w;
     cmp->compositor->bbox.max.y = y + h;
-    cmp->compositor->image.w = surface->w;
+    cmp->compositor->image.w = surface->stride;
     cmp->compositor->image.h = surface->h;
 
     //We know partial clear region


### PR DESCRIPTION
When canvas width was smaller than its stride and a composition is used,
the plots were drawn incorrectly. This is fixed by setting the image width
(image from a compositor) to be equal to the surface stride, instead of its width.
The image data are now allocated accordingly the fixed image width.

before:
![before_stride](https://user-images.githubusercontent.com/67589014/121101236-be65e680-c7fb-11eb-8485-39edaa9f6d17.PNG)


after:
![after_stride](https://user-images.githubusercontent.com/67589014/121101245-c160d700-c7fb-11eb-95e4-a52737c86315.PNG)
