### PR TITLE
svg_loader: support stroke gradient

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -2388,18 +2388,18 @@ static SvgStyleGradient* _gradientDup(Array<SvgStyleGradient*>* gradients, const
 }
 
 
-static void _updateGradient(SvgNode* node, Array<SvgStyleGradient*>* gradidents)
+static void _updateGradient(SvgNode* node, Array<SvgStyleGradient*>* gradients)
 {
     if (node->child.count > 0) {
         auto child = node->child.data;
         for (uint32_t i = 0; i < node->child.count; ++i, ++child) {
-            _updateGradient(*child, gradidents);
+            _updateGradient(*child, gradients);
         }
     } else {
         if (node->style->fill.paint.url) {
-            node->style->fill.paint.gradient = _gradientDup(gradidents, node->style->fill.paint.url);
+            node->style->fill.paint.gradient = _gradientDup(gradients, node->style->fill.paint.url);
         } else if (node->style->stroke.paint.url) {
-            //node->style->stroke.paint.gradient = _gradientDup(gradList, node->style->stroke.paint.url);
+            node->style->stroke.paint.gradient = _gradientDup(gradients, node->style->stroke.paint.url);
         }
     }
 }

--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -195,7 +195,7 @@ static void _applyProperty(SvgNode* node, Shape* vg, float vx, float vy, float v
     if (style->fill.paint.none) {
         //Do nothing
     } else if (style->fill.paint.gradient) {
-         if (!style->fill.paint.gradient->userSpace) vg->bounds(&vx, &vy, &vw, &vh);
+        if (!style->fill.paint.gradient->userSpace) vg->bounds(&vx, &vy, &vw, &vh);
 
         if (style->fill.paint.gradient->type == SvgGradientType::Linear) {
              auto linear = _applyLinearGradientProperty(style->fill.paint.gradient, vg, vx, vy, vw, vh);
@@ -232,7 +232,15 @@ static void _applyProperty(SvgNode* node, Shape* vg, float vx, float vy, float v
     if (style->stroke.paint.none) {
         //Do nothing
     } else if (style->stroke.paint.gradient) {
-        //TODO: Support gradient style
+        if (!style->stroke.paint.gradient->userSpace) vg->bounds(&vx, &vy, &vw, &vh);
+
+        if (style->stroke.paint.gradient->type == SvgGradientType::Linear) {
+             auto linear = _applyLinearGradientProperty(style->stroke.paint.gradient, vg, vx, vy, vw, vh);
+             vg->stroke(move(linear));
+        } else if (style->stroke.paint.gradient->type == SvgGradientType::Radial) {
+             auto radial = _applyRadialGradientProperty(style->stroke.paint.gradient, vg, vx, vy, vw, vh);
+             vg->stroke(move(radial));
+        }
     } else if (style->stroke.paint.url) {
         //TODO: Apply the color pointed by url
     } else if (style->stroke.paint.curColor) {


### PR DESCRIPTION
The loader was ready to handle the gradient stroke, but there was no API to support
it when the loader was introduced. We've had this API for a while already, so
its call has been added.

code:
```
<svg viewBox="0 0 300 300">
 <defs>
   <radialGradient id="phpg" gradientUnits="userSpaceOnUse" cx="250" cy="0" r="300">
     <stop offset="0.3" stop-color="#CCF"/>
     <stop offset="0.6" stop-color="#334"/>
   </radialGradient>
 </defs>
 <ellipse stroke="url(#phpg)" stroke-width="18" fill="#000" cx="150" cy="80" rx="143" ry="73"/>
</svg>
```

before:
![before](https://user-images.githubusercontent.com/67589014/121435405-1b3dda00-c97f-11eb-937d-7a0b61912617.PNG)

after:
![after](https://user-images.githubusercontent.com/67589014/121435416-21cc5180-c97f-11eb-9d44-c19fa7d1fac3.PNG)
