### PR TITLE
examples: revise examples

### DIFF
--- a/src/examples/CustomTransform.cpp
+++ b/src/examples/CustomTransform.cpp
@@ -25,18 +25,15 @@
 /************************************************************************/
 /* Drawing Commands                                                     */
 /************************************************************************/
-tvg::Shape* pShape = nullptr;
 
-void tvgDrawCmds(tvg::Canvas* canvas)
+void tvgUpdateCmds(tvg::Canvas* canvas, float progress)
 {
     if (!canvas) return;
 
-    //Shape1
-    auto shape = tvg::Shape::gen();
+    if (canvas->clear() != tvg::Result::Success) return;
 
-    /* Acquire shape pointer to access it again.
-       instead, you should consider not to interrupt this pointer life-cycle. */
-    pShape = shape.get();
+    //Shape
+    auto shape = tvg::Shape::gen();
 
     shape->moveTo(0, -114.5);
     shape->lineTo(54, -5.5);
@@ -52,16 +49,6 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     shape->fill(0, 0, 255, 255);
     shape->stroke(3);
     shape->stroke(255, 255, 255, 255);
-    if (canvas->push(move(shape)) != tvg::Result::Success) return;
-}
-
-void tvgUpdateCmds(tvg::Canvas* canvas, float progress)
-{
-    if (!canvas) return;
-
-    /* Update shape directly.
-       You can update only necessary properties of this shape,
-       while retaining other properties. */
 
     //Transform Matrix
     tvg::Matrix m = {1, 0, 0, 0, 1, 0, 0, 0, 1};
@@ -97,10 +84,9 @@ void tvgUpdateCmds(tvg::Canvas* canvas, float progress)
     m.e13 = progress * 300.0f + 300.0f;
     m.e23 = progress * -100.0f + 300.0f;
 
-    pShape->transform(m);
+    shape->transform(m);
 
-    //Update shape for drawing (this may work asynchronously)
-    canvas->update(pShape);
+    canvas->push(move(shape));
 }
 
 
@@ -120,7 +106,7 @@ void tvgSwTest(uint32_t* buffer)
        When this shape is into the canvas list, the shape could update & prepare
        internal data asynchronously for coming rendering.
        Canvas keeps this shape node unless user call canvas->clear() */
-    tvgDrawCmds(swCanvas.get());
+    tvgUpdateCmds(swCanvas.get(), 0);
 }
 
 void transitSwCb(Elm_Transit_Effect *effect, Elm_Transit* transit, double progress)
@@ -159,7 +145,7 @@ void initGLview(Evas_Object *obj)
        When this shape is into the canvas list, the shape could update & prepare
        internal data asynchronously for coming rendering.
        Canvas keeps this shape node unless user call canvas->clear() */
-    tvgDrawCmds(glCanvas.get());
+    tvgUpdateCmds(glCanvas.get(), 0);
 }
 
 void drawGLview(Evas_Object *obj)

--- a/src/examples/GradientStroke.cpp
+++ b/src/examples/GradientStroke.cpp
@@ -25,7 +25,6 @@
 /************************************************************************/
 /* Drawing Commands                                                     */
 /************************************************************************/
-tvg::Shape* pShape = nullptr;
 
 void tvgDrawCmds(tvg::Canvas* canvas)
 {
@@ -119,11 +118,9 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     fill5->linear(150, 450, 450, 750);
     fill5->colorStops(colorStops3, 2);
     shape5->fill(move(fill5));
-    pShape = shape5.get();
+    shape5->scale(0.8);
 
     if (canvas->push(move(shape5)) != tvg::Result::Success) return;
-    pShape->scale(0.8);
-    if (canvas->update(pShape) != tvg::Result::Success) return;
 }
 
 

--- a/src/examples/SceneTransform.cpp
+++ b/src/examples/SceneTransform.cpp
@@ -25,16 +25,15 @@
 /************************************************************************/
 /* Drawing Commands                                                     */
 /************************************************************************/
-tvg::Scene* pScene1 = nullptr;
-tvg::Scene* pScene2 = nullptr;
 
-void tvgDrawCmds(tvg::Canvas* canvas)
+void tvgUpdateCmds(tvg::Canvas* canvas, float progress)
 {
     if (!canvas) return;
 
+    if (canvas->clear() != tvg::Result::Success) return;
+
     //Create a Scene1
     auto scene = tvg::Scene::gen();
-    pScene1 = scene.get();
     scene->reserve(3);   //reserve 3 shape nodes (optional)
 
     //Prepare Round Rectangle (Scene1)
@@ -59,10 +58,10 @@ void tvgDrawCmds(tvg::Canvas* canvas)
 
     scene->translate(350, 350);
     scene->scale(0.5);
+    scene->rotate(360 * progress);
 
     //Create Scene2
     auto scene2 = tvg::Scene::gen();
-    pScene2 = scene2.get();
     scene2->reserve(2);   //reserve 2 shape nodes (optional)
 
     //Star (Scene2)
@@ -104,27 +103,13 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     scene2->push(move(shape5));
 
     scene2->translate(500, 350);
+    scene2->rotate(360 * progress);
 
     //Push scene2 onto the scene
     scene->push(move(scene2));
 
     //Draw the Scene onto the Canvas
     canvas->push(move(scene));
-}
-
-void tvgUpdateCmds(tvg::Canvas* canvas, float progress)
-{
-    if (!canvas) return;
-
-    /* Update scene directly.
-       You can update only necessary properties of this scene,
-       while retaining other properties. */
-
-    pScene1->rotate(360 * progress);
-    pScene2->rotate(360 * progress);
-
-    //Update shape for drawing (this may work asynchronously)
-    canvas->update(pScene1);
 }
 
 
@@ -144,7 +129,7 @@ void tvgSwTest(uint32_t* buffer)
        When this shape is into the canvas list, the shape could update & prepare
        internal data asynchronously for coming rendering.
        Canvas keeps this shape node unless user call canvas->clear() */
-    tvgDrawCmds(swCanvas.get());
+    tvgUpdateCmds(swCanvas.get(), 0);
 }
 
 void transitSwCb(Elm_Transit_Effect *effect, Elm_Transit* transit, double progress)
@@ -183,7 +168,7 @@ void initGLview(Evas_Object *obj)
        When this shape is into the canvas list, the shape could update & prepare
        internal data asynchronously for coming rendering.
        Canvas keeps this shape node unless user call canvas->clear() */
-    tvgDrawCmds(glCanvas.get());
+    tvgUpdateCmds(glCanvas.get(), 0);
 }
 
 void drawGLview(Evas_Object *obj)

--- a/src/examples/Stacking.cpp
+++ b/src/examples/Stacking.cpp
@@ -110,7 +110,6 @@ void tvgUpdateCmds(tvg::Canvas* canvas)
             canvas->push(unique_ptr<tvg::Shape>((tvg::Shape*)paints[1]));
             canvas->push(unique_ptr<tvg::Shape>((tvg::Shape*)paints[2]));
             break;
-
     }
 
     ++order;

--- a/src/examples/Transform.cpp
+++ b/src/examples/Transform.cpp
@@ -25,73 +25,46 @@
 /************************************************************************/
 /* Drawing Commands                                                     */
 /************************************************************************/
-tvg::Shape* pShape = nullptr;
-tvg::Shape* pShape2 = nullptr;
-tvg::Shape* pShape3 = nullptr;
 
-void tvgDrawCmds(tvg::Canvas* canvas)
+void tvgUpdateCmds(tvg::Canvas* canvas, float progress)
 {
     if (!canvas) return;
 
+    if (canvas->clear() != tvg::Result::Success) return;
+
     //Shape1
     auto shape = tvg::Shape::gen();
-
-    /* Acquire shape pointer to access it again.
-       instead, you should consider not to interrupt this pointer life-cycle. */
-    pShape = shape.get();
-
     shape->appendRect(-285, -300, 200, 200, 0, 0);
     shape->appendRect(-185, -200, 300, 300, 100, 100);
     shape->appendCircle(115, 100, 100, 100);
     shape->appendCircle(115, 200, 170, 100);
     shape->fill(255, 255, 255, 255);
     shape->translate(385, 400);
+    shape->scale(1 - 0.75 * progress);
+    shape->rotate(360 * progress);
+
     if (canvas->push(move(shape)) != tvg::Result::Success) return;
 
     //Shape2
     auto shape2 = tvg::Shape::gen();
-    pShape2 = shape2.get();
     shape2->appendRect(-50, -50, 100, 100, 0, 0);
     shape2->fill(0, 255, 255, 255);
     shape2->translate(400, 400);
+    shape2->rotate(360 * progress);
+    shape2->translate(400 + progress * 300, 400);
     if (canvas->push(move(shape2)) != tvg::Result::Success) return;
 
     //Shape3
     auto shape3 = tvg::Shape::gen();
-    pShape3 = shape3.get();
 
     /* Look, how shape3's origin is different with shape2
        The center of the shape is the anchor point for transformation. */
     shape3->appendRect(100, 100, 150, 50, 20, 20);
     shape3->fill(255, 0, 255, 255);
     shape3->translate(400, 400);
+    shape3->rotate(-360 * progress);
+    shape3->scale(0.5 + progress);
     if (canvas->push(move(shape3)) != tvg::Result::Success) return;
-}
-
-void tvgUpdateCmds(tvg::Canvas* canvas, float progress)
-{
-    if (!canvas) return;
-
-    /* Update shape directly.
-       You can update only necessary properties of this shape,
-       while retaining other properties. */
-
-    //Update Shape1
-    pShape->scale(1 - 0.75 * progress);
-    pShape->rotate(360 * progress);
-
-    //Update shape for drawing (this may work asynchronously)
-    if (canvas->update(pShape) != tvg::Result::Success) return;
-
-    //Update Shape2
-    pShape2->rotate(360 * progress);
-    pShape2->translate(400 + progress * 300, 400);
-    if (canvas->update(pShape2) != tvg::Result::Success) return;
-
-    //Update Shape3
-    pShape3->rotate(-360 * progress);
-    pShape3->scale(0.5 + progress);
-    if (canvas->update(pShape3) != tvg::Result::Success) return;
 }
 
 
@@ -111,7 +84,7 @@ void tvgSwTest(uint32_t* buffer)
        When this shape is into the canvas list, the shape could update & prepare
        internal data asynchronously for coming rendering.
        Canvas keeps this shape node unless user call canvas->clear() */
-    tvgDrawCmds(swCanvas.get());
+    tvgUpdateCmds(swCanvas.get(), 0);
 }
 
 void transitSwCb(Elm_Transit_Effect *effect, Elm_Transit* transit, double progress)
@@ -150,7 +123,7 @@ void initGLview(Evas_Object *obj)
        When this shape is into the canvas list, the shape could update & prepare
        internal data asynchronously for coming rendering.
        Canvas keeps this shape node unless user call canvas->clear() */
-    tvgDrawCmds(glCanvas.get());
+    tvgUpdateCmds(glCanvas.get(), 0);
 }
 
 void drawGLview(Evas_Object *obj)


### PR DESCRIPTION
remove the show-cases that accessing the raw memory from the unique_ptr

we don't like to use those cases without any inevitable excuse.