### PR TITLE
tvg_loader: Fixed missing 'this->' keyword

### DIFF
--- a/src/loaders/tvg/tvgTvgLoader.cpp
+++ b/src/loaders/tvg/tvgTvgLoader.cpp
@@ -88,8 +88,8 @@ bool TvgLoader::open(const char *data, uint32_t size)
 {
     //TODO: verify memory leak if open() is called multiple times.
 
-    pointer = data;
-    size = size;
+    this->pointer = data;
+    this->size = size;
 
     //FIXME: verify TVG format here.
 


### PR DESCRIPTION
Fixed missed 'this->' in `tvgTvgLoader.cpp`