### PR TITLE
loader_mgr: FileTypes order changed

### DIFF
--- a/src/lib/tvgLoaderMgr.h
+++ b/src/lib/tvgLoaderMgr.h
@@ -24,7 +24,7 @@
 
 #include "tvgLoader.h"
 
-enum class FileType { Svg = 0, Raw, Png, Tvg, Unknown };
+enum class FileType { Tvg = 0, Svg, Raw, Png, Unknown };
 
 struct LoaderMgr
 {


### PR DESCRIPTION
`FileType` order was changed in `tvgLoaderMgr.h` to move Tvg at the beginning.

When raw data loading [`LoaderMgr::loader(data, size)`], loaders are tried
one by one (in order according to the FileType enum) until the correct loader
is found.
When using EFL and load edj, multiple loader(data, size) with tvg data may be
called. This change should improve performance in that case.

Please merge after https://github.com/Samsung/thorvg/pull/437