### PR TITLE
draft: loaders: Async and sync loader

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -986,6 +986,7 @@ public:
 
     /**
      * @brief Loads a picture data from a memory block of a given size.
+     * Function allows to choose whether the loading should be asynchronous (default) or synchronous.
      *
      * @param[in] data A pointer to a memory location where the content of the picture file is stored.
      * @param[in] size The size in bytes of the memory occupied by the @p data.
@@ -997,7 +998,7 @@ public:
      *
      * @note: This api supports only SVG format
      */
-    Result load(const char* data, uint32_t size) noexcept;
+    Result load(const char* data, uint32_t size, bool async = true) noexcept;
 
     /**
      * @brief Resize the picture content with the given width and height.

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -1676,6 +1676,7 @@ TVG_EXPORT Tvg_Result tvg_picture_load_raw(Tvg_Paint* paint, uint32_t *data, uin
 * \param[in] paint Tvg_Paint pointer
 * \param[in] data raw data pointer
 * \param[in] size of data
+* \param[in] async if true load asynchronously, otherwise synchronously
 *
 * \return Tvg_Result return value
 * \retval TVG_RESULT_SUCCESS: if ok.
@@ -1683,7 +1684,7 @@ TVG_EXPORT Tvg_Result tvg_picture_load_raw(Tvg_Paint* paint, uint32_t *data, uin
 *
 * \warning Please do not use it, this API is not official one. It can be modified in the next version.
 */
-TVG_EXPORT Tvg_Result tvg_picture_load_data(Tvg_Paint* paint, const char *data, uint32_t size);
+TVG_EXPORT Tvg_Result tvg_picture_load_data(Tvg_Paint* paint, const char *data, uint32_t size, bool async);
 
 
 /*!

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -462,10 +462,10 @@ TVG_EXPORT Tvg_Result tvg_picture_load_raw(Tvg_Paint* paint, uint32_t *data, uin
 }
 
 
-TVG_EXPORT Tvg_Result tvg_picture_load_data(Tvg_Paint* paint, const char *data, uint32_t size)
+TVG_EXPORT Tvg_Result tvg_picture_load_data(Tvg_Paint* paint, const char *data, uint32_t size, bool async)
 {
     if (!paint) return TVG_RESULT_INVALID_ARGUMENT;
-    return (Tvg_Result) reinterpret_cast<Picture*>(paint)->load(data, size);
+    return (Tvg_Result) reinterpret_cast<Picture*>(paint)->load(data, size, async);
 }
 
 

--- a/src/lib/sw_engine/tvgSwRenderer.cpp
+++ b/src/lib/sw_engine/tvgSwRenderer.cpp
@@ -573,7 +573,7 @@ void* SwRenderer::prepareCommon(SwTask* task, const RenderTransform* transform, 
     task->bbox.max.y = min(static_cast<SwCoord>(surface->h), static_cast<SwCoord>(vport.y + vport.h));
 
     tasks.push(task);
-    TaskScheduler::request(task);
+    TaskScheduler::request(task, true);
 
     return task;
 }

--- a/src/lib/tvgLoader.h
+++ b/src/lib/tvgLoader.h
@@ -43,7 +43,7 @@ public:
     virtual bool open(const string& path) { /* Not supported */ return false; };
     virtual bool open(const char* data, uint32_t size) { /* Not supported */ return false; };
     virtual bool open(const uint32_t* data, uint32_t w, uint32_t h, bool copy) { /* Not supported */ return false; };
-    virtual bool read() = 0;
+    virtual bool read(bool async) = 0;
     virtual bool close() = 0;
     virtual const uint32_t* pixels() { return nullptr; };
     virtual unique_ptr<Scene> scene() { return nullptr; };

--- a/src/lib/tvgPicture.cpp
+++ b/src/lib/tvgPicture.cpp
@@ -53,11 +53,11 @@ Result Picture::load(const std::string& path) noexcept
 }
 
 
-Result Picture::load(const char* data, uint32_t size) noexcept
+Result Picture::load(const char* data, uint32_t size, bool async /*=true*/) noexcept
 {
     if (!data || size <= 0) return Result::InvalidArguments;
 
-    return pImpl->load(data, size);
+    return pImpl->load(data, size, async);
 }
 
 

--- a/src/lib/tvgPictureImpl.h
+++ b/src/lib/tvgPictureImpl.h
@@ -169,18 +169,18 @@ struct Picture::Impl
         if (loader) loader->close();
         loader = LoaderMgr::loader(path);
         if (!loader) return Result::NonSupport;
-        if (!loader->read()) return Result::Unknown;
+        if (!loader->read(true)) return Result::Unknown;
         w = loader->w;
         h = loader->h;
         return Result::Success;
     }
 
-    Result load(const char* data, uint32_t size)
+    Result load(const char* data, uint32_t size, bool async)
     {
         if (loader) loader->close();
         loader = LoaderMgr::loader(data, size);
         if (!loader) return Result::NonSupport;
-        if (!loader->read()) return Result::Unknown;
+        if (!loader->read(async)) return Result::Unknown;
         w = loader->w;
         h = loader->h;
         return Result::Success;

--- a/src/lib/tvgTaskScheduler.cpp
+++ b/src/lib/tvgTaskScheduler.cpp
@@ -139,10 +139,10 @@ public:
         }
     }
 
-    void request(Task* task)
+    void request(Task* task, bool async)
     {
         //Async
-        if (threadCnt > 0) {
+        if (async && threadCnt > 0) {
             task->prepare();
             auto i = idx++;
             for (unsigned n = 0; n < threadCnt; ++n) {
@@ -179,9 +179,9 @@ void TaskScheduler::term()
 }
 
 
-void TaskScheduler::request(Task* task)
+void TaskScheduler::request(Task* task, bool async)
 {
-    if (inst) inst->request(task);
+    if (inst) inst->request(task, async);
 }
 
 

--- a/src/lib/tvgTaskScheduler.h
+++ b/src/lib/tvgTaskScheduler.h
@@ -36,7 +36,7 @@ struct TaskScheduler
     static unsigned threads();
     static void init(unsigned threads);
     static void term();
-    static void request(Task* task);
+    static void request(Task* task, bool async);
 };
 
 struct Task

--- a/src/loaders/png/tvgPngLoader.cpp
+++ b/src/loaders/png/tvgPngLoader.cpp
@@ -51,7 +51,7 @@ bool PngLoader::open(const string& path)
     return true;
 }
 
-bool PngLoader::read()
+bool PngLoader::read(bool async)
 {
     png_bytep buffer;
     image->format = PNG_FORMAT_BGRA;

--- a/src/loaders/png/tvgPngLoader.h
+++ b/src/loaders/png/tvgPngLoader.h
@@ -36,7 +36,7 @@ public:
 
     using Loader::open;
     bool open(const string& path) override;
-    bool read() override;
+    bool read(bool async) override;
     bool close() override;
 
     const uint32_t* pixels() override;

--- a/src/loaders/raw/tvgRawLoader.cpp
+++ b/src/loaders/raw/tvgRawLoader.cpp
@@ -60,7 +60,7 @@ bool RawLoader::open(const uint32_t* data, uint32_t w, uint32_t h, bool copy)
 }
 
 
-bool RawLoader::read()
+bool RawLoader::read(bool async)
 {
     return true;
 }

--- a/src/loaders/raw/tvgRawLoader.h
+++ b/src/loaders/raw/tvgRawLoader.h
@@ -32,7 +32,7 @@ public:
 
     using Loader::open;
     bool open(const uint32_t* data, uint32_t w, uint32_t h, bool copy) override;
-    bool read() override;
+    bool read(bool async) override;
     bool close() override;
 
     const uint32_t* pixels() override;

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -2660,19 +2660,19 @@ bool SvgLoader::open(const string& path)
 }
 
 
-bool SvgLoader::read()
+bool SvgLoader::read(bool async)
 {
     if (!content || size == 0) return false;
 
-    TaskScheduler::request(this);
+    this->async = async;
+    TaskScheduler::request(this, async);
 
     return true;
 }
 
-
 bool SvgLoader::close()
 {
-    this->done();
+    if (async) this->done();
 
     if (loaderData.svgParse) {
         free(loaderData.svgParse);
@@ -2692,10 +2692,9 @@ bool SvgLoader::close()
     return true;
 }
 
-
 unique_ptr<Scene> SvgLoader::scene()
 {
-    this->done();
+    if (async) this->done();
     if (root) return move(root);
     else return nullptr;
 }

--- a/src/loaders/svg/tvgSvgLoader.h
+++ b/src/loaders/svg/tvgSvgLoader.h
@@ -31,6 +31,7 @@ public:
     string filePath;
     const char* content = nullptr;
     uint32_t size = 0;
+    bool async = false;
 
     SvgLoaderData loaderData;
     unique_ptr<Scene> root;
@@ -43,7 +44,7 @@ public:
     bool open(const char* data, uint32_t size) override;
 
     bool header();
-    bool read() override;
+    bool read(bool async) override;
     bool close() override;
     void run(unsigned tid) override;
 

--- a/src/loaders/tvg/tvgTvgLoader.cpp
+++ b/src/loaders/tvg/tvgTvgLoader.cpp
@@ -96,18 +96,19 @@ bool TvgLoader::open(const char *data, uint32_t size)
     return true;
 }
 
-bool TvgLoader::read()
+bool TvgLoader::read(bool async)
 {
     if (!pointer || size == 0) return false;
 
-    TaskScheduler::request(this);
+    this->async = async;
+    TaskScheduler::request(this, async);
 
     return true;
 }
 
 bool TvgLoader::close()
 {
-    this->done();
+    if (async) this->done();
     clearBuffer();
     return true;
 }
@@ -121,7 +122,7 @@ void TvgLoader::run(unsigned tid)
 
 unique_ptr<Scene> TvgLoader::scene()
 {
-    this->done();
+    if (async) this->done();
     if (root) return move(root);
     return nullptr;
 }

--- a/src/loaders/tvg/tvgTvgLoader.h
+++ b/src/loaders/tvg/tvgTvgLoader.h
@@ -31,6 +31,7 @@ public:
     char* buffer = nullptr;
     const char* pointer = nullptr;
     uint32_t size = 0;
+    bool async = false;
 
     unique_ptr<Scene> root = nullptr;
 
@@ -39,7 +40,8 @@ public:
     using Loader::open;
     bool open(const string &path) override;
     bool open(const char *data, uint32_t size) override;
-    bool read() override;
+
+    bool read(bool async) override;
     bool close() override;
 
     void run(unsigned tid) override;


### PR DESCRIPTION
This patch introduced synchronous loading possibility.

@API Changes:
Result Picture::load(const char* data, uint32_t size, bool async /*=true*/) noexcept
