### PR TITLE
svg_loader: gradient update takes into account a stroke and a fill

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -2398,7 +2398,8 @@ static void _updateGradient(SvgNode* node, Array<SvgStyleGradient*>* gradients)
     } else {
         if (node->style->fill.paint.url) {
             node->style->fill.paint.gradient = _gradientDup(gradients, node->style->fill.paint.url);
-        } else if (node->style->stroke.paint.url) {
+        }
+        if (node->style->stroke.paint.url) {
             node->style->stroke.paint.gradient = _gradientDup(gradients, node->style->stroke.paint.url);
         }
     }


### PR DESCRIPTION
For shapes with a grad fill and a grad stroke only the fill was drawn.
After this fix both can have a valid gradient.

svg example:
```
<svg viewBox="0 0 100 100">
  <defs>
    <linearGradient id="gradientFill" x1="0" y1="0" x2="0" y2="1">
      <stop offset="0%" stop-color="#f00" />
      <stop offset="100%" stop-color="#00f" />
    </linearGradient>
    <linearGradient id="gradientStroke" x1="0" y1="0" x2="1" y2="1">
      <stop offset="0%" stop-color="#0f0" />
      <stop offset="100%" stop-color="#f0f" />
    </linearGradient>
  </defs>
  <circle cx="50" cy="50" r="40" fill="url(#gradientFill)" stroke-width="30"  stroke="url(#gradientStroke)"/>
</svg>


```

before:
![before_gr](https://user-images.githubusercontent.com/67589014/121963313-38e9b580-cd6a-11eb-8548-bde13b80a32e.PNG)

after:
![after_gr](https://user-images.githubusercontent.com/67589014/121963332-3f782d00-cd6a-11eb-850a-0fb0b7b8e313.PNG)
