### PR TITLE
svg_loader: adding check if stroke-dasharray attribute != none

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -236,6 +236,8 @@ _PARSE_TAG(SvgFillRule, fillRule, FillRule, fillRuleTags, SvgFillRule::Winding)
 static inline void
 _parseDashArray(const char *str, SvgDash* dash)
 {
+    if (!strncmp(str, "none", 4)) return;
+
     char *end = nullptr;
 
     while (*str) {


### PR DESCRIPTION
The stroke-dasharray value equal to "none" was causing a segfault
during a conversion to float. Fixed now.

sample code:
```
<svg viewBox="0 0 30 10" xmlns="http://www.w3.org/2000/svg">

  <line x1="0" y1="3" x2="30" y2="3" stroke="black"
          stroke-dasharray="none" />
</svg>
```