### PR TITLE
svg_loader: after reading an unsupported style attribute no other val…

### DIFF
--- a/src/loaders/svg/tvgXmlParser.cpp
+++ b/src/loaders/svg/tvgXmlParser.cpp
@@ -503,7 +503,14 @@ bool simpleXmlParseW3CAttribute(const char* buf, simpleXMLAttributeCb func, cons
         }
 
         if (key[0]) {
-            if (!func((void*)data, key, val)) return false;
+
+#ifdef THORVG_LOG_ENABLED
+            if (!func((void*)data, key, val)) {
+                if (!_isIgnoreUnsupportedLogAttributes(key, val)) printf("SVG: Unsupported attributes used [Elements type: %s][Id : %s][Attribute: %s][Value: %s]\n", simpleXmlNodeTypeToString(((SvgLoaderData*)data)->svgParse->node->type).c_str(), ((SvgLoaderData*)data)->svgParse->node->id ? ((SvgLoaderData*)data)->svgParse->node->id->c_str() : "NO_ID", key, val ? val : "NONE");
+            }
+#else
+            func((void*)data, key, val);
+#endif
         }
 
         buf = next + 1;


### PR DESCRIPTION
…ues were read

After finding an unsupported style attribute the log is printed (on request)
and processing of other values continues.

code:
```
<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
  <defs
     id="defs4">
    <linearGradient
       id="linearGradient1"
       x1="0"
       y1="0"
       x2="0.2"
       y2="0.2"
       spreadMethod="reflect">
      <stop
         style="test:test_value;stop-color:#ffff00;stop-opacity:0.3;"    <!-- PROBLEM -->
         offset="0"/>
      <stop
         style="stop-color:#0000ff;stop-opacity:1;"
         offset="1"/>
    </linearGradient>
  </defs>
  <rect x="0" y="0" width="100" height="100" fill="url(#linearGradient1)"/>
</svg>
```

before (the first color style is not loaded):
![before](https://user-images.githubusercontent.com/67589014/122237095-5714fa00-cebf-11eb-9260-60f6feeb0cd5.PNG)

after:
![after](https://user-images.githubusercontent.com/67589014/122237110-5aa88100-cebf-11eb-86c7-cc33450531d5.PNG)

