### PR TITLE
svg_loader: fixing color parsing

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -275,7 +275,7 @@ static unsigned char _parserColor(const char* value, char** end)
 {
     float r;
 
-    r = svgUtilStrtof(value + 4, end);
+    r = svgUtilStrtof(value, end);
     *end = _skipSpace(*end, nullptr);
     if (**end == '%') r = 255 * r / 100;
     *end = _skipSpace(*end, nullptr);


### PR DESCRIPTION
For colors given in a style attribute in the format "rgb(rrr, ggg, bbb)"
a parsing was incorect. Now fixed.

code:
```
<svg height="300" width="300">
  <path d="M 0 0 h 200 v 200 z" style="fill: rgb(255, 155, 55);"/>
</svg>
```

before:
![before](https://user-images.githubusercontent.com/67589014/122307128-024aa100-cf0a-11eb-9a6c-ba9250d6ad42.PNG)

after:
![after](https://user-images.githubusercontent.com/67589014/122307132-05459180-cf0a-11eb-8ffb-d3cdf4f2b02e.PNG)
