### PR TITLE
svg_loader: key and value in the simpleXmlParseW3CAttribute needed to…

### DIFF
--- a/src/loaders/svg/tvgXmlParser.cpp
+++ b/src/loaders/svg/tvgXmlParser.cpp
@@ -503,6 +503,11 @@ bool simpleXmlParseW3CAttribute(const char* buf, simpleXMLAttributeCb func, cons
         }
 
         if (key[0]) {
+            key = const_cast<char*>(_simpleXmlSkipWhiteSpace(key, key + strlen(key)));
+            key[_simpleXmlUnskipWhiteSpace(key + strlen(key) , key) - key] = '\0';
+            val = const_cast<char*>(_simpleXmlSkipWhiteSpace(val, val + strlen(val)));
+            val[_simpleXmlUnskipWhiteSpace(val + strlen(val) , val) - val] = '\0';
+
             if (!func((void*)data, key, val)) return false;
         }
 


### PR DESCRIPTION
… be cleared out of spaces

code:
```
<svg height="200" width="400">
  <defs>
    <linearGradient id="linearGradient1">
      <stop offset="0.0" style="stop-color: rgb(255, 100, 100) ; stop-opacity: 1; test:tttt;"/>
      <stop offset="1.0" style="stop-color: rgb(255, 255, 0) ;"/>
    </linearGradient>
    <linearGradient xlink:href="#linearGradient1" id="linearGradient2" gradientUnits="userSpaceOnUse" x1="0" y1="0" x2="200" y2="200"/>
  </defs>
  <path d="M 0 0 h 200 v 200 z" style="fill: url(#linearGradient2);"/>
</svg>
```

before:
![before](https://user-images.githubusercontent.com/67589014/122308411-9c134d80-cf0c-11eb-9e15-6a12f1e99e36.PNG)

after:
![after](https://user-images.githubusercontent.com/67589014/122308426-a2092e80-cf0c-11eb-8e29-e727647114e5.PNG)
