### PR TITLE
common Scene: return FailedAllocation if it really failed at memory a…

### DIFF
--- a/src/lib/tvgScene.cpp
+++ b/src/lib/tvgScene.cpp
@@ -56,7 +56,7 @@ Result Scene::push(unique_ptr<Paint> paint) noexcept
 
 Result Scene::reserve(uint32_t size) noexcept
 {
-    pImpl->paints.reserve(size);
+    if (!pImpl->paints.reserve(size)) return Result::FailedAllocation;
 
     return Result::Success;
 }


### PR DESCRIPTION
…llocation.

Due to change of f0ecc67, the return type of reserve() is changed to bool,
which can return the result for the fail case.