### PR TITLE
svg_loader: radial gradient transformation support

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -1870,6 +1870,8 @@ static bool _attrParseRadialGradientNode(void* data, const char* key, const char
         grad->ref = _idFromHref(value);
     } else if (!strcmp(key, "gradientUnits") && !strcmp(value, "userSpaceOnUse")) {
         grad->userSpace = true;
+    } else if (!strcmp(key, "gradientTransform")) {
+        grad->transform = _parseTransformationMatrix(value);
     } else {
         return false;
     }

--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -114,8 +114,15 @@ static unique_ptr<RadialGradient> _applyRadialGradientProperty(SvgStyleGradient*
         g->radial->fy = g->radial->fy * rh + ry;
     }
 
-    //TODO: Radial gradient transformation is not yet supported.
-    //if (g->transform) {}
+    //TODO: Radial gradient transformation - all tests possible after rx/ry implementation
+    if (g->transform) {
+        auto cx = g->radial->cx * g->transform->e11 + g->radial->cy * g->transform->e12 + g->transform->e13;
+        g->radial->cy = g->radial->cx * g->transform->e21 + g->radial->cy * g->transform->e22 + g->transform->e23;
+        g->radial->cx = cx;
+
+        auto sx = sqrt(pow(g->transform->e11, 2) + pow(g->transform->e21, 2));
+        g->radial->r *= sx;
+    }
 
     //TODO: Tvg is not support to focal
     //if (g->radial->fx != 0 && g->radial->fy != 0) {


### PR DESCRIPTION
For now the gradient radius is scales like x-axis - it has to be changed
after issue #37 will be resolved.

issue #40 

code:
```
<svg viewBox="0 0 420 200">
  <radialGradient id="gradient1" gradientUnits="userSpaceOnUse"
      cx="100" cy="100" r="100" fx="100" fy="100"
      gradientTransform="scale(2) translate(-50, 0)">
    <stop offset="0%" stop-color="darkblue" />
    <stop offset="50%" stop-color="skyblue" />
    <stop offset="100%" stop-color="darkblue" />
  </radialGradient>

  <rect x="0" y="0" width="200" height="200" fill="url(#gradient1)" />
</svg>
```

before:
![image](https://user-images.githubusercontent.com/67589014/122482272-823b3e80-cfd0-11eb-8465-f6c34daa359b.png)

after:
![image](https://user-images.githubusercontent.com/67589014/122482289-89624c80-cfd0-11eb-9f26-e766035f948d.png)
