### PR TITLE
test Scene: Separate tests into SECTION()

### DIFF
--- a/test/testScene.cpp
+++ b/test/testScene.cpp
@@ -35,17 +35,20 @@ TEST_CASE("Pushing Paints Into Scene", "[tvgScene]")
 {
     auto scene = Scene::gen();
     REQUIRE(scene);
+    SECTION("Pushing Paints") {
+        REQUIRE(scene->push(move(Shape::gen())) == Result::Success);
+        REQUIRE(scene->push(move(Picture::gen())) == Result::Success);
+        REQUIRE(scene->push(move(Scene::gen())) == Result::Success);
+    }
 
-    REQUIRE(scene->push(move(Shape::gen())) == Result::Success);
-    REQUIRE(scene->push(move(Picture::gen())) == Result::Success);
-    REQUIRE(scene->push(move(Scene::gen())) == Result::Success);
+    SECTION("Pushing Null Pointer") {
+        REQUIRE(scene->push(nullptr) == Result::MemoryCorruption);
+    }
 
-    //Negative case 1
-    REQUIRE(scene->push(nullptr) == Result::MemoryCorruption);
-
-    //Negative case 2
-    std::unique_ptr<Shape> shape = nullptr;
-    REQUIRE(scene->push(move(shape)) == Result::MemoryCorruption);
+    SECTION("Pushing Invalid Object") {
+        std::unique_ptr<Shape> shape = nullptr;
+        REQUIRE(scene->push(move(shape)) == Result::MemoryCorruption);
+    }
 }
 
 TEST_CASE("Scene Memory Reservation", "[tvgScene]")
@@ -53,12 +56,16 @@ TEST_CASE("Scene Memory Reservation", "[tvgScene]")
     auto scene = Scene::gen();
     REQUIRE(scene);
 
-    REQUIRE(scene->reserve(10) == Result::Success);
-    REQUIRE(scene->reserve(1000) == Result::Success);
-    REQUIRE(scene->reserve(100) == Result::Success);
-    REQUIRE(scene->reserve(0) == Result::Success);
+    SECTION("Check Growth / Reduction") {
+        REQUIRE(scene->reserve(10) == Result::Success);
+        REQUIRE(scene->reserve(1000) == Result::Success);
+        REQUIRE(scene->reserve(100) == Result::Success);
+        REQUIRE(scene->reserve(0) == Result::Success);
+    }
 
-    REQUIRE(scene->reserve(-1) == Result::FailedAllocation);
+    SECTION("Too Big Size") {
+        REQUIRE(scene->reserve(-1) == Result::FailedAllocation);
+    }
 }
 
 TEST_CASE("Scene Clear", "[tvgScene]")


### PR DESCRIPTION
Split some tests into SECTIONs based on their type.
This improves the readability of TC.

And developer can run test in SECTION unit.
ex)
./build/test/tvgUnitTests "Pushing Paints Into Scene" -c "Pushing Null Pointer"