### PR TITLE
svg_loader SvgLoader: Copy the missing composite url

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -1587,6 +1587,9 @@ static void _copyAttr(SvgNode* to, const SvgNode* from)
     //Copy style attribute;
     memcpy(to->style, from->style, sizeof(SvgStyleProperty));
 
+    //Copy style composite attribute (clip-path, mask, ...)
+    if (from->style->comp.url) to->style->comp.url = new string(from->style->comp.url->c_str());
+
     //Copy node attribute
     switch (from->type) {
         case SvgNodeType::Circle: {


### PR DESCRIPTION
When copying an attribute, url information of stype's composite is overwritten with memcpy.
This causes double free by deleting the wrong string in freeNodeStyle.

issue: https://github.com/Samsung/thorvg/issues/455