### PR TITLE
svg_loader SvgLoader: Prevent invalid access

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -1621,7 +1621,7 @@ static void _copyAttr(SvgNode* to, const SvgNode* from)
             break;
         }
         case SvgNodeType::Path: {
-            to->node.path.path = new string(from->node.path.path->c_str());
+            if (from->node.path.path) to->node.path.path = new string(from->node.path.path->c_str());
             break;
         }
         case SvgNodeType::Polygon: {


### PR DESCRIPTION
If there is no path information, it is not copied.