### PR TITLE
sw_engine fill: fixing gradient calculations for 'repeat' spread value

### DIFF
--- a/src/lib/sw_engine/tvgSwFill.cpp
+++ b/src/lib/sw_engine/tvgSwFill.cpp
@@ -171,8 +171,8 @@ static inline uint32_t _clamp(const SwFill* fill, int32_t pos)
             break;
         }
         case FillSpread::Repeat: {
-            if (pos < 0) pos = GRADIENT_STOP_SIZE + pos;
             pos = pos % GRADIENT_STOP_SIZE;
+            if (pos < 0) pos = GRADIENT_STOP_SIZE + pos;
             break;
         }
         case FillSpread::Reflect: {
@@ -217,7 +217,7 @@ void fillFetchRadial(const SwFill* fill, uint32_t* dst, uint32_t y, uint32_t x, 
     auto detDelta = (rxryPlus + 1.0f) * inva;
     auto detDelta2 = 2.0f * inva;
 
-   for (uint32_t i = 0 ; i < len ; ++i) {
+    for (uint32_t i = 0 ; i < len ; ++i) {
         *dst = _pixel(fill, sqrt(det));
         ++dst;
         det += detDelta;


### PR DESCRIPTION
There was a call to the ctable element from outside its boundaries, because
the check was misplaced.

code:
```
<svg id="svg1" viewBox="0 0 200 200">
  
    <linearGradient id="grad" x1=".4" y1="0" x2=".6" y2="0" spreadMethod="repeat">
        <stop offset="0" stop-color="red"/>
        <stop offset="1" stop-color="black"/>
    </linearGradient>

    <rect id="rect1" x="20" y="20" width="160" height="160" fill="url(#grad)"/>

</svg>
```