### PR TITLE
svg_loader: correct parsing ColorStop offset values

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -141,10 +141,17 @@ static float _gradientToFloat(const SvgParser* svgParse, const char* str, SvgPar
 static float _toOffset(const char* str)
 {
     char* end = nullptr;
+    auto strEnd = str + strlen(str);
 
     float parsedValue = svgUtilStrtof(str, &end);
 
-    if (strstr(str, "%")) parsedValue = parsedValue / 100.0;
+    end = _skipSpace(end, nullptr);
+    auto ptr = strstr(str, "%");
+
+    if (ptr) {
+        parsedValue = parsedValue / 100.0;
+        if (end != ptr || (end + 1) != strEnd) return 0;
+    } else if (end != strEnd) return 0;
 
     return parsedValue;
 }


### PR DESCRIPTION
Values different from numbers and percentages should be ignored
and the default values should be applied (zeros).

We need this change to solve issue #457 (example e-stop-019.svg) - but there are also other problems with this svg file.

example:
```
<svg viewBox="0 0 200 200">
    <linearGradient id="grad" x1="0" y1="0" x2="1" y2="1">
        <stop offset="10%" stop-color="white"/>
        <stop offset="20% " stop-color="red"/>
        <stop offset="30% k" stop-color="blue"/>
        <stop offset="40%" stop-color="yellow"/>
        <stop offset="0.5m" stop-color="red"/>
        <stop offset="0.6 " stop-color="green"/>
        <stop offset="70%m" stop-color="black"/>
        <stop offset="80%" stop-color="white"/>
    </linearGradient>
    <rect x="20" y="20" width="160" height="160" fill="url(#grad)"/>
</svg>          
```

The results after applying #475 
before:
![before2](https://user-images.githubusercontent.com/67589014/122987174-969c8400-d3a0-11eb-96aa-d889c4131011.png)

after:
![after2](https://user-images.githubusercontent.com/67589014/122987187-9a300b00-d3a0-11eb-92cf-0c0f73146a68.png)
