### PR TITLE
infra: add memory sanitize option in meson

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('thorvg',
         'cpp',
-        default_options : ['buildtype=debugoptimized', 'werror=false', 'optimization=s'],
+        default_options : ['buildtype=debugoptimized', 'b_sanitize=none', 'werror=false', 'optimization=s'],
         version : '0.2.99',
         license : 'MIT')
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -6,9 +6,11 @@ if (cc.get_id() != 'msvc')
         compiler_flags += ['-mavx']
         message('Enable Advanced Vector Extension')
     endif
-    compiler_flags += ['-fno-exceptions', '-fno-rtti',
-                       '-fno-unwind-tables' , '-fno-asynchronous-unwind-tables',
-                       '-Woverloaded-virtual', '-Wno-unused-parameter']
+    if get_option('b_sanitize') == 'none'
+        compiler_flags += ['-fno-exceptions', '-fno-rtti',
+                           '-fno-unwind-tables' , '-fno-asynchronous-unwind-tables',
+                           '-Woverloaded-virtual', '-Wno-unused-parameter']
+    endif
 endif
 
 


### PR DESCRIPTION
for optimial library, we removed some peripheral information in default,
this breaks asan environment.

This patch changes it to make it both.

if you want to use asan, please change the meson option.

default is disabled.

example)
$meson . build -Db_sanitize=address
$meson . build -Db_sanitize=address,undefined