### PR TITLE
svg_loader SvgPath: Added corner case handling for flags of Arc

### DIFF
--- a/src/loaders/svg/tvgSvgPath.cpp
+++ b/src/loaders/svg/tvgSvgPath.cpp
@@ -54,15 +54,14 @@ static bool _parseNumber(char** content, float* number)
 
 static bool _parseFlag(char** content, int* number)
 {
-    char* end = NULL;
-    *number = strtol(*content, &end, 10);
-    //If the start of string is not number or a number was a float
-    if ((*content) == end || *end == '.') return false;
-    //If a flag has a different value than 0 or 1
-    if (*number != 0 && *number != 1) return false;
-    *content = _skipComma(end);
+    if (*(*content) != '0' && *(*content) != '1') return false;
+    *number = *(*content) - '0';
+    *content = _skipComma(*content + 1);
+    if (*(*content) == '.') return false;
+
     return true;
 }
+
 
 void _pathAppendArcTo(Array<PathCommand>* cmds, Array<Point>* pts, Point* cur, Point* curCtl, float x, float y, float rx, float ry, float angle, bool largeArc, bool sweep)
 {


### PR DESCRIPTION
It handles the case what the flag of the arc of the path is defined
without spaces or commas, such as 00, 01, 11 or 10.

issue: https://github.com/Samsung/thorvg/issues/455