### PR TITLE
common: fix compatibility issue for MSVC

### DIFF
--- a/src/lib/tvgShape.cpp
+++ b/src/lib/tvgShape.cpp
@@ -19,6 +19,9 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+
+#define _USE_MATH_DEFINES       //Math Constants are not defined in Standard C/C++.
+
 #include <limits>
 #include <float.h>
 #include <math.h>

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -19,6 +19,9 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+
+#define _USE_MATH_DEFINES       //Math Constants are not defined in Standard C/C++.
+
 #include <fstream>
 #include <float.h>
 #include <math.h>

--- a/src/loaders/svg/tvgSvgPath.cpp
+++ b/src/loaders/svg/tvgSvgPath.cpp
@@ -19,6 +19,9 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+
+#define _USE_MATH_DEFINES       //Math Constants are not defined in Standard C/C++.
+
 #include <math.h>
 #include <clocale>
 #include <ctype.h>


### PR DESCRIPTION
Math Constants are not defined in Standard C/C++

for this, we can use _USE_MATH_DEFINES before math headers.