### PR TITLE
common: introducing the composite API (getter)

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -266,7 +266,6 @@ public:
      * @param[in] method The method used to composite the source object with the target.
      *
      * @return Result::Success when succeed, Result::InvalidArguments otherwise.
-     *
      */
     Result composite(std::unique_ptr<Paint> target, CompositeMethod method) noexcept;
 
@@ -299,6 +298,17 @@ public:
      * @return The opacity value in the range [0 ~ 255], where 0 is completely transparent and 255 is opaque.
      */
     uint8_t opacity() const noexcept;
+
+    /**
+     * @brief Gets the composition target object and the composition method.
+     *
+     * @param[out] target The paint of the target object.
+     *
+     * @return The method used to composite the source object with the target.
+     *
+     * @BETA_API
+     */
+    CompositeMethod composite(const Paint** target) const noexcept;
 
     _TVG_DECLARE_ACCESSOR();
     _TVG_DECLARE_PRIVATE(Paint);

--- a/src/lib/tvgPaint.cpp
+++ b/src/lib/tvgPaint.cpp
@@ -308,6 +308,14 @@ Result Paint::composite(std::unique_ptr<Paint> target, CompositeMethod method) n
 }
 
 
+CompositeMethod Paint::composite(const Paint** target) const noexcept
+{
+    if (target) *target = pImpl->cmpTarget;
+
+    return pImpl->cmpMethod;
+}
+
+
 Result Paint::opacity(uint8_t o) noexcept
 {
     if (pImpl->opacity == o) return Result::Success;


### PR DESCRIPTION
The new API gets the composite method and the pointer to the composite
target of the given paint object.

I'd like to use this API in the saver module. 
The alternative would be to change the iterator and for example set the first node to be the composite target (if it exists) - in this approach I would need to mark the paint whether it is a comp target or not.