### PR TITLE
common: PaintType enum changed to identifier in Paint class

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -301,6 +301,7 @@ public:
     uint8_t opacity() const noexcept;
 
     _TVG_DECLARE_ACCESSOR();
+    _TVG_DECALRE_IDENTIFIER();
     _TVG_DECLARE_PRIVATE(Paint);
 };
 

--- a/src/lib/tvgCommon.h
+++ b/src/lib/tvgCommon.h
@@ -31,6 +31,9 @@ using namespace tvg;
 #define FILL_ID_LINEAR 0
 #define FILL_ID_RADIAL 1
 
+#define PAINT_ID_SHAPE   0
+#define PAINT_ID_SCENE   1
+#define PAINT_ID_PICTURE 2
 
 //for MSVC Compat
 #ifdef _MSC_VER

--- a/src/lib/tvgPaint.h
+++ b/src/lib/tvgPaint.h
@@ -27,8 +27,6 @@
 
 namespace tvg
 {
-    enum class PaintType { Shape = 0, Scene, Picture };
-
     struct StrategyMethod
     {
         virtual ~StrategyMethod() {}
@@ -48,7 +46,6 @@ namespace tvg
         uint32_t flag = RenderUpdateFlag::None;
         Paint* cmpTarget = nullptr;
         CompositeMethod cmpMethod = CompositeMethod::None;
-        PaintType type;
         uint8_t opacity = 255;
 
         ~Impl() {

--- a/src/lib/tvgPicture.cpp
+++ b/src/lib/tvgPicture.cpp
@@ -28,7 +28,7 @@
 
 Picture::Picture() : pImpl(new Impl(this))
 {
-    Paint::pImpl->type = PaintType::Picture;
+    _id = PAINT_ID_PICTURE;
     Paint::pImpl->method(new PaintMethod<Picture::Impl>(pImpl));
 }
 

--- a/src/lib/tvgScene.cpp
+++ b/src/lib/tvgScene.cpp
@@ -27,7 +27,7 @@
 
 Scene::Scene() : pImpl(new Impl())
 {
-    Paint::pImpl->type = PaintType::Scene;
+    _id = PAINT_ID_SCENE;
     Paint::pImpl->method(new PaintMethod<Scene::Impl>(pImpl));
 }
 

--- a/src/lib/tvgSceneImpl.h
+++ b/src/lib/tvgSceneImpl.h
@@ -60,7 +60,7 @@ struct Scene::Impl
 
         //If scene has several children or only scene, it may require composition.
         if (paints.count > 1) return true;
-        if (paints.count == 1 && (*paints.data)->pImpl->type == PaintType::Scene) return true;
+        if (paints.count == 1 && (*paints.data)->id() == PAINT_ID_SCENE) return true;
         return false;
     }
 

--- a/src/lib/tvgShape.cpp
+++ b/src/lib/tvgShape.cpp
@@ -38,7 +38,7 @@ constexpr auto PATH_KAPPA = 0.552284f;
 
 Shape :: Shape() : pImpl(new Impl(this))
 {
-    Paint::pImpl->type = PaintType::Shape;
+    _id = PAINT_ID_SHAPE;
     Paint::pImpl->method(new PaintMethod<Shape::Impl>(pImpl));
 }
 


### PR DESCRIPTION
The PaintType enum was used to set the paint type in the internal Paint
implementation. This solution is switched to an identifier with id() getter,
so that the information about the type can be reached from outside the Paint.

I'd like to use the information about the Paint type in the saver module.