### PR TITLE
tvg_loader: change values of flags

### DIFF
--- a/src/lib/tvgBinaryDesc.h
+++ b/src/lib/tvgBinaryDesc.h
@@ -80,18 +80,18 @@ struct tvgBlock
 #define TVG_SHAPE_COLOR_INDICATOR   (TvgIndicator)0x43 // Shape has color
 
 #define TVG_SHAPE_FILLRULE_INDICATOR    (TvgIndicator)0x44 // Shape FillRule
-#define TVG_SHAPE_FILLRULE_WINDING_FLAG      (TvgFlag)0x01 // FillRule::Winding
-#define TVG_SHAPE_FILLRULE_EVENODD_FLAG      (TvgFlag)0x02 // FillRule::EvenOdd
+#define TVG_SHAPE_FILLRULE_WINDING_FLAG      (TvgFlag)0x00 // FillRule::Winding
+#define TVG_SHAPE_FILLRULE_EVENODD_FLAG      (TvgFlag)0x01 // FillRule::EvenOdd
 
 #define TVG_SHAPE_STROKE_CAP_INDICATOR  (TvgIndicator)0x50 // Stroke StrokeCap
-#define TVG_SHAPE_STROKE_CAP_SQUARE_FLAG     (TvgFlag)0x01 // StrokeCap::Square
-#define TVG_SHAPE_STROKE_CAP_ROUND_FLAG      (TvgFlag)0x02 // StrokeCap::Round
-#define TVG_SHAPE_STROKE_CAP_BUTT_FLAG       (TvgFlag)0x03 // StrokeCap::Butt
+#define TVG_SHAPE_STROKE_CAP_SQUARE_FLAG     (TvgFlag)0x00 // StrokeCap::Square
+#define TVG_SHAPE_STROKE_CAP_ROUND_FLAG      (TvgFlag)0x01 // StrokeCap::Round
+#define TVG_SHAPE_STROKE_CAP_BUTT_FLAG       (TvgFlag)0x02 // StrokeCap::Butt
 
 #define TVG_SHAPE_STROKE_JOIN_INDICATOR (TvgIndicator)0x51 // Stroke StrokeJoin
-#define TVG_SHAPE_STROKE_JOIN_BEVEL_FLAG     (TvgFlag)0x01 // StrokeJoin::Bevel
-#define TVG_SHAPE_STROKE_JOIN_ROUND_FLAG     (TvgFlag)0x02 // StrokeJoin::Round
-#define TVG_SHAPE_STROKE_JOIN_MITER_FLAG     (TvgFlag)0x03 // StrokeJoin::Miter
+#define TVG_SHAPE_STROKE_JOIN_BEVEL_FLAG     (TvgFlag)0x00 // StrokeJoin::Bevel
+#define TVG_SHAPE_STROKE_JOIN_ROUND_FLAG     (TvgFlag)0x01 // StrokeJoin::Round
+#define TVG_SHAPE_STROKE_JOIN_MITER_FLAG     (TvgFlag)0x02 // StrokeJoin::Miter
 
 #define TVG_SHAPE_STROKE_WIDTH_INDICATOR    (TvgIndicator)0x52 // Stroke width
 #define TVG_SHAPE_STROKE_COLOR_INDICATOR    (TvgIndicator)0x53 // Stroke color
@@ -102,9 +102,9 @@ struct tvgBlock
 #define TVG_FILL_RADIAL_GRADIENT_INDICATOR  (TvgIndicator)0x61 // Radial gradient
 #define TVG_FILL_COLORSTOPS_INDICATOR       (TvgIndicator)0x62 // Gradient color stops
 #define TVG_FILL_FILLSPREAD_INDICATOR       (TvgIndicator)0x63 // Gradient fill spread
-#define TVG_FILL_FILLSPREAD_PAD_FLAG             (TvgFlag)0x01 // FillSpread::Pad
-#define TVG_FILL_FILLSPREAD_REFLECT_FLAG         (TvgFlag)0x02 // FillSpread::Reflect
-#define TVG_FILL_FILLSPREAD_REPEAT_FLAG          (TvgFlag)0x03 // FillSpread::Repeat
+#define TVG_FILL_FILLSPREAD_PAD_FLAG             (TvgFlag)0x00 // FillSpread::Pad
+#define TVG_FILL_FILLSPREAD_REFLECT_FLAG         (TvgFlag)0x01 // FillSpread::Reflect
+#define TVG_FILL_FILLSPREAD_REPEAT_FLAG          (TvgFlag)0x02 // FillSpread::Repeat
 
 // Picture
 #define TVG_RAW_IMAGE_BEGIN_INDICATOR (TvgIndicator)0x70 // Picture raw data


### PR DESCRIPTION
It's a middle stage leading to removing flags from the tvgBinaryDesc.h file
and use the corresponding enums from the thorvg.h file.

In the saver module I'm using the enums and in the tvg loader the flags are used.
With this change the enums and flags are compatible. 
In the future I'd like to use enums in both cases.
 