### PR TITLE
svg_loader: recalculating the default values of grads

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -1091,8 +1091,14 @@ static SvgNode* _createSvgNode(SvgLoaderData* loader, SvgNode* parent, const cha
     doc->preserveAspect = true;
     simpleXmlParseAttributes(buf, bufLength, _attrParseSvgNode, loader);
 
-    if (loader->svgParse->global.w == 0) loader->svgParse->global.w = loader->svgParse->node->node.doc.w;
-    if (loader->svgParse->global.h == 0) loader->svgParse->global.h = loader->svgParse->node->node.doc.h;
+    if (loader->svgParse->global.w == 0) {
+        if (doc->w < FLT_EPSILON) loader->svgParse->global.w = 1;
+        else loader->svgParse->global.w = doc->w;
+    }
+    if (loader->svgParse->global.h == 0) {
+        if (doc->h < FLT_EPSILON) loader->svgParse->global.h = 1;
+        else loader->svgParse->global.h =doc->h;
+    }
 
     return loader->svgParse->node;
 }
@@ -1913,13 +1919,13 @@ static SvgStyleGradient* _createRadialGradient(SvgLoaderData* loader, const char
         return nullptr;
     }
     /**
-    * Default values of gradient
+    * Default values of gradient transformed into global percentage
     */
-    grad->radial->cx = 0.5;
-    grad->radial->cy = 0.5;
-    grad->radial->fx = 0.5;
-    grad->radial->fy = 0.5;
-    grad->radial->r = 0.5;
+    grad->radial->cx = 0.5f / loader->svgParse->global.w;
+    grad->radial->cy = 0.5f / loader->svgParse->global.h;
+    grad->radial->fx = 0.5f / loader->svgParse->global.w;
+    grad->radial->fy = 0.5f / loader->svgParse->global.h;
+    grad->radial->r = 0.5f / (sqrt(pow(loader->svgParse->global.h, 2) + pow(loader->svgParse->global.w, 2)) / sqrt(2.0f));
 
     loader->svgParse->gradient.parsedFx = false;
     loader->svgParse->gradient.parsedFy = false;
@@ -2075,9 +2081,9 @@ static SvgStyleGradient* _createLinearGradient(SvgLoaderData* loader, const char
         return nullptr;
     }
     /**
-    * Default value of x2 is 100%
+    * Default value of x2 is 100% - transformed to the global percentage
     */
-    grad->linear->x2 = 1;
+    grad->linear->x2 = 1.0f / loader->svgParse->global.w;
     simpleXmlParseAttributes(buf, bufLength, _attrParseLinearGradientNode, loader);
 
     for (unsigned int i = 0; i < sizeof(linear_tags) / sizeof(linear_tags[0]); i++) {


### PR DESCRIPTION
The default values of gradient properties were handled differently
than the values given by a user/in an svg file.

before:
![1before](https://user-images.githubusercontent.com/67589014/123421506-37678b00-d5bd-11eb-9464-bc71d80b9574.PNG)

after:
![1after](https://user-images.githubusercontent.com/67589014/123421518-3c2c3f00-d5bd-11eb-8a94-f3b7bddb124c.PNG)

this helps in #430 and solves e-stop-019.svg from #457 