### PR TITLE
svg_loader: negative attrs length fix

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -2175,11 +2175,11 @@ static void _svgLoaderParserXmlOpen(SvgLoaderData* loader, const char* content, 
     if (attrs) {
         //Find out the tag name starting from content till sz length
         sz = attrs - content;
-        attrsLength = length - sz;
         while ((sz > 0) && (isspace(content[sz - 1]))) sz--;
         if ((unsigned)sz >= sizeof(tagName)) return;
         strncpy(tagName, content, sz);
         tagName[sz] = '\0';
+        attrsLength = length - sz;
     }
 
     if ((method = _findGroupFactory(tagName))) {
@@ -2541,11 +2541,11 @@ static bool _svgLoaderParserForValidCheckXmlOpen(SvgLoaderData* loader, const ch
 
     if (attrs) {
         sz = attrs - content;
-        attrsLength = length - sz;
         while ((sz > 0) && (isspace(content[sz - 1]))) sz--;
         if ((unsigned)sz >= sizeof(tagName)) return false;
         strncpy(tagName, content, sz);
         tagName[sz] = '\0';
+        attrsLength = length - sz;
     }
 
     if ((method = _findGroupFactory(tagName))) {


### PR DESCRIPTION
After finding no attributes but white spaces, attrsLength could be negative
that resulted in segmentation fault in simpleXmlParseAttributes function.

Minimal svg that caused segmentation fault before this patch applied:
```
<?xml version="1.0" encoding="UTF-8"?>
<svg><g ></g></svg>
```

@Issue: https://github.com/Samsung/thorvg/issues/487