### PR TITLE
svg_loader: applying opacity to the gradient

### DIFF
--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -38,12 +38,10 @@ static inline bool _isGroupType(SvgNodeType type)
 }
 
 
-static unique_ptr<LinearGradient> _applyLinearGradientProperty(SvgStyleGradient* g, const Shape* vg, float rx, float ry, float rw, float rh)
+static unique_ptr<LinearGradient> _applyLinearGradientProperty(SvgStyleGradient* g, const Shape* vg, float rx, float ry, float rw, float rh, int opacity)
 {
     Fill::ColorStop* stops;
     int stopCount = 0;
-    float fillOpacity = 255.0f;
-
     auto fillGrad = LinearGradient::gen();
 
     if (g->usePercentage) {
@@ -80,7 +78,7 @@ static unique_ptr<LinearGradient> _applyLinearGradientProperty(SvgStyleGradient*
             stops[i].r = colorStop->r;
             stops[i].g = colorStop->g;
             stops[i].b = colorStop->b;
-            stops[i].a = (colorStop->a * fillOpacity) / 255.0f;
+            stops[i].a = (colorStop->a * opacity) / 255.0f;
             stops[i].offset = colorStop->offset;
             // check the offset corner cases - refer to: https://svgwg.org/svg2-draft/pservers.html#StopNotes
             if (colorStop->offset < prevOffset) stops[i].offset = prevOffset;
@@ -94,13 +92,11 @@ static unique_ptr<LinearGradient> _applyLinearGradientProperty(SvgStyleGradient*
 }
 
 
-static unique_ptr<RadialGradient> _applyRadialGradientProperty(SvgStyleGradient* g, const Shape* vg, float rx, float ry, float rw, float rh)
+static unique_ptr<RadialGradient> _applyRadialGradientProperty(SvgStyleGradient* g, const Shape* vg, float rx, float ry, float rw, float rh, int opacity)
 {
     Fill::ColorStop *stops;
     int stopCount = 0;
     int radius;
-    float fillOpacity = 255.0f;
-
     auto fillGrad = RadialGradient::gen();
 
     radius = sqrt(pow(rw, 2) + pow(rh, 2)) / sqrt(2.0);
@@ -148,7 +144,7 @@ static unique_ptr<RadialGradient> _applyRadialGradientProperty(SvgStyleGradient*
             stops[i].r = colorStop->r;
             stops[i].g = colorStop->g;
             stops[i].b = colorStop->b;
-            stops[i].a = (colorStop->a * fillOpacity) / 255.0f;
+            stops[i].a = (colorStop->a * opacity) / 255.0f;
             stops[i].offset = colorStop->offset;
             // check the offset corner cases - refer to: https://svgwg.org/svg2-draft/pservers.html#StopNotes
             if (colorStop->offset < prevOffset) stops[i].offset = prevOffset;
@@ -215,10 +211,10 @@ static void _applyProperty(SvgNode* node, Shape* vg, float vx, float vy, float v
         if (!style->fill.paint.gradient->userSpace) vg->bounds(&vx, &vy, &vw, &vh);
 
         if (style->fill.paint.gradient->type == SvgGradientType::Linear) {
-             auto linear = _applyLinearGradientProperty(style->fill.paint.gradient, vg, vx, vy, vw, vh);
+             auto linear = _applyLinearGradientProperty(style->fill.paint.gradient, vg, vx, vy, vw, vh, style->fill.opacity);
              vg->fill(move(linear));
         } else if (style->fill.paint.gradient->type == SvgGradientType::Radial) {
-             auto radial = _applyRadialGradientProperty(style->fill.paint.gradient, vg, vx, vy, vw, vh);
+             auto radial = _applyRadialGradientProperty(style->fill.paint.gradient, vg, vx, vy, vw, vh, style->fill.opacity);
              vg->fill(move(radial));
         }
     } else if (style->fill.paint.curColor) {
@@ -252,10 +248,10 @@ static void _applyProperty(SvgNode* node, Shape* vg, float vx, float vy, float v
         if (!style->stroke.paint.gradient->userSpace) vg->bounds(&vx, &vy, &vw, &vh);
 
         if (style->stroke.paint.gradient->type == SvgGradientType::Linear) {
-             auto linear = _applyLinearGradientProperty(style->stroke.paint.gradient, vg, vx, vy, vw, vh);
+             auto linear = _applyLinearGradientProperty(style->stroke.paint.gradient, vg, vx, vy, vw, vh, style->stroke.opacity);
              vg->stroke(move(linear));
         } else if (style->stroke.paint.gradient->type == SvgGradientType::Radial) {
-             auto radial = _applyRadialGradientProperty(style->stroke.paint.gradient, vg, vx, vy, vw, vh);
+             auto radial = _applyRadialGradientProperty(style->stroke.paint.gradient, vg, vx, vy, vw, vh, style->stroke.opacity);
              vg->stroke(move(radial));
         }
     } else if (style->stroke.paint.url) {


### PR DESCRIPTION
Before this change the 'stroke-opacity' and the 'fill-opacity'
grad style attributes were not taken into account.

code:
```
<svg height="400" width="400" viewBox="0 0 400 400" >
  
<defs>
<radialGradient id="grad" gradientUnits="userSpaceOnUse" cx="125" cy="125" r="25">
<stop offset="0.000" style="stop-color: rgb(0, 0, 255); stop-opacity: 1;"/>
<stop offset="1.000" style="stop-color: rgb(0, 0, 255); stop-opacity: 1;"/>
</radialGradient>
</defs>

<path d="M 0,0 h 180 v 180 h -180 z" style="stroke: url(#grad); stroke-width:18 ; stroke-opacity: 1; fill: url(#grad); fill-opacity: 1;"/>
<path d="M 0,200 h 180 v 180 h -180 z" style="stroke: url(#grad); stroke-width:18 ; stroke-opacity: 0.5; fill: url(#grad); fill-opacity: 1;"/>
<path d="M 200,0 h 180 v 180 h -180 z" style="stroke: url(#grad); stroke-width:18 ; stroke-opacity: 1;  fill: url(#grad) rgb(0, 0, 0); fill-opacity: 0.5;"/>
<path d="M 200,200 h 180 v 180 h -180 z" style="stroke: url(#grad); stroke-width:18 ; stroke-opacity: 0.5; fill: url(#grad) rgb(0, 0, 0); fill-opacity: 0.5;"/>
</svg>
```

before:
![2before](https://user-images.githubusercontent.com/67589014/123511848-2b92cc00-d684-11eb-8914-78aeab596ba2.PNG)

after:
![2after](https://user-images.githubusercontent.com/67589014/123511850-2df52600-d684-11eb-93b0-ce1469c8d74a.PNG)
