### PR TITLE
sw_engine: removing a double application of the opacity to a grad

### DIFF
--- a/src/lib/sw_engine/tvgSwCommon.h
+++ b/src/lib/sw_engine/tvgSwCommon.h
@@ -313,8 +313,8 @@ void shapeResetStroke(SwShape* shape, const Shape* sdata, const Matrix* transfor
 bool shapeGenStrokeRle(SwShape* shape, const Shape* sdata, const Matrix* transform, const SwBBox& clipRegion, SwBBox& renderRegion, SwMpool* mpool, unsigned tid);
 void shapeFree(SwShape* shape);
 void shapeDelStroke(SwShape* shape);
-bool shapeGenFillColors(SwShape* shape, const Fill* fill, const Matrix* transform, SwSurface* surface, uint32_t opacity, bool ctable);
-bool shapeGenStrokeFillColors(SwShape* shape, const Fill* fill, const Matrix* transform, SwSurface* surface, uint32_t opacity, bool ctable);
+bool shapeGenFillColors(SwShape* shape, const Fill* fill, const Matrix* transform, SwSurface* surface, bool ctable);
+bool shapeGenStrokeFillColors(SwShape* shape, const Fill* fill, const Matrix* transform, SwSurface* surface, bool ctable);
 void shapeResetFill(SwShape* shape);
 void shapeResetStrokeFill(SwShape* shape);
 void shapeDelFill(SwShape* shape);
@@ -332,7 +332,7 @@ void imageDelOutline(SwImage* image, SwMpool* mpool, uint32_t tid);
 void imageReset(SwImage* image);
 void imageFree(SwImage* image);
 
-bool fillGenColorTable(SwFill* fill, const Fill* fdata, const Matrix* transform, SwSurface* surface, uint32_t opacity, bool ctable);
+bool fillGenColorTable(SwFill* fill, const Fill* fdata, const Matrix* transform, SwSurface* surface, bool ctable);
 void fillReset(SwFill* fill);
 void fillFree(SwFill* fill);
 void fillFetchLinear(const SwFill* fill, uint32_t* dst, uint32_t y, uint32_t x, uint32_t len);

--- a/src/lib/sw_engine/tvgSwFill.cpp
+++ b/src/lib/sw_engine/tvgSwFill.cpp
@@ -33,7 +33,7 @@
 #define FIXPT_SIZE (1<<FIXPT_BITS)
 
 
-static bool _updateColorTable(SwFill* fill, const Fill* fdata, const SwSurface* surface, uint32_t opacity)
+static bool _updateColorTable(SwFill* fill, const Fill* fdata, const SwSurface* surface)
 {
     if (!fill->ctable) {
         fill->ctable = static_cast<uint32_t*>(malloc(GRADIENT_STOP_SIZE * sizeof(uint32_t)));
@@ -46,7 +46,7 @@ static bool _updateColorTable(SwFill* fill, const Fill* fdata, const SwSurface* 
 
     auto pColors = colors;
 
-    auto a = (pColors->a * opacity) / 255;
+    auto a = pColors->a;
     if (a < 255) fill->translucent = true;
 
     auto r = ALPHA_MULTIPLY(pColors->r, a);
@@ -70,7 +70,7 @@ static bool _updateColorTable(SwFill* fill, const Fill* fdata, const SwSurface* 
         auto curr = colors + j;
         auto next = curr + 1;
         auto delta = 1.0f / (next->offset - curr->offset);
-        a = (next->a * opacity) / 255;
+        a = next->a;
         if (!fill->translucent && a < 255) fill->translucent = true;
 
         auto r = ALPHA_MULTIPLY(next->r, a);
@@ -265,14 +265,14 @@ void fillFetchLinear(const SwFill* fill, uint32_t* dst, uint32_t y, uint32_t x, 
 }
 
 
-bool fillGenColorTable(SwFill* fill, const Fill* fdata, const Matrix* transform, SwSurface* surface, uint32_t opacity, bool ctable)
+bool fillGenColorTable(SwFill* fill, const Fill* fdata, const Matrix* transform, SwSurface* surface, bool ctable)
 {
     if (!fill) return false;
 
     fill->spread = fdata->spread();
 
     if (ctable) {
-        if (!_updateColorTable(fill, fdata, surface, opacity)) return false;
+        if (!_updateColorTable(fill, fdata, surface)) return false;
     }
 
     if (fdata->id() == FILL_ID_LINEAR) {

--- a/src/lib/sw_engine/tvgSwRenderer.cpp
+++ b/src/lib/sw_engine/tvgSwRenderer.cpp
@@ -113,7 +113,7 @@ struct SwShapeTask : SwTask
             if (fill) {
                 auto ctable = (flags & RenderUpdateFlag::Gradient) ? true : false;
                 if (ctable) shapeResetFill(&shape);
-                if (!shapeGenFillColors(&shape, fill, transform, surface, opacity, ctable)) goto err;
+                if (!shapeGenFillColors(&shape, fill, transform, surface, ctable)) goto err;
                 ++addStroking;
             } else {
                 shapeDelFill(&shape);
@@ -130,7 +130,7 @@ struct SwShapeTask : SwTask
                 if (auto fill = sdata->strokeFill()) {
                     auto ctable = (flags & RenderUpdateFlag::GradientStroke) ? true : false;
                     if (ctable) shapeResetStrokeFill(&shape);
-                    if (!shapeGenStrokeFillColors(&shape, fill, transform, surface, opacity, ctable)) goto err;
+                    if (!shapeGenStrokeFillColors(&shape, fill, transform, surface, ctable)) goto err;
                 } else {
                     shapeDelStrokeFill(&shape);
                 }

--- a/src/lib/sw_engine/tvgSwShape.cpp
+++ b/src/lib/sw_engine/tvgSwShape.cpp
@@ -595,15 +595,15 @@ fail:
 }
 
 
-bool shapeGenFillColors(SwShape* shape, const Fill* fill, const Matrix* transform, SwSurface* surface, uint32_t opacity, bool ctable)
+bool shapeGenFillColors(SwShape* shape, const Fill* fill, const Matrix* transform, SwSurface* surface, bool ctable)
 {
-    return fillGenColorTable(shape->fill, fill, transform, surface, opacity, ctable);
+    return fillGenColorTable(shape->fill, fill, transform, surface, ctable);
 }
 
 
-bool shapeGenStrokeFillColors(SwShape* shape, const Fill* fill, const Matrix* transform, SwSurface* surface, uint32_t opacity, bool ctable)
+bool shapeGenStrokeFillColors(SwShape* shape, const Fill* fill, const Matrix* transform, SwSurface* surface, bool ctable)
 {
-    return fillGenColorTable(shape->stroke->fill, fill, transform, surface, opacity, ctable);
+    return fillGenColorTable(shape->stroke->fill, fill, transform, surface, ctable);
 }
 
 


### PR DESCRIPTION
The opacity is already applied and the fill-opacity and stroke-opacity
should be applied on the svg loader side - a separate PR.

code:
```
<svg height="400" width="400" viewBox="0 0 400 400" >
<defs>
<radialGradient id="grad" gradientUnits="userSpaceOnUse" cx="125" cy="125" r="25">
<stop offset="0.000" style="stop-color: rgb(255, 255, 255); stop-opacity: 1;"/>
<stop offset="1.000" style="stop-color: rgb(255, 255, 255); stop-opacity: 1;"/>
</radialGradient>
</defs>
<path d="M 0 0 h 400 v 400 h -400 z" fill="red" />
<path d="M 0,0 h 200 v 200 h -200 z" style="opacity: 0.5; fill: url(#grad);"/>
<path d="M 200,200 h 200 v 200 h -200 z" style="opacity: 0.5; fill: rgb(255, 255, 255);"/>
</svg>
```

before:
![3before](https://user-images.githubusercontent.com/67589014/123512913-626be080-d68a-11eb-9504-127bb4021cd2.PNG)

after:
![3after](https://user-images.githubusercontent.com/67589014/123512917-6697fe00-d68a-11eb-81f9-a35201911181.PNG)
