### PR TITLE
svg_loader: finish the search after founding the proper color

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -511,6 +511,7 @@ static void _toColor(const char* str, uint8_t* r, uint8_t* g, uint8_t* b, string
                 *r = (((uint8_t*)(&(colors[i].value)))[2]);
                 *g = (((uint8_t*)(&(colors[i].value)))[1]);
                 *b = (((uint8_t*)(&(colors[i].value)))[0]);
+                return;
             }
         }
     }


### PR DESCRIPTION
In the _toColor func, after founding the proper color, the search
should be finiched.