### PR TITLE
svg_loader: allow multiple <defs> tags without data and memory leak

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -2200,9 +2200,14 @@ static void _svgLoaderParserXmlOpen(SvgLoaderData* loader, const char* content, 
         }
 
         if (node->type == SvgNodeType::Defs) {
-            loader->doc->node.doc.defs = node;
-            loader->def = node;
-            if (!empty) loader->stack.push(node);
+            if (loader->def && loader->doc->node.doc.defs) {
+                free(node->style);
+                free(node);
+            } else {
+                loader->doc->node.doc.defs = node;
+                loader->def = node;
+                if (!empty) loader->stack.push(node);
+            }
         } else {
             loader->stack.push(node);
         }

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -1068,9 +1068,8 @@ static SvgNode* _createNode(SvgNode* parent, SvgNodeType type)
 
 static SvgNode* _createDefsNode(TVG_UNUSED SvgLoaderData* loader, TVG_UNUSED SvgNode* parent, const char* buf, unsigned bufLength)
 {
+    if (loader->def && loader->doc->node.doc.defs) return nullptr;
     SvgNode* node = _createNode(nullptr, SvgNodeType::Defs);
-    if (!node) return nullptr;
-    simpleXmlParseAttributes(buf, bufLength, nullptr, node);
     return node;
 }
 
@@ -2199,15 +2198,11 @@ static void _svgLoaderParserXmlOpen(SvgLoaderData* loader, const char* content, 
             node = method(loader, parent, attrs, attrsLength);
         }
 
+        if (!node) return;
         if (node->type == SvgNodeType::Defs) {
-            if (loader->def && loader->doc->node.doc.defs) {
-                free(node->style);
-                free(node);
-            } else {
-                loader->doc->node.doc.defs = node;
-                loader->def = node;
-                if (!empty) loader->stack.push(node);
-            }
+            loader->doc->node.doc.defs = node;
+            loader->def = node;
+            if (!empty) loader->stack.push(node);
         } else {
             loader->stack.push(node);
         }


### PR DESCRIPTION
If the svg file contained multiple defs tags, each subsequent tag
overwritten the previous one. This resulted in incorrect rendering of the
file and memory leaks.

Minimal svg that resulted in a memory leak:
```
<svg>
<defs></defs>
<defs></defs>
</svg>
```

Example svg file:
```
<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
<defs id="defs01">
	<linearGradient id="Gradient01"
       x1="0" y1="0" x2="1" y2="1">
		<stop offset="10%" stop-color="#000" />
		<stop offset="90%" stop-color="#fff" />
	</linearGradient>
</defs>
<defs id="defs02">
	<linearGradient id="Gradient02"
       x1="0" y1="0" x2="1" y2="1">
		<stop offset="0" stop-color="#00bacc" />
		<stop offset="1" stop-color="#ccba00" />
	</linearGradient>
</defs>
<rect x="0" y="0" width="200" height="100" fill="url(#Gradient01)" />
<rect x="0" y="100" width="200" height="100" fill="url(#Gradient02)" />
</svg>
```

Before (104 bytes definitely lost and 328 bytes indirectly lost):
![Screenshot before](https://user-images.githubusercontent.com/71131832/123770173-5a01e880-d8ca-11eb-8dd8-2c7e5b9f5e72.png)

After (no memory leak):
![Screenshot after](https://user-images.githubusercontent.com/71131832/123770193-5ff7c980-d8ca-11eb-9e98-6fc9b09ba399.png)


@Issues: https://github.com/Samsung/thorvg/issues/491