### PR TITLE
svg_loader: fix the inifite loop bug when size has 'em' unit.

### DIFF
--- a/src/loaders/svg/tvgSvgUtil.cpp
+++ b/src/loaders/svg/tvgSvgUtil.cpp
@@ -26,7 +26,6 @@
 #include <errno.h>
 #include "tvgSvgUtil.h"
 
-
 /************************************************************************/
 /* Internal Class Implementation                                        */
 /************************************************************************/
@@ -163,14 +162,21 @@ float svgUtilStrtof(const char *nPtr, char **endPtr)
         unsigned int expo_part;
         int minus_e;
 
-        iter++;
+        ++iter;
+
+        //Exception: svg may have 'em' unit for fonts. ex) 5em, 10.5em
+        if ((*iter == 'm') || (*iter == 'M')) {
+            //TODO: We don't support font em unit now, but has to multiply val * font size later...
+            a = iter + 1;
+            goto on_success;
+        }
 
         //signed or not
         minus_e = 1;
         if (*iter == '-')
         {
             minus_e = -1;
-            iter++;
+            ++iter;
         }
         else if (*iter == '+') iter++;
 


### PR DESCRIPTION
svg may have 'em' unit for fonts, strtof() must handle this case to not
drop in the infinite loop.

Yet thorvg doesn't support font feature in svg,
it must multiply values with font size if those values have 'em' size.

@Issue: https://github.com/Samsung/thorvg/issues/488