### PR TITLE
sw_engine: stop-opacity value should be interpolated between stops

### DIFF
--- a/src/lib/sw_engine/tvgSwFill.cpp
+++ b/src/lib/sw_engine/tvgSwFill.cpp
@@ -49,11 +49,11 @@ static bool _updateColorTable(SwFill* fill, const Fill* fdata, const SwSurface* 
     auto a = (pColors->a * opacity) / 255;
     if (a < 255) fill->translucent = true;
 
-    auto r = ALPHA_MULTIPLY(pColors->r, a);
-    auto g = ALPHA_MULTIPLY(pColors->g, a);
-    auto b = ALPHA_MULTIPLY(pColors->b, a);
-
+    auto r = pColors->r;
+    auto g = pColors->g;
+    auto b = pColors->b;
     auto rgba = surface->blender.join(r, g, b, a);
+
     auto inc = 1.0f / static_cast<float>(GRADIENT_STOP_SIZE);
     auto pos = 1.5f * inc;
     uint32_t i = 0;
@@ -70,30 +70,32 @@ static bool _updateColorTable(SwFill* fill, const Fill* fdata, const SwSurface* 
         auto curr = colors + j;
         auto next = curr + 1;
         auto delta = 1.0f / (next->offset - curr->offset);
-        a = (next->a * opacity) / 255;
+        auto a2 = (next->a * opacity) / 255;
         if (!fill->translucent && a < 255) fill->translucent = true;
 
-        auto r = ALPHA_MULTIPLY(next->r, a);
-        auto g = ALPHA_MULTIPLY(next->g, a);
-        auto b = ALPHA_MULTIPLY(next->b, a);
-
-        auto rgba2 = surface->blender.join(r, g, b, a);
+        auto rgba2 = surface->blender.join(next->r, next->g, next->b, a2);
 
         while (pos < next->offset && i < GRADIENT_STOP_SIZE) {
             auto t = (pos - curr->offset) * delta;
             auto dist = static_cast<int32_t>(256 * t);
             auto dist2 = 256 - dist;
-            fill->ctable[i] = COLOR_INTERPOLATE(rgba, dist2, rgba2, dist);
+
+            auto color = COLOR_INTERPOLATE(rgba, dist2, rgba2, dist);
+            uint8_t a = color >> 24;
+            fill->ctable[i] = ALPHA_BLEND(color | 0xff000000, a);
+
             ++i;
             pos += inc;
         }
         rgba = rgba2;
+        a = a2;
     }
+    rgba = ALPHA_BLEND(rgba | 0xff000000, a);
 
     for (; i < GRADIENT_STOP_SIZE; ++i)
         fill->ctable[i] = rgba;
 
-    //Make sure the lat color stop is represented at the end of the table
+    //Make sure the last color stop is represented at the end of the table
     fill->ctable[GRADIENT_STOP_SIZE - 1] = rgba;
 
     return true;


### PR DESCRIPTION
The opacity value is interpolated as are all color channels.

example with apis:
```
    auto shape1 = tvg::Shape::gen();
    shape1->appendRect(0, 0, 400, 400, 0, 0);    

    auto fill = tvg::LinearGradient::gen();
    fill->linear(0, 0, 400, 400);

    tvg::Fill::ColorStop colorStops[2];
    colorStops[0] = {0, 255, 0, 0, 255};
    colorStops[1] = {1, 0, 0, 255, 0};

    fill->colorStops(colorStops, 2);

    shape1->fill(move(fill));
    if (canvas->push(move(shape1)) != tvg::Result::Success) return;
```

svg xample (same result as from apis):
```
<svg viewBox="0 0 800 800">
  <defs>
    <linearGradient id="grad" x1="0" y1="0" x2="1" y2="1">
      <stop style="stop-color:#0000ff;stop-opacity:1;" offset="0"/>
      <stop style="stop-color:#ff0000;stop-opacity:0;" offset="1"/>
    </linearGradient>
  </defs>
  <rect x="0" y="0" width="400" height="400" fill="#000"/>
  <rect x="0" y="0" width="400" height="400" fill="url(#grad)"/>
</svg>
```

before:
![7before](https://user-images.githubusercontent.com/67589014/123875741-7e95a900-d93a-11eb-9558-725512ab65b7.PNG)

after:
![7after](https://user-images.githubusercontent.com/67589014/123875746-80f80300-d93a-11eb-9731-ab62c82f10c8.PNG)

issue #521