### PR TITLE
svg_loader: fix a infinite loop error if compositions have circular d…

### DIFF
--- a/src/loaders/svg/tvgSvgLoaderCommon.h
+++ b/src/loaders/svg/tvgSvgLoaderCommon.h
@@ -196,6 +196,7 @@ struct SvgComposite
     CompositeMethod method;     //TODO: Currently support either one method
     string *url;
     SvgNode* node;
+    bool applying;              //flag for checking circualr dependency.
 };
 
 struct SvgColor


### PR DESCRIPTION
…ependency.

Composition can be applied recursively if its children nodes have composition target to this one.
This can be occured by wrong svg description, and tvg prevents this exception case.

@Issue: https://github.com/Samsung/thorvg/issues/494