### PR TITLE
sw_engine: fix broken MSVC compatibility.

### DIFF
--- a/src/lib/sw_engine/tvgSwRle.cpp
+++ b/src/lib/sw_engine/tvgSwRle.cpp
@@ -94,7 +94,7 @@ struct RleWorker
 
 static inline SwPoint UPSCALE(const SwPoint& pt)
 {
-    return {SwCoord(ulong(pt.x) << (PIXEL_BITS - 6)), SwCoord(ulong(pt.y) << (PIXEL_BITS - 6))};
+    return {SwCoord(((unsigned long) pt.x) << (PIXEL_BITS - 6)), SwCoord(((unsigned long) pt.y) << (PIXEL_BITS - 6))};
 }
 
 
@@ -112,13 +112,13 @@ static inline SwCoord TRUNC(const SwCoord x)
 
 static inline SwPoint SUBPIXELS(const SwPoint& pt)
 {
-    return {SwCoord(ulong(pt.x) << PIXEL_BITS), SwCoord(ulong(pt.y) << PIXEL_BITS)};
+    return {SwCoord(((unsigned long) pt.x) << PIXEL_BITS), SwCoord(((unsigned long) pt.y) << PIXEL_BITS)};
 }
 
 
 static inline SwCoord SUBPIXELS(const SwCoord x)
 {
-    return SwCoord(ulong(x) << PIXEL_BITS);
+    return SwCoord(((unsigned long) x) << PIXEL_BITS);
 }
 
 /*


### PR DESCRIPTION
error: use of undeclared identifier 'ulong'

@Issue: https://github.com/Samsung/thorvg/issues/541