### PR TITLE
common array: -- sanitizer errors

### DIFF
--- a/src/lib/tvgArray.h
+++ b/src/lib/tvgArray.h
@@ -75,7 +75,7 @@ struct Array
     void operator=(const Array& rhs)
     {
         reserve(rhs.count);
-        memcpy(data, rhs.data, sizeof(T) * reserved);
+        if (rhs.count > 0) memcpy(data, rhs.data, sizeof(T) * reserved);
         count = rhs.count;
     }
 


### PR DESCRIPTION
runtime error: null pointer passed as argument 1, which is declared to never be null