### PR TITLE
svg_loader: memory leak after improper stop tag

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -2234,7 +2234,7 @@ static void _svgLoaderParserXmlOpen(SvgLoaderData* loader, const char* content, 
     } else if (!strcmp(tagName, "stop")) {
         if (!loader->latestGradient) {
 #ifdef THORVG_LOG_ENABLED
-            printf("SVG: Gradient stop but no gradient in the scope\n");
+            printf("SVG: Stop element is used outside of the Gradient element\n");
 #endif
             return;
         }

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -2232,15 +2232,19 @@ static void _svgLoaderParserXmlOpen(SvgLoaderData* loader, const char* content, 
         }
         loader->latestGradient = gradient;
     } else if (!strcmp(tagName, "stop")) {
+        if (!loader->latestGradient) {
+#ifdef THORVG_LOG_ENABLED
+            printf("SVG: Gradient stop but no gradient in the scope\n");
+#endif
+            return;
+        }
         auto stop = static_cast<Fill::ColorStop*>(calloc(1, sizeof(Fill::ColorStop)));
         if (!stop) return;
         loader->svgParse->gradStop = stop;
         /* default value for opacity */
         stop->a = 255;
         simpleXmlParseAttributes(attrs, attrsLength, _attrParseStops, loader);
-        if (loader->latestGradient) {
-            loader->latestGradient->stops.push(stop);
-        }
+        loader->latestGradient->stops.push(stop);
     }
 #ifdef THORVG_LOG_ENABLED
     else {


### PR DESCRIPTION
`<stop>` tag should be always a child of a `<linearGradient>` or `<radialGradient>` element, but there were files with `<stop>` tag inside `<rect>`.
This patch fixes a memory leak if no gradient is defined before `<stop>` tag.

@issue: #545