### PR TITLE
common picture: ++ exception case.

### DIFF
--- a/src/lib/tvgPicture.cpp
+++ b/src/lib/tvgPicture.cpp
@@ -85,6 +85,7 @@ Result Picture::size(float w, float h) noexcept
 
 Result Picture::size(float* w, float* h) const noexcept
 {
+    if (!pImpl->loader) return Result::InsufficientCondition;
     if (w) *w = pImpl->w;
     if (h) *h = pImpl->h;
     return Result::Success;


### PR DESCRIPTION
size() returns invalidArgument if it doesn't have any loaded data.