### PR TITLE
svg_loader: fix dead loop on non-digit char in stroke-dasharray

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -250,10 +250,15 @@ _parseDashArray(const char *str, SvgDash* dash)
 
     char *end = nullptr;
 
+    str = _skipComma(str);
     while (*str) {
-        // skip white space, comma
-        str = _skipComma(str);
-        (*dash).array.push(svgUtilStrtof(str, &end));
+        float parsedValue = svgUtilStrtof(str, &end);
+        if (str == end) break;
+        if (*end == '%') {
+            ++end;
+            //TODO: multiply percentage value
+        }
+        (*dash).array.push(parsedValue);
         str = _skipComma(end);
     }
     //If dash array size is 1, it means that dash and gap size are the same.

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -254,6 +254,7 @@ _parseDashArray(const char *str, SvgDash* dash)
         str = _skipComma(str);
         float parsedValue = svgUtilStrtof(str, &end);
         if (str == end) break;
+        if (parsedValue <= 0.0f) break;
         if (*end == '%') {
             ++end;
             //TODO: multiply percentage value

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -250,8 +250,8 @@ _parseDashArray(const char *str, SvgDash* dash)
 
     char *end = nullptr;
 
-    str = _skipComma(str);
     while (*str) {
+        str = _skipComma(str);
         float parsedValue = svgUtilStrtof(str, &end);
         if (str == end) break;
         if (*end == '%') {
@@ -259,7 +259,7 @@ _parseDashArray(const char *str, SvgDash* dash)
             //TODO: multiply percentage value
         }
         (*dash).array.push(parsedValue);
-        str = _skipComma(end);
+        str = end;
     }
     //If dash array size is 1, it means that dash and gap size are the same.
     if ((*dash).array.count == 1) (*dash).array.push((*dash).array.data[0]);


### PR DESCRIPTION
Any non digit character in `stroke-dasharray` resulted in a dead looping

@issue: #542 