### PR TITLE
common picture: fix invalid size returns from raw image.

### DIFF
--- a/src/lib/tvgPictureImpl.h
+++ b/src/lib/tvgPictureImpl.h
@@ -195,6 +195,8 @@ struct Picture::Impl
         if (loader) loader->close();
         loader = LoaderMgr::loader(data, w, h, copy);
         if (!loader) return Result::NonSupport;
+        this->w = loader->w;
+        this->h = loader->h;
         return Result::Success;
     }
 

--- a/src/loaders/raw/tvgRawLoader.cpp
+++ b/src/loaders/raw/tvgRawLoader.cpp
@@ -45,10 +45,10 @@ bool RawLoader::open(const uint32_t* data, uint32_t w, uint32_t h, bool copy)
 {
     if (!data || w == 0 || h == 0) return false;
 
-    vw = w;
-    vh = h;
-
+    this->w = vw = w;
+    this->h = vh = h;
     this->copy = copy;
+
     if (copy) {
         content = (uint32_t*)malloc(sizeof(uint32_t) * vw * vh);
         if (!content) return false;


### PR DESCRIPTION
picture/raw should update the size if the raw image
with size values are entered.