### PR TITLE
sw_engine: stop-opacity value should be interpolated between stops

### DIFF
--- a/src/lib/sw_engine/tvgSwFill.cpp
+++ b/src/lib/sw_engine/tvgSwFill.cpp
@@ -49,16 +49,16 @@ static bool _updateColorTable(SwFill* fill, const Fill* fdata, const SwSurface* 
     auto a = (pColors->a * opacity) / 255;
     if (a < 255) fill->translucent = true;
 
-    auto r = ALPHA_MULTIPLY(pColors->r, a);
-    auto g = ALPHA_MULTIPLY(pColors->g, a);
-    auto b = ALPHA_MULTIPLY(pColors->b, a);
-
+    auto r = pColors->r;
+    auto g = pColors->g;
+    auto b = pColors->b;
     auto rgba = surface->blender.join(r, g, b, a);
+
     auto inc = 1.0f / static_cast<float>(GRADIENT_STOP_SIZE);
     auto pos = 1.5f * inc;
     uint32_t i = 0;
 
-    fill->ctable[i++] = rgba;
+    fill->ctable[i++] = ALPHA_BLEND(rgba | 0xff000000, a);
 
     while (pos <= pColors->offset) {
         fill->ctable[i] = fill->ctable[i - 1];
@@ -70,30 +70,32 @@ static bool _updateColorTable(SwFill* fill, const Fill* fdata, const SwSurface* 
         auto curr = colors + j;
         auto next = curr + 1;
         auto delta = 1.0f / (next->offset - curr->offset);
-        a = (next->a * opacity) / 255;
-        if (!fill->translucent && a < 255) fill->translucent = true;
+        auto a2 = (next->a * opacity) / 255;
+        if (!fill->translucent && a2 < 255) fill->translucent = true;
 
-        auto r = ALPHA_MULTIPLY(next->r, a);
-        auto g = ALPHA_MULTIPLY(next->g, a);
-        auto b = ALPHA_MULTIPLY(next->b, a);
-
-        auto rgba2 = surface->blender.join(r, g, b, a);
+        auto rgba2 = surface->blender.join(next->r, next->g, next->b, a2);
 
         while (pos < next->offset && i < GRADIENT_STOP_SIZE) {
             auto t = (pos - curr->offset) * delta;
             auto dist = static_cast<int32_t>(256 * t);
             auto dist2 = 256 - dist;
-            fill->ctable[i] = COLOR_INTERPOLATE(rgba, dist2, rgba2, dist);
+
+            auto color = COLOR_INTERPOLATE(rgba, dist2, rgba2, dist);
+            uint8_t a = color >> 24;
+            fill->ctable[i] = ALPHA_BLEND(color | 0xff000000, a);
+
             ++i;
             pos += inc;
         }
         rgba = rgba2;
+        a = a2;
     }
+    rgba = ALPHA_BLEND(rgba | 0xff000000, a);
 
     for (; i < GRADIENT_STOP_SIZE; ++i)
         fill->ctable[i] = rgba;
 
-    //Make sure the lat color stop is represented at the end of the table
+    //Make sure the last color stop is represented at the end of the table
     fill->ctable[GRADIENT_STOP_SIZE - 1] = rgba;
 
     return true;


### PR DESCRIPTION
The opacity value is interpolated as are all color channels.
It's similar to the reverted commit ac95433, but with two slight changes
(alpha_blend was missing in the ctable init and 'a' was used in an if
statement instead of 'a2').

like #531 but with 2 changes - marked in comments