### PR TITLE
sw_engine renderer: fix memory leak.

### DIFF
--- a/src/lib/sw_engine/tvgSwRenderer.cpp
+++ b/src/lib/sw_engine/tvgSwRenderer.cpp
@@ -230,6 +230,7 @@ static void _termEngine()
 SwRenderer::~SwRenderer()
 {
     clear();
+    clearCompositors();
 
     if (surface) delete(surface);
 
@@ -304,11 +305,8 @@ bool SwRenderer::preRender()
     return rasterClear(surface);
 }
 
-
-bool SwRenderer::postRender()
+void SwRenderer::clearCompositors()
 {
-    tasks.clear();
-
     //Free Composite Caches
     for (auto comp = compositors.data; comp < (compositors.data + compositors.count); ++comp) {
         free((*comp)->compositor->image.data);
@@ -316,7 +314,13 @@ bool SwRenderer::postRender()
         delete(*comp);
     }
     compositors.reset();
+}
 
+
+bool SwRenderer::postRender()
+{
+    tasks.clear();
+    clearCompositors();
     return true;
 }
 

--- a/src/lib/sw_engine/tvgSwRenderer.h
+++ b/src/lib/sw_engine/tvgSwRenderer.h
@@ -54,6 +54,7 @@ public:
     Compositor* target(const RenderRegion& region) override;
     bool beginComposite(Compositor* cmp, CompositeMethod method, uint32_t opacity) override;
     bool endComposite(Compositor* cmp) override;
+    void clearCompositors();
 
     static SwRenderer* gen();
     static bool init(uint32_t threads);


### PR DESCRIPTION
prepared compositors can be dangled if the rendering is not occured.

free them by doubl-checking in the destructor.