### PR TITLE
jpg_loader JpgLoader: Prevent memory leak

### DIFF
--- a/src/loaders/jpg/tvgJpgLoader.cpp
+++ b/src/loaders/jpg/tvgJpgLoader.cpp
@@ -47,6 +47,7 @@ JpgLoader::JpgLoader()
 
 JpgLoader::~JpgLoader()
 {
+    if (data) tjFree(data);
     tjDestroy(jpegDecompressor);
     tjFree(image);
     image = NULL;


### PR DESCRIPTION
If the copied data in JpgLoader's data open is invalid,
it is processed without being cleared.
Therefore, data memory free is handled in the destructor.