### PR TITLE
svg_loader SvgLoader: Initialize to flag value of SvgParser

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -2780,6 +2780,8 @@ bool SvgLoader::header()
     loaderData.svgParse = (SvgParser*)malloc(sizeof(SvgParser));
     if (!loaderData.svgParse) return false;
 
+    loaderData.svgParse->flags = SvgStopStyleFlags::StopDefault;
+
     simpleXmlParse(content, size, true, _svgLoaderParserForValidCheck, &(loaderData));
 
     if (loaderData.doc && loaderData.doc->type == SvgNodeType::Doc) {

--- a/src/loaders/svg/tvgSvgLoaderCommon.h
+++ b/src/loaders/svg/tvgSvgLoaderCommon.h
@@ -112,6 +112,7 @@ enum class SvgStyleFlags
 
 enum class SvgStopStyleFlags
 {
+    StopDefault = 0x0,
     StopOpacity = 0x01,
     StopColor = 0x02
 };


### PR DESCRIPTION
This patch fixes valgrind detection

$valgrind --leak-check=yes ./Svg

==21410== Conditional jump or move depends on uninitialised value(s)
==21410== at 0x505DB66: _attrParseStops(void*, char const*, char const*) (tvgSvgLoader.cpp:2099)
==21410== by 0x5064F6D: simpleXmlParseAttributes(char const*, unsigned int, bool ()(void, char const*, char const*), void const*) (tvgXmlParser.cpp:319)
==21410== by 0x5061774: _svgLoaderParserXmlOpen(SvgLoaderData*, char const*, unsigned int, bool) (tvgSvgLoader.cpp:2387)
==21410== by 0x5061857: _svgLoaderParser(void*, SimpleXMLType, char const*, unsigned int) (tvgSvgLoader.cpp:2408)
==21410== by 0x5065052: simpleXmlParse(char const*, unsigned int, bool, bool ()(void, SimpleXMLType, char const*, unsigned int), void const*) (tvgXmlParser.cpp:425)
==21410== by 0x5061993: SvgLoader::run(unsigned int) (tvgSvgLoader.cpp:2757)
==21410== by 0x5052F5E: operator() (tvgTaskScheduler.h:68)
==21410== by 0x5052F5E: tvg::TaskSchedulerImpl::run(unsigned int) (tvgTaskScheduler.cpp:138)
==21410== by 0x62C36DE: ??? (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.25)
==21410== by 0x6DA36DA: start_thread (pthread_create.c:463)
==21410== by 0x68C871E: clone (clone.S:95)


issue :https://github.com/Samsung/thorvg/issues/590