### PR TITLE
svg_loader: image tag: fixed utf8 decode

### DIFF
--- a/src/loaders/svg/tvgSvgUtil.cpp
+++ b/src/loaders/svg/tvgSvgUtil.cpp
@@ -271,11 +271,6 @@ string svgUtilURLDecode(const char *src)
 
     char a, b;
     while (*src) {
-        if (*src <= 0x20) {
-            ++src;
-            continue;
-        }
-
         if (*src == '%' &&
             ((a = src[1]) && (b = src[2])) &&
             (isxdigit(a) && isxdigit(b))) {


### PR DESCRIPTION
Fixed svgUtilURLDecode function.
Deleted snippet was not needed and it broken decoding when space.