### PR TITLE
sw_renderer: changing the condition for a valid stroke

### DIFF
--- a/src/lib/sw_engine/tvgSwRenderer.cpp
+++ b/src/lib/sw_engine/tvgSwRenderer.cpp
@@ -80,7 +80,7 @@ struct SwShapeTask : SwTask
         if (HALF_STROKE(strokeWidth) > 0) {
             sdata->strokeColor(nullptr, nullptr, nullptr, &strokeAlpha);
         }
-        bool validStroke = (strokeAlpha > 0) || sdata->strokeFill();
+        bool validStroke = (static_cast<uint32_t>(strokeAlpha * opacity / 255) > 0) || sdata->strokeFill();
         auto clipRegion = bbox;
 
         //invisible shape turned to visible by alpha.


### PR DESCRIPTION
The product of a stroke alpha value and the opacity should be > 0,
otherwise the stroke is invisible and there is no point to generate its rle.