### PR TITLE
compositeMethod: introduced ColorMask

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -143,8 +143,9 @@ enum class TVG_EXPORT CompositeMethod
 {
     None = 0,     ///< No composition is applied.
     ClipPath,     ///< The intersection of the source and the target is determined and only the resulting pixels from the source are rendered.
-    AlphaMask,    ///< The pixels of the source and the target are alpha blended. As a result, only the part of the source, which intersects with the target is visible.
-    InvAlphaMask  ///< The pixels of the source and the complement to the target's pixels are alpha blended. As a result, only the part of the source which is not covered by the target is visible.
+    AlphaMask,    ///< The pixels of the source and the target are alpha blended. As a result, only the part of the source, which alpha intersects with the target is visible.
+    InvAlphaMask, ///< The pixels of the source and the complement to the target's pixels are alpha blended. As a result, only the part of the source which alpha is not covered by the target is visible.
+    LumaMask      ///< @BETA_API The source pixels are converted to the grayscale (luma value) and alpha blended with the target. As a result, only the part of the source, which intersects with the target is visible.
 };
 
 /**

--- a/src/lib/sw_engine/tvgSwCommon.h
+++ b/src/lib/sw_engine/tvgSwCommon.h
@@ -235,6 +235,7 @@ struct SwImage
 struct SwBlender
 {
     uint32_t (*join)(uint8_t r, uint8_t g, uint8_t b, uint8_t a);
+    uint32_t (*lumaValue)(uint32_t c);
 };
 
 struct SwCompositor;


### PR DESCRIPTION
Introduced CompositeMethod::ColorMask that converts the source pixels to the
grayscale before alpha blending. Thanks to it, mask works more like typical
mask in graphics editor software.
Grayscale is calculated as an average value: A*(R+G+B)/3

@issue: #428