### PR TITLE
sw_engine Raster: Apply bilinear interpolation to images

### DIFF
--- a/src/lib/sw_engine/tvgSwCommon.h
+++ b/src/lib/sw_engine/tvgSwCommon.h
@@ -282,6 +282,21 @@ static inline uint32_t COLOR_INTERPOLATE(uint32_t c1, uint32_t a1, uint32_t c2, 
     return (c1 |= t);
 }
 
+//c1(x,y)--a1-- c2
+// |        |    |
+// |        |    |
+//a2---result---a2
+// |        |    |
+// |        |    |
+//c4 ------a1-- c3
+static inline uint32_t COLOR_BILINEAR_INTERPOLATE(uint32_t c1, uint32_t c2, uint32_t c3, uint32_t c4, uint32_t a1, uint32_t a2)
+{
+    return COLOR_INTERPOLATE(COLOR_INTERPOLATE(c1, 255 - a1, c2, a1),
+                             255 - a2,
+                             COLOR_INTERPOLATE(c4, 255 - a1, c3, a1),
+                             a2);
+}
+
 static inline uint32_t ALPHA_MULTIPLY(uint32_t c, uint32_t a)
 {
     return ((c * a + 0xff) >> 8);

--- a/src/lib/sw_engine/tvgSwCommon.h
+++ b/src/lib/sw_engine/tvgSwCommon.h
@@ -282,18 +282,6 @@ static inline uint32_t COLOR_INTERPOLATE(uint32_t c1, uint32_t a1, uint32_t c2, 
     return (c1 |= t);
 }
 
-//c1(x,y)--a1-- c2
-// |        |    |
-// |        |    |
-//a2---result---a2
-// |        |    |
-// |        |    |
-//c4 ------a1-- c3
-static inline uint32_t COLOR_BILINEAR_INTERPOLATE(uint32_t c1, uint32_t c2, uint32_t c3, uint32_t c4, uint32_t a1, uint32_t a2)
-{
-    return COLOR_INTERPOLATE(COLOR_INTERPOLATE(c1, 255 - a1, c2, a1), 255 - a2, COLOR_INTERPOLATE(c4, 255 - a1, c3, a1), a2);
-}
-
 static inline uint32_t ALPHA_MULTIPLY(uint32_t c, uint32_t a)
 {
     return ((c * a + 0xff) >> 8);

--- a/src/lib/sw_engine/tvgSwCommon.h
+++ b/src/lib/sw_engine/tvgSwCommon.h
@@ -291,10 +291,7 @@ static inline uint32_t COLOR_INTERPOLATE(uint32_t c1, uint32_t a1, uint32_t c2, 
 //c4 ------a1-- c3
 static inline uint32_t COLOR_BILINEAR_INTERPOLATE(uint32_t c1, uint32_t c2, uint32_t c3, uint32_t c4, uint32_t a1, uint32_t a2)
 {
-    return COLOR_INTERPOLATE(COLOR_INTERPOLATE(c1, 255 - a1, c2, a1),
-                             255 - a2,
-                             COLOR_INTERPOLATE(c4, 255 - a1, c3, a1),
-                             a2);
+    return COLOR_INTERPOLATE(COLOR_INTERPOLATE(c1, 255 - a1, c2, a1), 255 - a2, COLOR_INTERPOLATE(c4, 255 - a1, c3, a1), a2);
 }
 
 static inline uint32_t ALPHA_MULTIPLY(uint32_t c, uint32_t a)

--- a/src/lib/sw_engine/tvgSwRaster.cpp
+++ b/src/lib/sw_engine/tvgSwRaster.cpp
@@ -106,10 +106,8 @@ static uint32_t _applyBilinearInterpolation(const uint32_t *img, uint32_t w, uin
     auto c3 = img[(rX + 1) + ((rY + 1) * w)];
     auto c4 = img[rX + ((rY + 1) * w)];
 
-    if (c1 == c2 && c1 == c3 && c1 == c4) {
-        return img[rX + (rY * w)];
-    }
-    return COLOR_BILINEAR_INTERPOLATE(c1, c2, c3, c4, dX, dY);
+    if (c1 == c2 && c1 == c3 && c1 == c4) return img[rX + (rY * w)];
+    return COLOR_INTERPOLATE(COLOR_INTERPOLATE(c1, 255 - dX, c2, dX), 255 - dY, COLOR_INTERPOLATE(c4, 255 - dX, c3, dX), dY);
 }
 
 
@@ -338,7 +336,26 @@ static bool _rasterTranslucentImageRle(SwSurface* surface, const SwRleData* rle,
 static bool _rasterTranslucentImageRle(SwSurface* surface, const SwRleData* rle, uint32_t *img, uint32_t w, uint32_t h, uint32_t opacity, const Matrix* invTransform)
 {
     auto span = rle->spans;
-    bool isDownScaling = (invTransform->e11 * invTransform->e11) + (invTransform->e21 * invTransform->e21) > 1 ? true : false;
+
+    for (uint32_t i = 0; i < rle->size; ++i, ++span) {
+        auto ey1 = span->y * invTransform->e12 + invTransform->e13;
+        auto ey2 = span->y * invTransform->e22 + invTransform->e23;
+        auto dst = &surface->buffer[span->y * surface->stride + span->x];
+        auto alpha = ALPHA_MULTIPLY(span->coverage, opacity);
+        for (uint32_t x = 0; x < span->len; ++x, ++dst) {
+            auto rX = static_cast<uint32_t>(roundf((span->x + x) * invTransform->e11 + ey1));
+            auto rY = static_cast<uint32_t>(roundf((span->x + x) * invTransform->e21 + ey2));
+            if (rX >= w || rY >= h) continue;
+            auto src = ALPHA_BLEND(img[rY * w + rX], alpha);     //TODO: need to use image's stride
+            *dst = src + ALPHA_BLEND(*dst, 255 - surface->blender.alpha(src));
+        }
+    }
+    return true;
+}
+
+static bool _rasterTranslucentUpScaleImageRle(SwSurface* surface, const SwRleData* rle, uint32_t *img, uint32_t w, uint32_t h, uint32_t opacity, const Matrix* invTransform)
+{
+    auto span = rle->spans;
     for (uint32_t i = 0; i < rle->size; ++i, ++span) {
         auto ey1 = span->y * invTransform->e12 + invTransform->e13;
         auto ey2 = span->y * invTransform->e22 + invTransform->e23;
@@ -351,11 +368,8 @@ static bool _rasterTranslucentImageRle(SwSurface* surface, const SwRleData* rle,
             auto rY = static_cast<uint32_t>(roundf(fY));
             if (rX >= w || rY >= h) continue;
             uint32_t src;
-            if (isDownScaling || rX == w - 1 || rY == h - 1) {
-                src = ALPHA_BLEND(img[rY * w + rX], alpha);     //TODO: need to use image's stride
-            } else {
-                src = ALPHA_BLEND(_applyBilinearInterpolation(img, w, h, fX, fY), alpha);     //TODO: need to use image's stride
-            }
+            if (rX == w - 1 || rY == h - 1) src = ALPHA_BLEND(img[rY * w + rX], alpha);     //TODO: need to use image's stride
+            else src = ALPHA_BLEND(_applyBilinearInterpolation(img, w, h, fX, fY), alpha);     //TODO: need to use image's stride
             *dst = src + ALPHA_BLEND(*dst, 255 - surface->blender.alpha(src));
         }
     }
@@ -382,7 +396,26 @@ static bool _rasterImageRle(SwSurface* surface, SwRleData* rle, uint32_t *img, u
 static bool _rasterImageRle(SwSurface* surface, SwRleData* rle, uint32_t *img, uint32_t w, uint32_t h, const Matrix* invTransform)
 {
     auto span = rle->spans;
-    bool isDownScaling = (invTransform->e11 * invTransform->e11) + (invTransform->e21 * invTransform->e21) > 1 ? true : false;
+
+    for (uint32_t i = 0; i < rle->size; ++i, ++span) {
+        auto ey1 = span->y * invTransform->e12 + invTransform->e13;
+        auto ey2 = span->y * invTransform->e22 + invTransform->e23;
+        auto dst = &surface->buffer[span->y * surface->stride + span->x];
+        for (uint32_t x = 0; x < span->len; ++x, ++dst) {
+            auto rX = static_cast<uint32_t>(roundf((span->x + x) * invTransform->e11 + ey1));
+            auto rY = static_cast<uint32_t>(roundf((span->x + x) * invTransform->e21 + ey2));
+            if (rX >= w || rY >= h) continue;
+            auto src = ALPHA_BLEND(img[rY * w + rX], span->coverage);    //TODO: need to use image's stride
+            *dst = src + ALPHA_BLEND(*dst, 255 - surface->blender.alpha(src));
+        }
+    }
+    return true;
+}
+
+
+static bool _rasterUpScaleImageRle(SwSurface* surface, SwRleData* rle, uint32_t *img, uint32_t w, uint32_t h, const Matrix* invTransform)
+{
+    auto span = rle->spans;
 
     for (uint32_t i = 0; i < rle->size; ++i, ++span) {
         auto ey1 = span->y * invTransform->e12 + invTransform->e13;
@@ -395,11 +428,8 @@ static bool _rasterImageRle(SwSurface* surface, SwRleData* rle, uint32_t *img, u
             auto rY = static_cast<uint32_t>(roundf(fY));
             if (rX >= w || rY >= h) continue;
             uint32_t src;
-            if (isDownScaling || rX == w - 1 || rY == h - 1) {
-                src = ALPHA_BLEND(img[rY * w + rX], span->coverage);    //TODO: need to use image's stride
-            } else {
-                src = ALPHA_BLEND(_applyBilinearInterpolation(img, w, h, fX, fY), span->coverage);    //TODO: need to use image's stride
-            }
+            if (rX == w - 1 || rY == h - 1) src = ALPHA_BLEND(img[rY * w + rX], span->coverage);    //TODO: need to use image's stride
+            else src = ALPHA_BLEND(_applyBilinearInterpolation(img, w, h, fX, fY), span->coverage);    //TODO: need to use image's stride
             *dst = src + ALPHA_BLEND(*dst, 255 - surface->blender.alpha(src));
         }
     }
@@ -410,24 +440,16 @@ static bool _rasterImageRle(SwSurface* surface, SwRleData* rle, uint32_t *img, u
 static bool _translucentImage(SwSurface* surface, const uint32_t *img, uint32_t w, TVG_UNUSED uint32_t h, uint32_t opacity, const SwBBox& region, const Matrix* invTransform)
 {
     auto dbuffer = &surface->buffer[region.min.y * surface->stride + region.min.x];
-    bool isDownScaling = (invTransform->e11 * invTransform->e11) + (invTransform->e21 * invTransform->e21) > 1 ? true : false;
 
     for (auto y = region.min.y; y < region.max.y; ++y) {
         auto dst = dbuffer;
         auto ey1 = y * invTransform->e12 + invTransform->e13;
         auto ey2 = y * invTransform->e22 + invTransform->e23;
         for (auto x = region.min.x; x < region.max.x; ++x, ++dst) {
-            auto fX = x * invTransform->e11 + ey1;
-            auto fY = x * invTransform->e21 + ey2;
-            auto rX = static_cast<uint32_t>(roundf(fX));
-            auto rY = static_cast<uint32_t>(roundf(fY));
+            auto rX = static_cast<uint32_t>(roundf(x * invTransform->e11 + ey1));
+            auto rY = static_cast<uint32_t>(roundf(x * invTransform->e21 + ey2));
             if (rX >= w || rY >= h) continue;
-            uint32_t src;
-            if (isDownScaling || rX == w - 1 || rY == h - 1) {
-                src = ALPHA_BLEND(img[rX + (rY * w)], opacity);    //TODO: need to use image's stride
-            } else {
-                src = ALPHA_BLEND(_applyBilinearInterpolation(img, w, h, fX, fY), opacity);    //TODO: need to use image's stride
-            }
+            auto src = ALPHA_BLEND(img[rX + (rY * w)], opacity);    //TODO: need to use image's stride
             *dst = src + ALPHA_BLEND(*dst, 255 - surface->blender.alpha(src));
         }
         dbuffer += surface->stride;
@@ -442,7 +464,6 @@ static bool _translucentImageAlphaMask(SwSurface* surface, const uint32_t *img, 
 
     auto dbuffer = &surface->buffer[region.min.y * surface->stride + region.min.x];
     auto cbuffer = &surface->compositor->image.data[region.min.y * surface->stride + region.min.x];
-    bool isDownScaling = (invTransform->e11 * invTransform->e11) + (invTransform->e21 * invTransform->e21) > 1 ? true : false;
 
     for (auto y = region.min.y; y < region.max.y; ++y) {
         auto dst = dbuffer;
@@ -450,17 +471,10 @@ static bool _translucentImageAlphaMask(SwSurface* surface, const uint32_t *img, 
         float ey1 = y * invTransform->e12 + invTransform->e13;
         float ey2 = y * invTransform->e22 + invTransform->e23;
         for (auto x = region.min.x; x < region.max.x; ++x, ++dst, ++cmp) {
-            auto fX = x * invTransform->e11 + ey1;
-            auto fY = x * invTransform->e21 + ey2;
-            auto rX = static_cast<uint32_t>(roundf(fX));
-            auto rY = static_cast<uint32_t>(roundf(fY));
+            auto rX = static_cast<uint32_t>(roundf(x * invTransform->e11 + ey1));
+            auto rY = static_cast<uint32_t>(roundf(x * invTransform->e21 + ey2));
             if (rX >= w || rY >= h) continue;
-            uint32_t src;
-            if (isDownScaling || rX == w - 1 || rY == h - 1) {
-                src = ALPHA_BLEND(img[rX + (rY * w)], ALPHA_MULTIPLY(opacity, surface->blender.alpha(*cmp)));  //TODO: need to use image's stride
-            } else {
-                src = ALPHA_BLEND(_applyBilinearInterpolation(img, w, h, fX, fY), ALPHA_MULTIPLY(opacity, surface->blender.alpha(*cmp)));  //TODO: need to use image's stride
-            }
+            auto src = ALPHA_BLEND(img[rX + (rY * w)], ALPHA_MULTIPLY(opacity, surface->blender.alpha(*cmp)));  //TODO: need to use image's stride
             *dst = src + ALPHA_BLEND(*dst, 255 - surface->blender.alpha(src));
         }
         dbuffer += surface->stride;
@@ -475,7 +489,71 @@ static bool _translucentImageInvAlphaMask(SwSurface* surface, const uint32_t *im
 
     auto dbuffer = &surface->buffer[region.min.y * surface->stride + region.min.x];
     auto cbuffer = &surface->compositor->image.data[region.min.y * surface->stride + region.min.x];
-    bool isDownScaling = (invTransform->e11 * invTransform->e11) + (invTransform->e21 * invTransform->e21) > 1 ? true : false;
+
+    for (auto y = region.min.y; y < region.max.y; ++y) {
+        auto dst = dbuffer;
+        auto cmp = cbuffer;
+        float ey1 = y * invTransform->e12 + invTransform->e13;
+        float ey2 = y * invTransform->e22 + invTransform->e23;
+        for (auto x = region.min.x; x < region.max.x; ++x, ++dst, ++cmp) {
+            auto rX = static_cast<uint32_t>(roundf(x * invTransform->e11 + ey1));
+            auto rY = static_cast<uint32_t>(roundf(x * invTransform->e21 + ey2));
+            if (rX >= w || rY >= h) continue;
+            auto src = ALPHA_BLEND(img[rX + (rY * w)], ALPHA_MULTIPLY(opacity, 255 - surface->blender.alpha(*cmp)));  //TODO: need to use image's stride
+            *dst = src + ALPHA_BLEND(*dst, 255 - surface->blender.alpha(src));
+        }
+        dbuffer += surface->stride;
+        cbuffer += surface->stride;
+    }
+    return true;
+}
+
+
+static bool _rasterTranslucentImage(SwSurface* surface, const uint32_t *img, uint32_t w, uint32_t h, uint32_t opacity, const SwBBox& region, const Matrix* invTransform)
+{
+    if (surface->compositor) {
+        if (surface->compositor->method == CompositeMethod::AlphaMask) {
+            return _translucentImageAlphaMask(surface, img, w, h, opacity, region, invTransform);
+        }
+        if (surface->compositor->method == CompositeMethod::InvAlphaMask) {
+            return _translucentImageInvAlphaMask(surface, img, w, h, opacity, region, invTransform);
+        }
+    }
+    return _translucentImage(surface, img, w, h, opacity, region, invTransform);
+}
+
+
+static bool _translucentUpScaleImage(SwSurface* surface, const uint32_t *img, uint32_t w, TVG_UNUSED uint32_t h, uint32_t opacity, const SwBBox& region, const Matrix* invTransform)
+{
+    auto dbuffer = &surface->buffer[region.min.y * surface->stride + region.min.x];
+
+    for (auto y = region.min.y; y < region.max.y; ++y) {
+        auto dst = dbuffer;
+        auto ey1 = y * invTransform->e12 + invTransform->e13;
+        auto ey2 = y * invTransform->e22 + invTransform->e23;
+        for (auto x = region.min.x; x < region.max.x; ++x, ++dst) {
+            auto fX = x * invTransform->e11 + ey1;
+            auto fY = x * invTransform->e21 + ey2;
+            auto rX = static_cast<uint32_t>(roundf(fX));
+            auto rY = static_cast<uint32_t>(roundf(fY));
+            if (rX >= w || rY >= h) continue;
+            uint32_t src;
+            if (rX == w - 1 || rY == h - 1) src = ALPHA_BLEND(img[rX + (rY * w)], opacity);    //TODO: need to use image's stride
+            else src = ALPHA_BLEND(_applyBilinearInterpolation(img, w, h, fX, fY), opacity);    //TODO: need to use image's stride
+            *dst = src + ALPHA_BLEND(*dst, 255 - surface->blender.alpha(src));
+        }
+        dbuffer += surface->stride;
+    }
+    return true;
+}
+
+
+static bool _translucentUpScaleImageAlphaMask(SwSurface* surface, const uint32_t *img, uint32_t w, TVG_UNUSED uint32_t h, uint32_t opacity, const SwBBox& region, const Matrix* invTransform)
+{
+    TVGLOG("SW_ENGINE", "Transformed Image Alpha Mask Composition");
+
+    auto dbuffer = &surface->buffer[region.min.y * surface->stride + region.min.x];
+    auto cbuffer = &surface->compositor->image.data[region.min.y * surface->stride + region.min.x];
 
     for (auto y = region.min.y; y < region.max.y; ++y) {
         auto dst = dbuffer;
@@ -489,11 +567,8 @@ static bool _translucentImageInvAlphaMask(SwSurface* surface, const uint32_t *im
             auto rY = static_cast<uint32_t>(roundf(fY));
             if (rX >= w || rY >= h) continue;
             uint32_t src;
-            if (isDownScaling || rX == w - 1 || rY == h - 1) {
-                src = ALPHA_BLEND(img[rX + (rY * w)], ALPHA_MULTIPLY(opacity, 255 - surface->blender.alpha(*cmp)));  //TODO: need to use image's stride
-            } else {
-                src = ALPHA_BLEND(_applyBilinearInterpolation(img, w, h, fX, fY), ALPHA_MULTIPLY(opacity, 255 - surface->blender.alpha(*cmp)));  //TODO: need to use image's stride
-            }
+            if (rX == w - 1 || rY == h - 1) src = ALPHA_BLEND(img[rX + (rY * w)], ALPHA_MULTIPLY(opacity, surface->blender.alpha(*cmp)));  //TODO: need to use image's stride
+            else src = ALPHA_BLEND(_applyBilinearInterpolation(img, w, h, fX, fY), ALPHA_MULTIPLY(opacity, surface->blender.alpha(*cmp)));  //TODO: need to use image's stride
             *dst = src + ALPHA_BLEND(*dst, 255 - surface->blender.alpha(src));
         }
         dbuffer += surface->stride;
@@ -502,17 +577,48 @@ static bool _translucentImageInvAlphaMask(SwSurface* surface, const uint32_t *im
     return true;
 }
 
-static bool _rasterTranslucentImage(SwSurface* surface, const uint32_t *img, uint32_t w, uint32_t h, uint32_t opacity, const SwBBox& region, const Matrix* invTransform)
+
+static bool _translucentUpScaleImageInvAlphaMask(SwSurface* surface, const uint32_t *img, uint32_t w, uint32_t h, uint32_t opacity, const SwBBox& region, const Matrix* invTransform)
+{
+    TVGLOG("SW_ENGINE", "Transformed Image Inverse Alpha Mask Composition");
+
+    auto dbuffer = &surface->buffer[region.min.y * surface->stride + region.min.x];
+    auto cbuffer = &surface->compositor->image.data[region.min.y * surface->stride + region.min.x];
+
+    for (auto y = region.min.y; y < region.max.y; ++y) {
+        auto dst = dbuffer;
+        auto cmp = cbuffer;
+        float ey1 = y * invTransform->e12 + invTransform->e13;
+        float ey2 = y * invTransform->e22 + invTransform->e23;
+        for (auto x = region.min.x; x < region.max.x; ++x, ++dst, ++cmp) {
+            auto fX = x * invTransform->e11 + ey1;
+            auto fY = x * invTransform->e21 + ey2;
+            auto rX = static_cast<uint32_t>(roundf(fX));
+            auto rY = static_cast<uint32_t>(roundf(fY));
+            if (rX >= w || rY >= h) continue;
+            uint32_t src;
+            if (rX == w - 1 || rY == h - 1) src = ALPHA_BLEND(img[rX + (rY * w)], ALPHA_MULTIPLY(opacity, 255 - surface->blender.alpha(*cmp)));  //TODO: need to use image's stride
+            else src = ALPHA_BLEND(_applyBilinearInterpolation(img, w, h, fX, fY), ALPHA_MULTIPLY(opacity, 255 - surface->blender.alpha(*cmp)));  //TODO: need to use image's stride
+            *dst = src + ALPHA_BLEND(*dst, 255 - surface->blender.alpha(src));
+        }
+        dbuffer += surface->stride;
+        cbuffer += surface->stride;
+    }
+    return true;
+}
+
+
+static bool _rasterTranslucentUpScaleImage(SwSurface* surface, const uint32_t *img, uint32_t w, uint32_t h, uint32_t opacity, const SwBBox& region, const Matrix* invTransform)
 {
     if (surface->compositor) {
         if (surface->compositor->method == CompositeMethod::AlphaMask) {
-            return _translucentImageAlphaMask(surface, img, w, h, opacity, region, invTransform);
+            return _translucentUpScaleImageAlphaMask(surface, img, w, h, opacity, region, invTransform);
         }
         if (surface->compositor->method == CompositeMethod::InvAlphaMask) {
-            return _translucentImageInvAlphaMask(surface, img, w, h, opacity, region, invTransform);
+            return _translucentUpScaleImageInvAlphaMask(surface, img, w, h, opacity, region, invTransform);
         }
     }
-    return _translucentImage(surface, img, w, h, opacity, region, invTransform);
+    return _translucentUpScaleImage(surface, img, w, h, opacity, region, invTransform);
 }
 
 
@@ -588,6 +694,7 @@ static bool _translucentImageInvAlphaMask(SwSurface* surface, uint32_t *img, uin
     return true;
 }
 
+
 static bool _rasterTranslucentImage(SwSurface* surface, uint32_t *img, uint32_t w, uint32_t h, uint32_t opacity, const SwBBox& region)
 {
     if (surface->compositor) {
@@ -619,9 +726,27 @@ static bool _rasterImage(SwSurface* surface, uint32_t *img, uint32_t w, TVG_UNUS
     return true;
 }
 
+
 static bool _rasterImage(SwSurface* surface, const uint32_t *img, uint32_t w, uint32_t h, const SwBBox& region, const Matrix* invTransform)
 {
-    bool isDownScaling = (invTransform->e11 * invTransform->e11) + (invTransform->e21 * invTransform->e21) > 1 ? true : false;
+    for (auto y = region.min.y; y < region.max.y; ++y) {
+        auto dst = &surface->buffer[y * surface->stride + region.min.x];
+        auto ey1 = y * invTransform->e12 + invTransform->e13;
+        auto ey2 = y * invTransform->e22 + invTransform->e23;
+        for (auto x = region.min.x; x < region.max.x; ++x, ++dst) {
+            auto rX = static_cast<uint32_t>(roundf(x * invTransform->e11 + ey1));
+            auto rY = static_cast<uint32_t>(roundf(x * invTransform->e21 + ey2));
+            if (rX >= w || rY >= h) continue;
+            auto src = img[rX + (rY * w)];    //TODO: need to use image's stride
+            *dst = src + ALPHA_BLEND(*dst, 255 - surface->blender.alpha(src));
+        }
+    }
+    return true;
+}
+
+
+static bool _rasterUpScaleImage(SwSurface* surface, const uint32_t *img, uint32_t w, uint32_t h, const SwBBox& region, const Matrix* invTransform)
+{
     for (auto y = region.min.y; y < region.max.y; ++y) {
         auto dst = &surface->buffer[y * surface->stride + region.min.x];
         auto ey1 = y * invTransform->e12 + invTransform->e13;
@@ -633,17 +758,13 @@ static bool _rasterImage(SwSurface* surface, const uint32_t *img, uint32_t w, ui
             auto rY = static_cast<uint32_t>(roundf(fY));
             if (rX >= w || rY >= h) continue;
             uint32_t src;
-            if (isDownScaling || rX == w - 1 || rY == h - 1) {
-                src = img[rX + (rY * w)];
-            } else {
-                src = _applyBilinearInterpolation(img, w, h, fX, fY);
-            }
+            if (rX == w - 1 || rY == h - 1) src = img[rX + (rY * w)];
+            else src = _applyBilinearInterpolation(img, w, h, fX, fY);
             *dst = src + ALPHA_BLEND(*dst, 255 - surface->blender.alpha(src));
         }
     }
     return true;
 }
-
 /************************************************************************/
 /* Gradient                                                             */
 /************************************************************************/
@@ -1295,9 +1416,11 @@ bool rasterClear(SwSurface* surface)
 bool rasterImage(SwSurface* surface, SwImage* image, const Matrix* transform, const SwBBox& bbox, uint32_t opacity)
 {
     Matrix invTransform;
+    auto isUpScaling = false;
 
     if (transform) {
         if (!_inverse(transform, &invTransform)) return false;
+        isUpScaling = (transform->e11 * transform->e11) + (transform->e21 * transform->e21) > 1 ? true : false;
     }
     else invTransform = {1, 0, 0, 0, 1, 0, 0, 0, 1};
 
@@ -1310,7 +1433,11 @@ bool rasterImage(SwSurface* surface, SwImage* image, const Matrix* transform, co
             if (translucent) return _rasterTranslucentImageRle(surface, image->rle, image->data, image->w, image->h, opacity);
             return _rasterImageRle(surface, image->rle, image->data, image->w, image->h);
         } else {
-            if (translucent) return _rasterTranslucentImageRle(surface, image->rle, image->data, image->w, image->h, opacity, &invTransform);
+            if (translucent) {
+                if (isUpScaling) return _rasterTranslucentUpScaleImageRle(surface, image->rle, image->data, image->w, image->h, opacity, &invTransform);
+                return _rasterTranslucentImageRle(surface, image->rle, image->data, image->w, image->h, opacity, &invTransform);
+            }
+            if (isUpScaling) return _rasterUpScaleImageRle(surface, image->rle, image->data, image->w, image->h, &invTransform);
             return _rasterImageRle(surface, image->rle, image->data, image->w, image->h, &invTransform);
         }
     }
@@ -1319,10 +1446,14 @@ bool rasterImage(SwSurface* surface, SwImage* image, const Matrix* transform, co
         if (_identify(transform)) {
             //OPTIMIZE ME: Support non transformed image. Only shifted image can use these routines.
             if (translucent) return _rasterTranslucentImage(surface, image->data, image->w, image->h, opacity, bbox);
-            else return _rasterImage(surface, image->data, image->w, image->h, bbox);
+            return _rasterImage(surface, image->data, image->w, image->h, bbox);
         } else {
-            if (translucent) return _rasterTranslucentImage(surface, image->data, image->w, image->h, opacity, bbox, &invTransform);
-            else return _rasterImage(surface, image->data, image->w, image->h, bbox, &invTransform);
+            if (translucent) {
+                if (isUpScaling) return _rasterTranslucentUpScaleImage(surface, image->data, image->w, image->h, opacity, bbox, &invTransform);
+                return _rasterTranslucentImage(surface, image->data, image->w, image->h, opacity, bbox, &invTransform);
+            }
+            if (isUpScaling) return _rasterUpScaleImage(surface, image->data, image->w, image->h, bbox, &invTransform);
+            return _rasterImage(surface, image->data, image->w, image->h, bbox, &invTransform);
         }
     }
 }

--- a/src/lib/sw_engine/tvgSwRaster.cpp
+++ b/src/lib/sw_engine/tvgSwRaster.cpp
@@ -338,6 +338,7 @@ static bool _rasterTranslucentImageRle(SwSurface* surface, const SwRleData* rle,
 static bool _rasterTranslucentImageRle(SwSurface* surface, const SwRleData* rle, uint32_t *img, uint32_t w, uint32_t h, uint32_t opacity, const Matrix* invTransform)
 {
     auto span = rle->spans;
+    bool isDownScaling = (invTransform->e11 * invTransform->e11) + (invTransform->e21 * invTransform->e21) > 1 ? true : false;
     for (uint32_t i = 0; i < rle->size; ++i, ++span) {
         auto ey1 = span->y * invTransform->e12 + invTransform->e13;
         auto ey2 = span->y * invTransform->e22 + invTransform->e23;
@@ -350,7 +351,7 @@ static bool _rasterTranslucentImageRle(SwSurface* surface, const SwRleData* rle,
             auto rY = static_cast<uint32_t>(roundf(fY));
             if (rX >= w || rY >= h) continue;
             uint32_t src;
-            if (rX == w - 1 || rY == h - 1 || (invTransform->e11 * invTransform->e11) + (invTransform->e21 * invTransform->e21) > 1) {
+            if (isDownScaling || rX == w - 1 || rY == h - 1) {
                 src = ALPHA_BLEND(img[rY * w + rX], alpha);     //TODO: need to use image's stride
             } else {
                 src = ALPHA_BLEND(_applyBilinearInterpolation(img, w, h, fX, fY), alpha);     //TODO: need to use image's stride
@@ -381,6 +382,7 @@ static bool _rasterImageRle(SwSurface* surface, SwRleData* rle, uint32_t *img, u
 static bool _rasterImageRle(SwSurface* surface, SwRleData* rle, uint32_t *img, uint32_t w, uint32_t h, const Matrix* invTransform)
 {
     auto span = rle->spans;
+    bool isDownScaling = (invTransform->e11 * invTransform->e11) + (invTransform->e21 * invTransform->e21) > 1 ? true : false;
 
     for (uint32_t i = 0; i < rle->size; ++i, ++span) {
         auto ey1 = span->y * invTransform->e12 + invTransform->e13;
@@ -393,7 +395,7 @@ static bool _rasterImageRle(SwSurface* surface, SwRleData* rle, uint32_t *img, u
             auto rY = static_cast<uint32_t>(roundf(fY));
             if (rX >= w || rY >= h) continue;
             uint32_t src;
-            if (rX == w - 1 || rY == h - 1 || (invTransform->e11 * invTransform->e11) + (invTransform->e21 * invTransform->e21) > 1) {
+            if (isDownScaling || rX == w - 1 || rY == h - 1) {
                 src = ALPHA_BLEND(img[rY * w + rX], span->coverage);    //TODO: need to use image's stride
             } else {
                 src = ALPHA_BLEND(_applyBilinearInterpolation(img, w, h, fX, fY), span->coverage);    //TODO: need to use image's stride
@@ -408,6 +410,7 @@ static bool _rasterImageRle(SwSurface* surface, SwRleData* rle, uint32_t *img, u
 static bool _translucentImage(SwSurface* surface, const uint32_t *img, uint32_t w, TVG_UNUSED uint32_t h, uint32_t opacity, const SwBBox& region, const Matrix* invTransform)
 {
     auto dbuffer = &surface->buffer[region.min.y * surface->stride + region.min.x];
+    bool isDownScaling = (invTransform->e11 * invTransform->e11) + (invTransform->e21 * invTransform->e21) > 1 ? true : false;
 
     for (auto y = region.min.y; y < region.max.y; ++y) {
         auto dst = dbuffer;
@@ -420,7 +423,7 @@ static bool _translucentImage(SwSurface* surface, const uint32_t *img, uint32_t 
             auto rY = static_cast<uint32_t>(roundf(fY));
             if (rX >= w || rY >= h) continue;
             uint32_t src;
-            if (rX == w - 1 || rY == h - 1 || (invTransform->e11 * invTransform->e11) + (invTransform->e21 * invTransform->e21) > 1) {
+            if (isDownScaling || rX == w - 1 || rY == h - 1) {
                 src = ALPHA_BLEND(img[rX + (rY * w)], opacity);    //TODO: need to use image's stride
             } else {
                 src = ALPHA_BLEND(_applyBilinearInterpolation(img, w, h, fX, fY), opacity);    //TODO: need to use image's stride
@@ -439,6 +442,7 @@ static bool _translucentImageAlphaMask(SwSurface* surface, const uint32_t *img, 
 
     auto dbuffer = &surface->buffer[region.min.y * surface->stride + region.min.x];
     auto cbuffer = &surface->compositor->image.data[region.min.y * surface->stride + region.min.x];
+    bool isDownScaling = (invTransform->e11 * invTransform->e11) + (invTransform->e21 * invTransform->e21) > 1 ? true : false;
 
     for (auto y = region.min.y; y < region.max.y; ++y) {
         auto dst = dbuffer;
@@ -452,7 +456,7 @@ static bool _translucentImageAlphaMask(SwSurface* surface, const uint32_t *img, 
             auto rY = static_cast<uint32_t>(roundf(fY));
             if (rX >= w || rY >= h) continue;
             uint32_t src;
-            if (rX == w - 1 || rY == h - 1 || (invTransform->e11 * invTransform->e11) + (invTransform->e21 * invTransform->e21) > 1) {
+            if (isDownScaling || rX == w - 1 || rY == h - 1) {
                 src = ALPHA_BLEND(img[rX + (rY * w)], ALPHA_MULTIPLY(opacity, surface->blender.alpha(*cmp)));  //TODO: need to use image's stride
             } else {
                 src = ALPHA_BLEND(_applyBilinearInterpolation(img, w, h, fX, fY), ALPHA_MULTIPLY(opacity, surface->blender.alpha(*cmp)));  //TODO: need to use image's stride
@@ -471,6 +475,7 @@ static bool _translucentImageInvAlphaMask(SwSurface* surface, const uint32_t *im
 
     auto dbuffer = &surface->buffer[region.min.y * surface->stride + region.min.x];
     auto cbuffer = &surface->compositor->image.data[region.min.y * surface->stride + region.min.x];
+    bool isDownScaling = (invTransform->e11 * invTransform->e11) + (invTransform->e21 * invTransform->e21) > 1 ? true : false;
 
     for (auto y = region.min.y; y < region.max.y; ++y) {
         auto dst = dbuffer;
@@ -484,7 +489,7 @@ static bool _translucentImageInvAlphaMask(SwSurface* surface, const uint32_t *im
             auto rY = static_cast<uint32_t>(roundf(fY));
             if (rX >= w || rY >= h) continue;
             uint32_t src;
-            if (rX == w - 1 || rY == h - 1 || (invTransform->e11 * invTransform->e11) + (invTransform->e21 * invTransform->e21) > 1) {
+            if (isDownScaling || rX == w - 1 || rY == h - 1) {
                 src = ALPHA_BLEND(img[rX + (rY * w)], ALPHA_MULTIPLY(opacity, 255 - surface->blender.alpha(*cmp)));  //TODO: need to use image's stride
             } else {
                 src = ALPHA_BLEND(_applyBilinearInterpolation(img, w, h, fX, fY), ALPHA_MULTIPLY(opacity, 255 - surface->blender.alpha(*cmp)));  //TODO: need to use image's stride
@@ -616,6 +621,7 @@ static bool _rasterImage(SwSurface* surface, uint32_t *img, uint32_t w, TVG_UNUS
 
 static bool _rasterImage(SwSurface* surface, const uint32_t *img, uint32_t w, uint32_t h, const SwBBox& region, const Matrix* invTransform)
 {
+    bool isDownScaling = (invTransform->e11 * invTransform->e11) + (invTransform->e21 * invTransform->e21) > 1 ? true : false;
     for (auto y = region.min.y; y < region.max.y; ++y) {
         auto dst = &surface->buffer[y * surface->stride + region.min.x];
         auto ey1 = y * invTransform->e12 + invTransform->e13;
@@ -627,7 +633,7 @@ static bool _rasterImage(SwSurface* surface, const uint32_t *img, uint32_t w, ui
             auto rY = static_cast<uint32_t>(roundf(fY));
             if (rX >= w || rY >= h) continue;
             uint32_t src;
-            if (rX == w - 1 || rY == h - 1 || (invTransform->e11 * invTransform->e11) + (invTransform->e21 * invTransform->e21) > 1) {
+            if (isDownScaling || rX == w - 1 || rY == h - 1) {
                 src = img[rX + (rY * w)];
             } else {
                 src = _applyBilinearInterpolation(img, w, h, fX, fY);

--- a/src/lib/sw_engine/tvgSwRaster.cpp
+++ b/src/lib/sw_engine/tvgSwRaster.cpp
@@ -350,7 +350,7 @@ static bool _rasterTranslucentImageRle(SwSurface* surface, const SwRleData* rle,
             auto rY = static_cast<uint32_t>(roundf(fY));
             if (rX >= w || rY >= h) continue;
             uint32_t src;
-            if (rX == w - 1 || rY == h - 1 || invTransform->e11 < 0 || invTransform->e22 < 0) {
+            if (rX == w - 1 || rY == h - 1 || (invTransform->e11 * invTransform->e11) + (invTransform->e21 * invTransform->e21) > 1) {
                 src = ALPHA_BLEND(img[rY * w + rX], alpha);     //TODO: need to use image's stride
             } else {
                 src = ALPHA_BLEND(_applyBilinearInterpolation(img, w, h, fX, fY), alpha);     //TODO: need to use image's stride
@@ -393,7 +393,7 @@ static bool _rasterImageRle(SwSurface* surface, SwRleData* rle, uint32_t *img, u
             auto rY = static_cast<uint32_t>(roundf(fY));
             if (rX >= w || rY >= h) continue;
             uint32_t src;
-            if (rX == w - 1 || rY == h - 1 || invTransform->e11 < 0 || invTransform->e22 < 0) {
+            if (rX == w - 1 || rY == h - 1 || (invTransform->e11 * invTransform->e11) + (invTransform->e21 * invTransform->e21) > 1) {
                 src = ALPHA_BLEND(img[rY * w + rX], span->coverage);    //TODO: need to use image's stride
             } else {
                 src = ALPHA_BLEND(_applyBilinearInterpolation(img, w, h, fX, fY), span->coverage);    //TODO: need to use image's stride
@@ -420,7 +420,7 @@ static bool _translucentImage(SwSurface* surface, const uint32_t *img, uint32_t 
             auto rY = static_cast<uint32_t>(roundf(fY));
             if (rX >= w || rY >= h) continue;
             uint32_t src;
-            if (rX == w - 1 || rY == h - 1 || invTransform->e11 < 0 || invTransform->e22 < 0) {
+            if (rX == w - 1 || rY == h - 1 || (invTransform->e11 * invTransform->e11) + (invTransform->e21 * invTransform->e21) > 1) {
                 src = ALPHA_BLEND(img[rX + (rY * w)], opacity);    //TODO: need to use image's stride
             } else {
                 src = ALPHA_BLEND(_applyBilinearInterpolation(img, w, h, fX, fY), opacity);    //TODO: need to use image's stride
@@ -452,7 +452,7 @@ static bool _translucentImageAlphaMask(SwSurface* surface, const uint32_t *img, 
             auto rY = static_cast<uint32_t>(roundf(fY));
             if (rX >= w || rY >= h) continue;
             uint32_t src;
-            if (rX == w - 1 || rY == h - 1 || invTransform->e11 < 0 || invTransform->e22 < 0) {
+            if (rX == w - 1 || rY == h - 1 || (invTransform->e11 * invTransform->e11) + (invTransform->e21 * invTransform->e21) > 1) {
                 src = ALPHA_BLEND(img[rX + (rY * w)], ALPHA_MULTIPLY(opacity, surface->blender.alpha(*cmp)));  //TODO: need to use image's stride
             } else {
                 src = ALPHA_BLEND(_applyBilinearInterpolation(img, w, h, fX, fY), ALPHA_MULTIPLY(opacity, surface->blender.alpha(*cmp)));  //TODO: need to use image's stride
@@ -484,7 +484,7 @@ static bool _translucentImageInvAlphaMask(SwSurface* surface, const uint32_t *im
             auto rY = static_cast<uint32_t>(roundf(fY));
             if (rX >= w || rY >= h) continue;
             uint32_t src;
-            if (rX == w - 1 || rY == h - 1 || invTransform->e11 < 0 || invTransform->e22 < 0) {
+            if (rX == w - 1 || rY == h - 1 || (invTransform->e11 * invTransform->e11) + (invTransform->e21 * invTransform->e21) > 1) {
                 src = ALPHA_BLEND(img[rX + (rY * w)], ALPHA_MULTIPLY(opacity, 255 - surface->blender.alpha(*cmp)));  //TODO: need to use image's stride
             } else {
                 src = ALPHA_BLEND(_applyBilinearInterpolation(img, w, h, fX, fY), ALPHA_MULTIPLY(opacity, 255 - surface->blender.alpha(*cmp)));  //TODO: need to use image's stride
@@ -627,7 +627,7 @@ static bool _rasterImage(SwSurface* surface, const uint32_t *img, uint32_t w, ui
             auto rY = static_cast<uint32_t>(roundf(fY));
             if (rX >= w || rY >= h) continue;
             uint32_t src;
-            if (rX == w - 1 || rY == h - 1 || invTransform->e11 < 0 || invTransform->e22 < 0) {
+            if (rX == w - 1 || rY == h - 1 || (invTransform->e11 * invTransform->e11) + (invTransform->e21 * invTransform->e21) > 1) {
                 src = img[rX + (rY * w)];
             } else {
                 src = _applyBilinearInterpolation(img, w, h, fX, fY);


### PR DESCRIPTION
Apply bilinear interpolation when drawing images with transformation
If the mapped coordinate value is a floating point value,
bilinear interpolation is performed using adjacent pixel values.
Interpolation is not performed in cases when the color values to be interpolated
are the same or scale down case.

issue : https://github.com/Samsung/thorvg/issues/373

[left before right after]
![image](https://user-images.githubusercontent.com/7413838/126261545-666ba134-07bd-48ec-9674-33d5b0c6bbfd.png)

![image](https://user-images.githubusercontent.com/7413838/126261663-8f942bd0-9a47-4577-8cd6-a867cb0d3da9.png)
(scale down case is same result)

![image](https://user-images.githubusercontent.com/7413838/126261714-db1ab692-d0dd-4908-8c27-9d47411d7052.png)
(scale up x3)

![Screenshot from 2021-07-21 10-56-39](https://user-images.githubusercontent.com/7413838/126420379-3c40ff8f-32df-49ea-83db-37d5cbad9146.png)
(Translucent Image with clippath)

![Screenshot from 2021-07-21 10-59-27](https://user-images.githubusercontent.com/7413838/126420466-7dc9ed27-2b0d-4d92-9e22-062d6ae1cc90.png)
(Image with clippath)

![Screenshot from 2021-07-21 11-04-25](https://user-images.githubusercontent.com/7413838/126420512-3d181335-ca1a-469f-a1d8-7296d16482b8.png)
(Translucent Image)

![Screenshot from 2021-07-21 11-07-37_mask](https://user-images.githubusercontent.com/7413838/126420536-94a24247-fbaa-41e3-8a19-499cc6bcf325.png)
(Translucent Image with mask)

![Screenshot from 2021-07-21 11-09-58_invmask](https://user-images.githubusercontent.com/7413838/126420558-1998a314-751e-4c29-85c0-ba6e4490d4f2.png)
(Translucent Image with inverse mask)



