### PR TITLE
examples: replace sprintf() with snprintf()

### DIFF
--- a/src/examples/MultiCanvas.cpp
+++ b/src/examples/MultiCanvas.cpp
@@ -51,7 +51,7 @@ void tvgDrawCmds(tvg::Canvas* canvas, const char* path, const char* name)
     auto picture = tvg::Picture::gen();
 
     char buf[PATH_MAX];
-    sprintf(buf,"%s/%s", path, name);
+    snprintf(buf, sizeof(buf), "%s/%s", path, name);
 
     if (picture->load(buf) != tvg::Result::Success) return;
 

--- a/src/examples/Stress.cpp
+++ b/src/examples/Stress.cpp
@@ -45,7 +45,7 @@ void svgDirCallback(const char* name, const char* path, void* data)
     auto picture = tvg::Picture::gen();
 
     char buf[PATH_MAX];
-    sprintf(buf, "/%s/%s", path, name);
+    snprintf(buf, sizeof(buf), "/%s/%s", path, name);
 
     if (picture->load(buf) != tvg::Result::Success) return;
 

--- a/src/examples/Svg.cpp
+++ b/src/examples/Svg.cpp
@@ -43,7 +43,7 @@ void svgDirCallback(const char* name, const char* path, void* data)
     auto picture = tvg::Picture::gen();
 
     char buf[PATH_MAX];
-    sprintf(buf, "/%s/%s", path, name);
+    snprintf(buf, sizeof(buf), "/%s/%s", path, name);
 
     if (picture->load(buf) != tvg::Result::Success) return;
 


### PR DESCRIPTION
snprintf() is more preferred to use in preventing buffer overflow.