### PR TITLE
sw_engine clipping: fix segfault after scene used for ClipPath

### DIFF
--- a/src/lib/tvgPaint.cpp
+++ b/src/lib/tvgPaint.cpp
@@ -215,7 +215,7 @@ void* Paint::Impl::update(RenderMethod& renderer, const RenderTransform* pTransf
 
         if (!cmpFastTrack) {
             cmpData = cmpTarget->pImpl->update(renderer, pTransform, 255, clips, pFlag);
-            if (cmpMethod == CompositeMethod::ClipPath) clips.push(cmpData);
+            if (cmpData && cmpMethod == CompositeMethod::ClipPath) clips.push(cmpData);
         }
     }
 


### PR DESCRIPTION
ClipPath doesn't work with scene. This is a temporary solution that fixes
segfault if scene is applied as clippath composition anyway.