### PR TITLE
sw_engine clipping: allow scene for ClipPath

### DIFF
--- a/src/lib/tvgArray.h
+++ b/src/lib/tvgArray.h
@@ -43,6 +43,18 @@ struct Array
         data[count++] = element;
     }
 
+    void push(Array<T>* array)
+    {
+        if (count + array->count > reserved) {
+            reserved = count + array->count;
+            data = static_cast<T*>(realloc(data, sizeof(T) * reserved));
+        }
+        for (auto element = array->data; element < (array->data + array->count); ++element) {
+            if (*element) data[count++] = *element;
+        }
+        delete(array);
+    }
+
     bool reserve(uint32_t size)
     {
         if (size > reserved) {

--- a/src/lib/tvgPaint.cpp
+++ b/src/lib/tvgPaint.cpp
@@ -215,7 +215,13 @@ void* Paint::Impl::update(RenderMethod& renderer, const RenderTransform* pTransf
 
         if (!cmpFastTrack) {
             cmpData = cmpTarget->pImpl->update(renderer, pTransform, 255, clips, pFlag);
-            if (cmpMethod == CompositeMethod::ClipPath) clips.push(cmpData);
+            if (cmpMethod == CompositeMethod::ClipPath) {
+                if (cmpTarget->id() == TVG_CLASS_ID_SCENE) {
+                    clips.push(static_cast<Array<RenderData>*>(cmpData));
+                } else {
+                    clips.push(cmpData);
+                }
+            }
         }
     }
 

--- a/src/lib/tvgSceneImpl.h
+++ b/src/lib/tvgSceneImpl.h
@@ -87,16 +87,19 @@ struct Scene::Impl
         this->opacity = static_cast<uint8_t>(opacity);
         if (needComposition(opacity)) opacity = 255;
 
+        Array<RenderData>* array = new Array<RenderData>();
         for (auto paint = paints.data; paint < (paints.data + paints.count); ++paint) {
-            (*paint)->pImpl->update(renderer, transform, opacity, clips, static_cast<uint32_t>(flag));
+            void* data = (*paint)->pImpl->update(renderer, transform, opacity, clips, static_cast<uint32_t>(flag));
+            if ((*paint)->id() == TVG_CLASS_ID_SCENE) {
+                array->push(static_cast<Array<RenderData>*>(data));
+            } else {
+                array->push(data);
+            }
         }
-
-        /* FXIME: it requires to return list of children engine data
-           This is necessary for scene composition */
 
         this->renderer = &renderer;
 
-        return nullptr;
+        return array;
     }
 
     bool render(RenderMethod& renderer)


### PR DESCRIPTION
This patch changes tvgSceneImpl::update behaviour to return an array of
paints, allowing to use scene for ClipPath.
@issue: https://github.com/Samsung/thorvg/issues/524