### PR TITLE
tvg_saver: removing saving the default values

### DIFF
--- a/src/savers/tvg/tvgTvgSaver.h
+++ b/src/savers/tvg/tvgTvgSaver.h
@@ -67,4 +67,4 @@ public:
 
 }
 
-#endif  //_TVG_SAVE_MODULE_H_    
+#endif  //_TVG_SAVE_MODULE_H_


### PR DESCRIPTION
The default values (stroke cap/join, fill rule or color with alpha = 0)
were unnecessarily saved in the tvg format file.