### PR TITLE
common log: use the log macro to replace the print method easier.

### DIFF
--- a/src/lib/gl_engine/tvgGlCommon.h
+++ b/src/lib/gl_engine/tvgGlCommon.h
@@ -34,7 +34,7 @@
         do { \
           GLenum glError = glGetError(); \
           if(glError != GL_NO_ERROR) { \
-            printf("glGetError() = %i (0x%.8x) at line %s : %i\n", glError, glError, __FILE__, __LINE__); \
+            TVGERR("GL_ENGINE: glGetError() = %i (0x%.8x)", glError, glError); \
             assert(0); \
           } \
         } while(0)
@@ -44,7 +44,7 @@
     do { \
         EGLint eglError = eglGetError(); \
         if(eglError != EGL_SUCCESS) { \
-            printf("eglGetError() = %i (0x%.8x) at line %s : %i\n", eglError, eglError, __FILE__, __LINE__); \
+            TVGERR("GL_ENGINE: eglGetError() = %i (0x%.8x)", eglError, eglError); \
             assert(0); \
         } \
     } while(0)

--- a/src/lib/gl_engine/tvgGlProgram.cpp
+++ b/src/lib/gl_engine/tvgGlProgram.cpp
@@ -20,9 +20,7 @@
  * SOFTWARE.
  */
 
-#include <iostream>
 #include "tvgGlProgram.h"
-
 
 /************************************************************************/
 /* Internal Class Implementation                                        */
@@ -167,7 +165,7 @@ void GlProgram::linkProgram(std::shared_ptr<GlShader> shader)
         {
             char* infoLog = new char[infoLen];
             glGetProgramInfoLog(progObj, infoLen, NULL, infoLog);
-            std::cout << "Error linking shader: " << infoLog << std::endl;
+            TVGERR("GL_ENGINE: Error linking shader: %s", infoLog);
             delete[] infoLog;
 
         }

--- a/src/lib/gl_engine/tvgGlRenderer.cpp
+++ b/src/lib/gl_engine/tvgGlRenderer.cpp
@@ -332,7 +332,7 @@ void GlRenderer::drawPrimitive(GlShape& sdata, const Fill* fill, uint32_t primit
     auto matrix = sdata.geometry->getTransforMatrix();
 
     switch (fill->id()) {
-        case FILL_ID_LINEAR: {
+        case TVG_CLASS_ID_LINEAR: {
             float x1, y1, x2, y2;
             GlLinearGradientRenderTask *renderTask = static_cast<GlLinearGradientRenderTask*>(mRenderTasks[GlRenderTask::RenderTypes::RT_LinGradient].get());
             assert(renderTask);
@@ -345,7 +345,7 @@ void GlRenderer::drawPrimitive(GlShape& sdata, const Fill* fill, uint32_t primit
             renderTask->setEndPosition(x2, y2);
             break;
         }
-        case FILL_ID_RADIAL: {
+        case TVG_CLASS_ID_RADIAL: {
             float x1, y1, r1;
             GlRadialGradientRenderTask *renderTask = static_cast<GlRadialGradientRenderTask*>(mRenderTasks[GlRenderTask::RenderTypes::RT_RadGradient].get());
             assert(renderTask);

--- a/src/lib/gl_engine/tvgGlShader.cpp
+++ b/src/lib/gl_engine/tvgGlShader.cpp
@@ -20,9 +20,7 @@
  * SOFTWARE.
  */
 
-#include <iostream>
 #include "tvgGlShader.h"
-
 
 /************************************************************************/
 /* External Class Implementation                                        */
@@ -68,7 +66,6 @@ uint32_t GlShader::complileShader(uint32_t type, char* shaderSrc)
 
     // Create the shader object
     shader = glCreateShader(type);
-    assert(shader);
 
     // Load the shader source
     glShaderSource(shader, 1, &shaderSrc, NULL);
@@ -89,11 +86,10 @@ uint32_t GlShader::complileShader(uint32_t type, char* shaderSrc)
         {
             char* infoLog = new char[infoLen];
             glGetShaderInfoLog(shader, infoLen, NULL, infoLog);
-            std::cout << "Error compiling shader: " << infoLog << std::endl;
+            TVGERR("GL_ENGINE: Error compiling shader: %s", infoLog);
             delete[] infoLog;
         }
         glDeleteShader(shader);
-        assert(0);
     }
 
     return shader;

--- a/src/lib/sw_engine/tvgSwRaster.cpp
+++ b/src/lib/sw_engine/tvgSwRaster.cpp
@@ -121,9 +121,7 @@ static bool _translucentRectAlphaMask(SwSurface* surface, const SwBBox& region, 
     auto h = static_cast<uint32_t>(region.max.y - region.min.y);
     auto w = static_cast<uint32_t>(region.max.x - region.min.x);
 
-#ifdef THORVG_LOG_ENABLED
-    cout <<"SW_ENGINE: Rectangle Alpha Mask Composition" << endl;
-#endif
+    TVGLOG("SW_ENGINE: Rectangle Alpha Mask Composition");
 
     auto cbuffer = surface->compositor->image.data + (region.min.y * surface->stride) + region.min.x;   //compositor buffer
 
@@ -145,9 +143,7 @@ static bool _translucentRectInvAlphaMask(SwSurface* surface, const SwBBox& regio
     auto h = static_cast<uint32_t>(region.max.y - region.min.y);
     auto w = static_cast<uint32_t>(region.max.x - region.min.x);
 
-#ifdef THORVG_LOG_ENABLED
-    cout <<"SW_ENGINE: Rectangle Inverse Alpha Mask Composition" << endl;
-#endif
+    TVGLOG("SW_ENGINE: Rectangle Inverse Alpha Mask Composition");
 
     auto cbuffer = surface->compositor->image.data + (region.min.y * surface->stride) + region.min.x;   //compositor buffer
 
@@ -216,9 +212,8 @@ static bool _translucentRle(SwSurface* surface, const SwRleData* rle, uint32_t c
 
 static bool _translucentRleAlphaMask(SwSurface* surface, const SwRleData* rle, uint32_t color)
 {
-#ifdef THORVG_LOG_ENABLED
-    cout <<"SW_ENGINE: Rle Alpha Mask Composition" << endl;
-#endif
+    TVGLOG("SW_ENGINE: Rle Alpha Mask Composition");
+
     auto span = rle->spans;
     uint32_t src;
     auto cbuffer = surface->compositor->image.data;
@@ -240,9 +235,8 @@ static bool _translucentRleAlphaMask(SwSurface* surface, const SwRleData* rle, u
 
 static bool _translucentRleInvAlphaMask(SwSurface* surface, SwRleData* rle, uint32_t color)
 {
-#ifdef THORVG_LOG_ENABLED
-    cout <<"SW_ENGINE: Rle Inverse Alpha Mask Composition" << endl;
-#endif
+    TVGLOG("SW_ENGINE: Rle Inverse Alpha Mask Composition");
+
     auto span = rle->spans;
     uint32_t src;
     auto cbuffer = surface->compositor->image.data;
@@ -402,9 +396,8 @@ static bool _translucentImage(SwSurface* surface, const uint32_t *img, uint32_t 
 
 static bool _translucentImageAlphaMask(SwSurface* surface, const uint32_t *img, uint32_t w, TVG_UNUSED uint32_t h, uint32_t opacity, const SwBBox& region, const Matrix* invTransform)
 {
-#ifdef THORVG_LOG_ENABLED
-    cout <<"SW_ENGINE: Transformed Image Alpha Mask Composition" << endl;
-#endif
+    TVGLOG("SW_ENGINE: Transformed Image Alpha Mask Composition");
+
     auto dbuffer = &surface->buffer[region.min.y * surface->stride + region.min.x];
     auto cbuffer = &surface->compositor->image.data[region.min.y * surface->stride + region.min.x];
 
@@ -428,9 +421,8 @@ static bool _translucentImageAlphaMask(SwSurface* surface, const uint32_t *img, 
 
 static bool _translucentImageInvAlphaMask(SwSurface* surface, const uint32_t *img, uint32_t w, uint32_t h, uint32_t opacity, const SwBBox& region, const Matrix* invTransform)
 {
-#ifdef THORVG_LOG_ENABLED
-    cout <<"SW_ENGINE: Transformed Image Inverse Alpha Mask Composition" << endl;
-#endif
+    TVGLOG("SW_ENGINE: Transformed Image Inverse Alpha Mask Composition");
+
     auto dbuffer = &surface->buffer[region.min.y * surface->stride + region.min.x];
     auto cbuffer = &surface->compositor->image.data[region.min.y * surface->stride + region.min.x];
 
@@ -491,9 +483,7 @@ static bool _translucentImageAlphaMask(SwSurface* surface, uint32_t *img, uint32
     auto h2 = static_cast<uint32_t>(region.max.y - region.min.y);
     auto w2 = static_cast<uint32_t>(region.max.x - region.min.x);
 
-#ifdef THORVG_LOG_ENABLED
-    cout <<"SW_ENGINE: Image Alpha Mask Composition" << endl;
-#endif
+    TVGLOG("SW_ENGINE: Image Alpha Mask Composition");
 
     auto sbuffer = img + (region.min.y * w) + region.min.x;
     auto cbuffer = surface->compositor->image.data + (region.min.y * surface->stride) + region.min.x;   //compositor buffer
@@ -520,9 +510,7 @@ static bool _translucentImageInvAlphaMask(SwSurface* surface, uint32_t *img, uin
     auto h2 = static_cast<uint32_t>(region.max.y - region.min.y);
     auto w2 = static_cast<uint32_t>(region.max.x - region.min.x);
 
-#ifdef THORVG_LOG_ENABLED
-    cout <<"SW_ENGINE: Image Inverse Alpha Mask Composition" << endl;
-#endif
+    TVGLOG("SW_ENGINE: Image Inverse Alpha Mask Composition");
 
     auto sbuffer = img + (region.min.y * w) + region.min.x;
     auto cbuffer = surface->compositor->image.data + (region.min.y * surface->stride) + region.min.x;   //compositor buffer

--- a/src/lib/sw_engine/tvgSwRenderer.cpp
+++ b/src/lib/sw_engine/tvgSwRenderer.cpp
@@ -463,9 +463,7 @@ Compositor* SwRenderer::target(const RenderRegion& region)
     if (x + w > surface->w) w = (surface->w - x);
     if (y + h > surface->h) h = (surface->h - y);
 
-#ifdef THORVG_LOG_ENABLED
-    printf("SW_ENGINE: Using intermediate composition [Region: %d %d %d %d]\n", x, y, w, h);
-#endif
+    TVGLOG("SW_ENGINE: Using intermediate composition [Region: %d %d %d %d]", x, y, w, h);
 
     cmp->compositor->recoverSfc = surface;
     cmp->compositor->recoverCmp = surface->compositor;

--- a/src/lib/sw_engine/tvgSwRle.cpp
+++ b/src/lib/sw_engine/tvgSwRle.cpp
@@ -177,11 +177,11 @@ static void _horizLine(RleWorker& rw, SwCoord x, SwCoord y, SwCoord area, SwCoor
 
     //span has ushort coordinates. check limit overflow
     if (x >= SHRT_MAX) {
-        //LOG: x coordinate overflow!
+        TVGERR("SW_ENGINE: X-coordiante overflow!");
         x = SHRT_MAX;
     }
     if (y >= SHRT_MAX) {
-        //LOG: y coordinate overflow!
+        TVGERR("SW_ENGINE: Y Coordiante overflow!");
         y = SHRT_MAX;
     }
 
@@ -589,7 +589,7 @@ static bool _decomposeOutline(RleWorker& rw)
     return true;
 
 invalid_outline:
-    //LOG: Invalid Outline!
+    TVGERR("SW_ENGINE: Invalid Outline!");
     return false;
 }
 
@@ -927,9 +927,7 @@ void rleClipPath(SwRleData *rle, const SwRleData *clip)
 
     _replaceClipSpan(rle, spans, spansEnd - spans);
 
-#ifdef THORVG_LOG_ENABLED
-    cout << "SW_ENGINE: Using ClipPath!" << endl;
-#endif
+    TVGLOG("SW_ENGINE: Using ClipPath!");
 }
 
 
@@ -942,9 +940,7 @@ void rleClipRect(SwRleData *rle, const SwBBox* clip)
 
     _replaceClipSpan(rle, spans, spansEnd - spans);
 
-#ifdef THORVG_LOG_ENABLED
-    cout <<"SW_ENGINE: Using ClipRect!" << endl;
-#endif
+    TVGLOG("SW_ENGINE: Using ClipRect!");
 }
 
 
@@ -960,4 +956,3 @@ void rleAlphaMask(SwRleData *rle, const SwRleData *clip)
 
     _replaceClipSpan(rle, spans, spansEnd - spans);
 }
-

--- a/src/lib/tvgCommon.h
+++ b/src/lib/tvgCommon.h
@@ -28,6 +28,16 @@
 using namespace std;
 using namespace tvg;
 
+//for MSVC Compat
+#ifdef _MSC_VER
+    #define TVG_UNUSED
+    #define strncasecmp _strnicmp
+    #define strcasecmp _stricmp
+#else
+    #define TVG_UNUSED __attribute__ ((__unused__))
+#endif
+
+
 //TVG class identifier values
 #define TVG_CLASS_ID_UNDEFINED 0
 #define TVG_CLASS_ID_SHAPE     1
@@ -38,14 +48,12 @@ using namespace tvg;
 
 enum class FileType { Tvg = 0, Svg, Raw, Png, Jpg, Unknown };
 
-//for MSVC Compat
-#ifdef _MSC_VER
-    #define TVG_UNUSED
-    #define strncasecmp _strnicmp
-    #define strcasecmp _stricmp
+#ifdef THORVG_LOG_ENABLED
+    #define TVGLOG(fmt, ...) fprintf(stdout, fmt "\n", ##__VA_ARGS__)  //Error Message for us to fix it
+    #define TVGERR(fmt, ...) fprintf(stderr, fmt "\n", ##__VA_ARGS__)  //Log Message for notifying user some useful hints
 #else
-    #define TVG_UNUSED __attribute__ ((__unused__))
+    #define TVGERR(...)
+    #define TVGLOG(...)
 #endif
-
 
 #endif //_TVG_COMMON_H_

--- a/src/lib/tvgLoader.cpp
+++ b/src/lib/tvgLoader.cpp
@@ -107,9 +107,8 @@ static LoadModule* _find(FileType type)
             break;
         }
     }
-    printf("LOADER: %s format is not supported\n", format);
+    TVGLOG("LOADER: %s format is not supported", format);
 #endif
-
     return nullptr;
 }
 

--- a/src/lib/tvgPaint.h
+++ b/src/lib/tvgPaint.h
@@ -27,7 +27,6 @@
 
 namespace tvg
 {
-
     struct Iterator
     {
         virtual ~Iterator() {}

--- a/src/lib/tvgSaver.cpp
+++ b/src/lib/tvgSaver.cpp
@@ -66,7 +66,7 @@ static SaveModule* _find(FileType type)
             break;
         }
     }
-    printf("SAVER: %s format is not supported\n", format);
+    TVGLOG("SAVER: %s format is not supported", format);
 #endif
     return nullptr;
 }

--- a/src/loaders/tvg/tvgTvgLoadParser.cpp
+++ b/src/loaders/tvg/tvgTvgLoadParser.cpp
@@ -489,9 +489,7 @@ unique_ptr<Scene> tvgLoadData(const char *ptr, uint32_t size)
     auto end = ptr + size;
 
     if (!_readTvgHeader(&ptr) || ptr >= end) {
-#ifdef THORVG_LOG_ENABLED
-        printf("TVG_LOADER: Invalid TVG Data!\n");
-#endif
+        TVGLOG("TVG: Invalid TVG Data!");
         return nullptr;
     }
 


### PR DESCRIPTION
We can replace the system logger method by changing single line print source in common,
This also helps to remove the THORVG_LOG_ENABLED macro from each use-cases.

TVGLOG(): To print the hint & tip messages for users.
TVGERR(): To print the error message for debugging.

@Issues: https://github.com/Samsung/thorvg/issues/36