### PR TITLE
common log: use the log macro to replace the print method easier.

### DIFF
--- a/src/lib/gl_engine/tvgGlCommon.h
+++ b/src/lib/gl_engine/tvgGlCommon.h
@@ -34,7 +34,7 @@
         do { \
           GLenum glError = glGetError(); \
           if(glError != GL_NO_ERROR) { \
-            printf("glGetError() = %i (0x%.8x) at line %s : %i\n", glError, glError, __FILE__, __LINE__); \
+            TVGERR("GL_ENGINE", "glGetError() = %i (0x%.8x)", glError, glError); \
             assert(0); \
           } \
         } while(0)
@@ -44,7 +44,7 @@
     do { \
         EGLint eglError = eglGetError(); \
         if(eglError != EGL_SUCCESS) { \
-            printf("eglGetError() = %i (0x%.8x) at line %s : %i\n", eglError, eglError, __FILE__, __LINE__); \
+            TVGERR("GL_ENGINE", "eglGetError() = %i (0x%.8x)", eglError, eglError); \
             assert(0); \
         } \
     } while(0)

--- a/src/lib/gl_engine/tvgGlProgram.cpp
+++ b/src/lib/gl_engine/tvgGlProgram.cpp
@@ -20,9 +20,7 @@
  * SOFTWARE.
  */
 
-#include <iostream>
 #include "tvgGlProgram.h"
-
 
 /************************************************************************/
 /* Internal Class Implementation                                        */
@@ -167,7 +165,7 @@ void GlProgram::linkProgram(std::shared_ptr<GlShader> shader)
         {
             char* infoLog = new char[infoLen];
             glGetProgramInfoLog(progObj, infoLen, NULL, infoLog);
-            std::cout << "Error linking shader: " << infoLog << std::endl;
+            TVGERR("GL_ENGINE", "Error linking shader: %s", infoLog);
             delete[] infoLog;
 
         }

--- a/src/lib/gl_engine/tvgGlRenderer.cpp
+++ b/src/lib/gl_engine/tvgGlRenderer.cpp
@@ -332,7 +332,7 @@ void GlRenderer::drawPrimitive(GlShape& sdata, const Fill* fill, uint32_t primit
     auto matrix = sdata.geometry->getTransforMatrix();
 
     switch (fill->id()) {
-        case FILL_ID_LINEAR: {
+        case TVG_CLASS_ID_LINEAR: {
             float x1, y1, x2, y2;
             GlLinearGradientRenderTask *renderTask = static_cast<GlLinearGradientRenderTask*>(mRenderTasks[GlRenderTask::RenderTypes::RT_LinGradient].get());
             assert(renderTask);
@@ -345,7 +345,7 @@ void GlRenderer::drawPrimitive(GlShape& sdata, const Fill* fill, uint32_t primit
             renderTask->setEndPosition(x2, y2);
             break;
         }
-        case FILL_ID_RADIAL: {
+        case TVG_CLASS_ID_RADIAL: {
             float x1, y1, r1;
             GlRadialGradientRenderTask *renderTask = static_cast<GlRadialGradientRenderTask*>(mRenderTasks[GlRenderTask::RenderTypes::RT_RadGradient].get());
             assert(renderTask);

--- a/src/lib/gl_engine/tvgGlShader.cpp
+++ b/src/lib/gl_engine/tvgGlShader.cpp
@@ -20,9 +20,7 @@
  * SOFTWARE.
  */
 
-#include <iostream>
 #include "tvgGlShader.h"
-
 
 /************************************************************************/
 /* External Class Implementation                                        */
@@ -68,7 +66,6 @@ uint32_t GlShader::complileShader(uint32_t type, char* shaderSrc)
 
     // Create the shader object
     shader = glCreateShader(type);
-    assert(shader);
 
     // Load the shader source
     glShaderSource(shader, 1, &shaderSrc, NULL);
@@ -89,11 +86,10 @@ uint32_t GlShader::complileShader(uint32_t type, char* shaderSrc)
         {
             char* infoLog = new char[infoLen];
             glGetShaderInfoLog(shader, infoLen, NULL, infoLog);
-            std::cout << "Error compiling shader: " << infoLog << std::endl;
+            TVGERR("GL_ENGINE", "Error compiling shader: %s", infoLog);
             delete[] infoLog;
         }
         glDeleteShader(shader);
-        assert(0);
     }
 
     return shader;

--- a/src/lib/sw_engine/tvgSwRaster.cpp
+++ b/src/lib/sw_engine/tvgSwRaster.cpp
@@ -121,9 +121,7 @@ static bool _translucentRectAlphaMask(SwSurface* surface, const SwBBox& region, 
     auto h = static_cast<uint32_t>(region.max.y - region.min.y);
     auto w = static_cast<uint32_t>(region.max.x - region.min.x);
 
-#ifdef THORVG_LOG_ENABLED
-    cout <<"SW_ENGINE: Rectangle Alpha Mask Composition" << endl;
-#endif
+    TVGLOG("SW_ENGINE", "Rectangle Alpha Mask Composition");
 
     auto cbuffer = surface->compositor->image.data + (region.min.y * surface->stride) + region.min.x;   //compositor buffer
 
@@ -145,9 +143,7 @@ static bool _translucentRectInvAlphaMask(SwSurface* surface, const SwBBox& regio
     auto h = static_cast<uint32_t>(region.max.y - region.min.y);
     auto w = static_cast<uint32_t>(region.max.x - region.min.x);
 
-#ifdef THORVG_LOG_ENABLED
-    cout <<"SW_ENGINE: Rectangle Inverse Alpha Mask Composition" << endl;
-#endif
+    TVGLOG("SW_ENGINE", "Rectangle Inverse Alpha Mask Composition");
 
     auto cbuffer = surface->compositor->image.data + (region.min.y * surface->stride) + region.min.x;   //compositor buffer
 
@@ -216,9 +212,8 @@ static bool _translucentRle(SwSurface* surface, const SwRleData* rle, uint32_t c
 
 static bool _translucentRleAlphaMask(SwSurface* surface, const SwRleData* rle, uint32_t color)
 {
-#ifdef THORVG_LOG_ENABLED
-    cout <<"SW_ENGINE: Rle Alpha Mask Composition" << endl;
-#endif
+    TVGLOG("SW_ENGINE", "Rle Alpha Mask Composition");
+
     auto span = rle->spans;
     uint32_t src;
     auto cbuffer = surface->compositor->image.data;
@@ -240,9 +235,8 @@ static bool _translucentRleAlphaMask(SwSurface* surface, const SwRleData* rle, u
 
 static bool _translucentRleInvAlphaMask(SwSurface* surface, SwRleData* rle, uint32_t color)
 {
-#ifdef THORVG_LOG_ENABLED
-    cout <<"SW_ENGINE: Rle Inverse Alpha Mask Composition" << endl;
-#endif
+    TVGLOG("SW_ENGINE", "Rle Inverse Alpha Mask Composition");
+
     auto span = rle->spans;
     uint32_t src;
     auto cbuffer = surface->compositor->image.data;
@@ -402,9 +396,8 @@ static bool _translucentImage(SwSurface* surface, const uint32_t *img, uint32_t 
 
 static bool _translucentImageAlphaMask(SwSurface* surface, const uint32_t *img, uint32_t w, TVG_UNUSED uint32_t h, uint32_t opacity, const SwBBox& region, const Matrix* invTransform)
 {
-#ifdef THORVG_LOG_ENABLED
-    cout <<"SW_ENGINE: Transformed Image Alpha Mask Composition" << endl;
-#endif
+    TVGLOG("SW_ENGINE", "Transformed Image Alpha Mask Composition");
+
     auto dbuffer = &surface->buffer[region.min.y * surface->stride + region.min.x];
     auto cbuffer = &surface->compositor->image.data[region.min.y * surface->stride + region.min.x];
 
@@ -428,9 +421,8 @@ static bool _translucentImageAlphaMask(SwSurface* surface, const uint32_t *img, 
 
 static bool _translucentImageInvAlphaMask(SwSurface* surface, const uint32_t *img, uint32_t w, uint32_t h, uint32_t opacity, const SwBBox& region, const Matrix* invTransform)
 {
-#ifdef THORVG_LOG_ENABLED
-    cout <<"SW_ENGINE: Transformed Image Inverse Alpha Mask Composition" << endl;
-#endif
+    TVGLOG("SW_ENGINE", "Transformed Image Inverse Alpha Mask Composition");
+
     auto dbuffer = &surface->buffer[region.min.y * surface->stride + region.min.x];
     auto cbuffer = &surface->compositor->image.data[region.min.y * surface->stride + region.min.x];
 
@@ -491,9 +483,7 @@ static bool _translucentImageAlphaMask(SwSurface* surface, uint32_t *img, uint32
     auto h2 = static_cast<uint32_t>(region.max.y - region.min.y);
     auto w2 = static_cast<uint32_t>(region.max.x - region.min.x);
 
-#ifdef THORVG_LOG_ENABLED
-    cout <<"SW_ENGINE: Image Alpha Mask Composition" << endl;
-#endif
+    TVGLOG("SW_ENGINE", "Image Alpha Mask Composition");
 
     auto sbuffer = img + (region.min.y * w) + region.min.x;
     auto cbuffer = surface->compositor->image.data + (region.min.y * surface->stride) + region.min.x;   //compositor buffer
@@ -520,9 +510,7 @@ static bool _translucentImageInvAlphaMask(SwSurface* surface, uint32_t *img, uin
     auto h2 = static_cast<uint32_t>(region.max.y - region.min.y);
     auto w2 = static_cast<uint32_t>(region.max.x - region.min.x);
 
-#ifdef THORVG_LOG_ENABLED
-    cout <<"SW_ENGINE: Image Inverse Alpha Mask Composition" << endl;
-#endif
+    TVGLOG("SW_ENGINE", "Image Inverse Alpha Mask Composition");
 
     auto sbuffer = img + (region.min.y * w) + region.min.x;
     auto cbuffer = surface->compositor->image.data + (region.min.y * surface->stride) + region.min.x;   //compositor buffer

--- a/src/lib/sw_engine/tvgSwRenderer.cpp
+++ b/src/lib/sw_engine/tvgSwRenderer.cpp
@@ -463,9 +463,7 @@ Compositor* SwRenderer::target(const RenderRegion& region)
     if (x + w > surface->w) w = (surface->w - x);
     if (y + h > surface->h) h = (surface->h - y);
 
-#ifdef THORVG_LOG_ENABLED
-    printf("SW_ENGINE: Using intermediate composition [Region: %d %d %d %d]\n", x, y, w, h);
-#endif
+    TVGLOG("SW_ENGINE", "Using intermediate composition [Region: %d %d %d %d]", x, y, w, h);
 
     cmp->compositor->recoverSfc = surface;
     cmp->compositor->recoverCmp = surface->compositor;

--- a/src/lib/sw_engine/tvgSwRle.cpp
+++ b/src/lib/sw_engine/tvgSwRle.cpp
@@ -177,11 +177,11 @@ static void _horizLine(RleWorker& rw, SwCoord x, SwCoord y, SwCoord area, SwCoor
 
     //span has ushort coordinates. check limit overflow
     if (x >= SHRT_MAX) {
-        //LOG: x coordinate overflow!
+        TVGERR("SW_ENGINE", "X-coordiante overflow!");
         x = SHRT_MAX;
     }
     if (y >= SHRT_MAX) {
-        //LOG: y coordinate overflow!
+        TVGERR("SW_ENGINE", "Y Coordiante overflow!");
         y = SHRT_MAX;
     }
 
@@ -589,7 +589,7 @@ static bool _decomposeOutline(RleWorker& rw)
     return true;
 
 invalid_outline:
-    //LOG: Invalid Outline!
+    TVGERR("SW_ENGINE", "Invalid Outline!");
     return false;
 }
 
@@ -927,9 +927,7 @@ void rleClipPath(SwRleData *rle, const SwRleData *clip)
 
     _replaceClipSpan(rle, spans, spansEnd - spans);
 
-#ifdef THORVG_LOG_ENABLED
-    cout << "SW_ENGINE: Using ClipPath!" << endl;
-#endif
+    TVGLOG("SW_ENGINE", "Using ClipPath!");
 }
 
 
@@ -942,9 +940,7 @@ void rleClipRect(SwRleData *rle, const SwBBox* clip)
 
     _replaceClipSpan(rle, spans, spansEnd - spans);
 
-#ifdef THORVG_LOG_ENABLED
-    cout <<"SW_ENGINE: Using ClipRect!" << endl;
-#endif
+    TVGLOG("SW_ENGINE", "Using ClipRect!");
 }
 
 
@@ -960,4 +956,3 @@ void rleAlphaMask(SwRleData *rle, const SwRleData *clip)
 
     _replaceClipSpan(rle, spans, spansEnd - spans);
 }
-

--- a/src/lib/tvgCommon.h
+++ b/src/lib/tvgCommon.h
@@ -28,6 +28,16 @@
 using namespace std;
 using namespace tvg;
 
+//for MSVC Compat
+#ifdef _MSC_VER
+    #define TVG_UNUSED
+    #define strncasecmp _strnicmp
+    #define strcasecmp _stricmp
+#else
+    #define TVG_UNUSED __attribute__ ((__unused__))
+#endif
+
+
 //TVG class identifier values
 #define TVG_CLASS_ID_UNDEFINED 0
 #define TVG_CLASS_ID_SHAPE     1
@@ -38,14 +48,12 @@ using namespace tvg;
 
 enum class FileType { Tvg = 0, Svg, Raw, Png, Jpg, Unknown };
 
-//for MSVC Compat
-#ifdef _MSC_VER
-    #define TVG_UNUSED
-    #define strncasecmp _strnicmp
-    #define strcasecmp _stricmp
+#ifdef THORVG_LOG_ENABLED
+    #define TVGLOG(tag, fmt, ...) fprintf(stdout, tag ": " fmt "\n", ##__VA_ARGS__)  //Log Message for notifying user some useful info
+    #define TVGERR(tag, fmt, ...) fprintf(stderr, tag ": " fmt "\n", ##__VA_ARGS__)  //Error Message for us to fix it
 #else
-    #define TVG_UNUSED __attribute__ ((__unused__))
+    #define TVGERR(...)
+    #define TVGLOG(...)
 #endif
-
 
 #endif //_TVG_COMMON_H_

--- a/src/lib/tvgLoader.cpp
+++ b/src/lib/tvgLoader.cpp
@@ -107,9 +107,8 @@ static LoadModule* _find(FileType type)
             break;
         }
     }
-    printf("LOADER: %s format is not supported\n", format);
+    TVGLOG("LOADER", "%s format is not supported", format);
 #endif
-
     return nullptr;
 }
 

--- a/src/lib/tvgPaint.h
+++ b/src/lib/tvgPaint.h
@@ -27,7 +27,6 @@
 
 namespace tvg
 {
-
     struct Iterator
     {
         virtual ~Iterator() {}

--- a/src/lib/tvgSaver.cpp
+++ b/src/lib/tvgSaver.cpp
@@ -66,7 +66,7 @@ static SaveModule* _find(FileType type)
             break;
         }
     }
-    printf("SAVER: %s format is not supported\n", format);
+    TVGLOG("SAVER", "%s format is not supported", format);
 #endif
     return nullptr;
 }

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -760,7 +760,7 @@ static bool _attrParseSvgNode(void* data, const char* key, const char* value)
     }
 #ifdef THORVG_LOG_ENABLED
     else if (!strcmp(key, "x") || !strcmp(key, "y")) {
-        if (0.0f == _parseLength(value, &type)) printf("SVG: Unsupported attributes used [Elements type: Svg][Attribute: %s][Value: %s]\n", key, value);
+        if (0.0f == _parseLength(value, &type)) TVGLOG("SVG", "Unsupported attributes used [Elements type: Svg][Attribute: %s][Value: %s]", key, value);
     }
 #endif
     else {
@@ -1340,7 +1340,6 @@ static bool _attrParsePolygonPoints(const char* str, float** points, int* ptCoun
     return true;
 
 error_alloc:
-    //LOG: allocation for point array failed. out of memory
     return false;
 }
 
@@ -2378,21 +2377,16 @@ static void _svgLoaderParserXmlOpen(SvgLoaderData* loader, const char* content, 
         loader->latestGradient = gradient;
     } else if (!strcmp(tagName, "stop")) {
         if (!loader->latestGradient) {
-#ifdef THORVG_LOG_ENABLED
-            printf("SVG: Stop element is used outside of the Gradient element\n");
-#endif
+            TVGLOG("SVG", "Stop element is used outside of the Gradient element");
             return;
         }
         /* default value for opacity */
         loader->svgParse->gradStop = {0.0f, 0, 0, 0, 255};
         simpleXmlParseAttributes(attrs, attrsLength, _attrParseStops, loader);
         loader->latestGradient->stops.push(loader->svgParse->gradStop);
+    } else if (!isIgnoreUnsupportedLogElements(tagName)) {
+        TVGLOG("SVG", "Unsupported elements used [Elements: %s]", tagName);
     }
-#ifdef THORVG_LOG_ENABLED
-    else {
-        if (!isIgnoreUnsupportedLogElements(tagName)) printf("SVG: Unsupported elements used [Elements: %s]\n", tagName);
-    }
-#endif
 }
 
 
@@ -2488,34 +2482,34 @@ static void _inefficientNodeCheck(TVG_UNUSED SvgNode* node){
 #ifdef THORVG_LOG_ENABLED
     auto type = simpleXmlNodeTypeToString(node->type);
 
-    if (!node->display && node->type != SvgNodeType::ClipPath) printf("SVG: Inefficient elements used [Display is none][Node Type : %s]\n", type);
-    if (node->style->opacity == 0) printf("SVG: Inefficient elements used [Opacity is zero][Node Type : %s]\n", type);
-    if (node->style->fill.opacity == 0 && node->style->stroke.opacity == 0) printf("SVG: Inefficient elements used [Fill opacity and stroke opacity are zero][Node Type : %s]\n", type);
+    if (!node->display && node->type != SvgNodeType::ClipPath) TVGLOG("SVG", "Inefficient elements used [Display is none][Node Type : %s]", type);
+    if (node->style->opacity == 0) TVGLOG("SVG", "Inefficient elements used [Opacity is zero][Node Type : %s]", type);
+    if (node->style->fill.opacity == 0 && node->style->stroke.opacity == 0) TVGLOG("SVG", "Inefficient elements used [Fill opacity and stroke opacity are zero][Node Type : %s]", type);
 
     switch (node->type) {
         case SvgNodeType::Path: {
-            if (!node->node.path.path || node->node.path.path->empty()) printf("SVG: Inefficient elements used [Empty path][Node Type : %s]\n", type);
+            if (!node->node.path.path || node->node.path.path->empty()) TVGLOG("SVG", "Inefficient elements used [Empty path][Node Type : %s]", type);
             break;
         }
         case SvgNodeType::Ellipse: {
-            if (node->node.ellipse.rx == 0 && node->node.ellipse.ry == 0) printf("SVG: Inefficient elements used [Size is zero][Node Type : %s]\n", type);
+            if (node->node.ellipse.rx == 0 && node->node.ellipse.ry == 0) TVGLOG("SVG", "Inefficient elements used [Size is zero][Node Type : %s]", type);
             break;
         }
         case SvgNodeType::Polygon:
         case SvgNodeType::Polyline: {
-            if (node->node.polygon.pointsCount < 2) printf("SVG: Inefficient elements used [Invalid Polygon][Node Type : %s]\n", type);
+            if (node->node.polygon.pointsCount < 2) TVGLOG("SVG", "Inefficient elements used [Invalid Polygon][Node Type : %s]", type);
             break;
         }
         case SvgNodeType::Circle: {
-            if (node->node.circle.r == 0) printf("SVG: Inefficient elements used [Size is zero][Node Type : %s]\n", type);
+            if (node->node.circle.r == 0) TVGLOG("SVG", "Inefficient elements used [Size is zero][Node Type : %s]", type);
             break;
         }
         case SvgNodeType::Rect: {
-            if (node->node.rect.w == 0 && node->node.rect.h) printf("SVG: Inefficient elements used [Size is zero][Node Type : %s]\n", type);
+            if (node->node.rect.w == 0 && node->node.rect.h) TVGLOG("SVG", "Inefficient elements used [Size is zero][Node Type : %s]", type);
             break;
         }
         case SvgNodeType::Line: {
-            if (node->node.line.x1 == node->node.line.x2 && node->node.line.y1 == node->node.line.y2) printf("SVG: Inefficient elements used [Size is zero][Node Type : %s]\n", type);
+            if (node->node.line.x1 == node->node.line.x2 && node->node.line.y1 == node->node.line.y2) TVGLOG("SVG", "Inefficient elements used [Size is zero][Node Type : %s]", type);
             break;
         }
         default: break;
@@ -2810,7 +2804,7 @@ bool SvgLoader::header()
 
         preserveAspect = loaderData.doc->node.doc.preserveAspect;
     } else {
-        //LOG: No SVG File. There is no <svg/>
+        TVGLOG("SVG", "No SVG File. There is no <svg/>");
         return false;
     }
 

--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -182,9 +182,7 @@ static void _applyComposition(Paint* paint, const SvgNode* node, float vx, float
     /* Do not drop in Circular Dependency for ClipPath.
        Composition can be applied recursively if its children nodes have composition target to this one. */
     if (node->style->clipPath.applying) {
-#ifdef THORVG_LOG_ENABLED
-    printf("SVG: Multiple Composition Tried! Check out Circular dependency?\n");
-#endif
+        TVGLOG("SVG", "Multiple Composition Tried! Check out Circular dependency?");
     } else {
         auto compNode = node->style->clipPath.node;
         if (compNode && compNode->child.count > 0) {
@@ -211,9 +209,7 @@ static void _applyComposition(Paint* paint, const SvgNode* node, float vx, float
     /* Do not drop in Circular Dependency for Mask.
        Composition can be applied recursively if its children nodes have composition target to this one. */
     if (node->style->mask.applying) {
-#ifdef THORVG_LOG_ENABLED
-    printf("SVG: Multiple Composition Tried! Check out Circular dependency?\n");
-#endif
+        TVGLOG("SVG", "Multiple Composition Tried! Check out Circular dependency?");
     } else  {
         auto compNode = node->style->mask.node;
         if (compNode && compNode->child.count > 0) {
@@ -468,9 +464,7 @@ static unique_ptr<Picture> _imageBuildHelper(SvgNode* node, float vx, float vy, 
         //Temporarily disable embedded svg:
         const char *dot = strrchr(href, '.');
         if (dot && !strcmp(dot, ".svg")) {
-#ifdef THORVG_LOG_ENABLED
-            printf("SVG: Embedded svg file is disabled.\n");
-#endif
+            TVGLOG("SVG", "Embedded svg file is disabled.");
             return nullptr;
         }
 

--- a/src/loaders/svg/tvgXmlParser.cpp
+++ b/src/loaders/svg/tvgXmlParser.cpp
@@ -35,9 +35,9 @@
 /* Internal Class Implementation                                        */
 /************************************************************************/
 
-#ifdef THORVG_LOG_ENABLED
-bool _isIgnoreUnsupportedLogAttributes(const char* tagAttribute, const char* tagValue)
+bool _isIgnoreUnsupportedLogAttributes(TVG_UNUSED const char* tagAttribute, TVG_UNUSED const char* tagValue)
 {
+#ifdef THORVG_LOG_ENABLED
     const auto attributesNum = 6;
     const struct
     {
@@ -64,8 +64,10 @@ bool _isIgnoreUnsupportedLogAttributes(const char* tagAttribute, const char* tag
         }
     }
     return false;
-}
 #endif
+    return true;
+}
+
 
 
 static const char* _simpleXmlFindWhiteSpace(const char* itr, const char* itrEnd)
@@ -316,17 +318,11 @@ bool simpleXmlParseAttributes(const char* buf, unsigned bufLength, simpleXMLAttr
         }
         tval[i] = '\0';
 
-#ifdef THORVG_LOG_ENABLED
         if (!func((void*)data, tmpBuf, tval)) {
             if (!_isIgnoreUnsupportedLogAttributes(tmpBuf, tval)) {
-                auto type = simpleXmlNodeTypeToString(((SvgLoaderData*)data)->svgParse->node->type);
-                auto id = ((SvgLoaderData*)data)->svgParse->node->id ? ((SvgLoaderData*)data)->svgParse->node->id->c_str() : "NO_ID";
-                printf("SVG: Unsupported attributes used [Elements type: %s][Id : %s][Attribute: %s][Value: %s]\n", type, id, tmpBuf, tval ? tval : "NONE");
+                TVGLOG("SVG", "Unsupported attributes used [Elements type: %s][Id : %s][Attribute: %s][Value: %s]", simpleXmlNodeTypeToString(((SvgLoaderData*)data)->svgParse->node->type), ((SvgLoaderData*)data)->svgParse->node->id ? ((SvgLoaderData*)data)->svgParse->node->id->c_str() : "NO_ID", tmpBuf, tval ? tval : "NONE");
             }
         }
-#else
-        func((void*)data, tmpBuf, tval);
-#endif
     }
     return true;
 }
@@ -517,17 +513,11 @@ bool simpleXmlParseW3CAttribute(const char* buf, simpleXMLAttributeCb func, cons
             val = const_cast<char*>(_simpleXmlSkipWhiteSpace(val, val + strlen(val)));
             val[_simpleXmlUnskipWhiteSpace(val + strlen(val) , val) - val] = '\0';
 
-#ifdef THORVG_LOG_ENABLED
             if (!func((void*)data, key, val)) {
                 if (!_isIgnoreUnsupportedLogAttributes(key, val)) {
-                    auto type = simpleXmlNodeTypeToString(((SvgLoaderData*)data)->svgParse->node->type);
-                    auto id = ((SvgLoaderData*)data)->svgParse->node->id ? ((SvgLoaderData*)data)->svgParse->node->id->c_str() : "NO_ID";
-                    printf("SVG: Unsupported attributes used [Elements type: %s][Id : %s][Attribute: %s][Value: %s]\n", type, id, key, val ? val : "NONE");
+                    TVGLOG("SVG", "Unsupported attributes used [Elements type: %s][Id : %s][Attribute: %s][Value: %s]", simpleXmlNodeTypeToString(((SvgLoaderData*)data)->svgParse->node->type), ((SvgLoaderData*)data)->svgParse->node->id ? ((SvgLoaderData*)data)->svgParse->node->id->c_str() : "NO_ID", key, val ? val : "NONE");
                 }
             }
-#else
-            func((void*)data, key, val);
-#endif
         }
 
         buf = next + 1;

--- a/src/loaders/tvg/tvgTvgLoadParser.cpp
+++ b/src/loaders/tvg/tvgTvgLoadParser.cpp
@@ -489,9 +489,7 @@ unique_ptr<Scene> tvgLoadData(const char *ptr, uint32_t size)
     auto end = ptr + size;
 
     if (!_readTvgHeader(&ptr) || ptr >= end) {
-#ifdef THORVG_LOG_ENABLED
-        printf("TVG_LOADER: Invalid TVG Data!\n");
-#endif
+        TVGLOG("TVG", "Invalid TVG Data!");
         return nullptr;
     }
 


### PR DESCRIPTION
We can replace the system logger method by changing single line print source in common,
This also helps to remove the THORVG_LOG_ENABLED macro from each use-cases.

TVGLOG(): To print the hint & tip messages for users.
TVGERR(): To print the error message for debugging.

@Issues: https://github.com/Samsung/thorvg/issues/36