### PR TITLE
common picture: remove viewbox() api.

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -1066,15 +1066,6 @@ public:
     Result load(uint32_t* data, uint32_t w, uint32_t h, bool copy) noexcept;
 
     /**
-     * @brief Gets the position and the size of the loaded picture.
-     *
-     * @warning Please do not use it, this API is not official one. It could be modified in the next version.
-     *
-     * @BETA_API
-     */
-    Result viewbox(float* x, float* y, float* w, float* h) const noexcept;
-
-    /**
      * @brief Creates a new Picture object.
      *
      * @return A new Picture object.

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -1688,11 +1688,11 @@ TVG_EXPORT Tvg_Result tvg_picture_load_data(Tvg_Paint* paint, const char *data, 
 
 
 /*!
-* \brief Gets the position and the size of the loaded picture. (BETA version)
+* \brief Gets the size of the loaded picture. (BETA version)
 *
 * \warning Please do not use it, this API is not official one. It can be modified in the next version.
 */
-TVG_EXPORT Tvg_Result tvg_picture_get_viewbox(const Tvg_Paint* paint, float* x, float* y, float* w, float* h);
+TVG_EXPORT Tvg_Result tvg_picture_get_size(const Tvg_Paint* paint, float* w, float* h);
 
 
 /** \} */   // end defgroup ThorVGCapi_Picture

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -470,10 +470,10 @@ TVG_EXPORT Tvg_Result tvg_picture_load_data(Tvg_Paint* paint, const char *data, 
 }
 
 
-TVG_EXPORT Tvg_Result tvg_picture_get_viewbox(const Tvg_Paint* paint, float* x, float* y, float* w, float* h)
+TVG_EXPORT Tvg_Result tvg_picture_get_size(const Tvg_Paint* paint, float* w, float* h)
 {
     if (!paint) return TVG_RESULT_INVALID_ARGUMENT;
-    return (Tvg_Result) reinterpret_cast<Picture*>(CCP(paint))->viewbox(x, y, w, h);
+    return (Tvg_Result) reinterpret_cast<Picture*>(CCP(paint))->size(w, h);
 }
 
 /************************************************************************/

--- a/src/lib/sw_engine/tvgSwImage.cpp
+++ b/src/lib/sw_engine/tvgSwImage.cpp
@@ -29,7 +29,7 @@
 static bool _genOutline(SwImage* image, const Picture* pdata, const Matrix* transform, SwMpool* mpool,  unsigned tid)
 {
     float w, h;
-    pdata->viewbox(nullptr, nullptr, &w, &h);
+    pdata->size(&w, &h);
     if (w == 0 || h == 0) return false;
 
     image->outline = mpoolReqOutline(mpool, tid);

--- a/src/lib/tvgPicture.cpp
+++ b/src/lib/tvgPicture.cpp
@@ -69,13 +69,6 @@ Result Picture::load(uint32_t* data, uint32_t w, uint32_t h, bool copy) noexcept
 }
 
 
-Result Picture::viewbox(float* x, float* y, float* w, float* h) const noexcept
-{
-    if (pImpl->viewbox(x, y, w, h)) return Result::Success;
-    return Result::InsufficientCondition;
-}
-
-
 Result Picture::size(float w, float h) noexcept
 {
     if (pImpl->size(w, h)) return Result::Success;

--- a/src/lib/tvgPictureImpl.h
+++ b/src/lib/tvgPictureImpl.h
@@ -148,16 +148,6 @@ struct Picture::Impl
         return false;
     }
 
-    bool viewbox(float* x, float* y, float* w, float* h) const
-    {
-        if (!loader) return false;
-        if (x) *x = loader->vx;
-        if (y) *y = loader->vy;
-        if (w) *w = loader->vw;
-        if (h) *h = loader->vh;
-        return true;
-    }
-
     bool size(uint32_t w, uint32_t h)
     {
         this->w = w;

--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -457,7 +457,6 @@ static unique_ptr<Picture> _imageBuildHelper(SvgNode* node, float vx, float vy, 
             string decoded = svgUtilURLDecode(href);
             if (picture->load(decoded.c_str(), decoded.size(), true) != Result::Success) return nullptr;
         }
-
     } else {
         if (!strncmp(href, "file://", sizeof("file://") - 1)) href += sizeof("file://") - 1;
         //TODO: protect against recursive svg image loading
@@ -467,17 +466,14 @@ static unique_ptr<Picture> _imageBuildHelper(SvgNode* node, float vx, float vy, 
             TVGLOG("SVG", "Embedded svg file is disabled.");
             return nullptr;
         }
-
         if (picture->load(href) != Result::Success) return nullptr;
     }
 
-    float x, y, w, h;
-    if (picture->viewbox(&x, &y, &w, &h) == Result::Success && w && h) {
+    float w, h;
+    if (picture->size(&w, &h) == Result::Success && w  > 0 && h > 0) {
         auto sx = node->node.image.w / w;
         auto sy = node->node.image.h / h;
-        auto sxt = x * sx;
-        auto syt = y * sy;
-        Matrix m = {sx, 0, node->node.image.x - sxt, 0, sy, node->node.image.y - syt, 0, 0, 1};
+        Matrix m = {sx, 0, node->node.image.x, 0, sy, node->node.image.y, 0, 0, 1};
         picture->transform(m);
     }
 

--- a/test/capi/capiPicture.cpp
+++ b/test/capi/capiPicture.cpp
@@ -39,8 +39,8 @@ TEST_CASE("Load Svg file in Picture", "[capiPicture]")
     //Load Svg file
     REQUIRE(tvg_picture_load(picture, TEST_DIR"/logo.svg") == TVG_RESULT_SUCCESS);
 
-    float x, y, w, h;
-    REQUIRE(tvg_picture_get_viewbox(picture, &x, &y, &w, &h) == TVG_RESULT_SUCCESS);
+    float w, h;
+    REQUIRE(tvg_picture_get_size(picture, &w, &h) == TVG_RESULT_SUCCESS);
 
     REQUIRE(tvg_paint_del(picture) == TVG_RESULT_SUCCESS);
 }
@@ -62,7 +62,7 @@ TEST_CASE("Load Svg Data in Picture", "[capiPicture]")
 
     //Verify Size
     float w, h;
-    REQUIRE(tvg_picture_get_viewbox(picture, nullptr, nullptr, &w, &h) == TVG_RESULT_SUCCESS);
+    REQUIRE(tvg_picture_get_size(picture, &w, &h) == TVG_RESULT_SUCCESS);
     REQUIRE(w == Approx(1000).epsilon(0.0000001));
     REQUIRE(h == Approx(1000).epsilon(0.0000001));
 
@@ -92,7 +92,7 @@ TEST_CASE("Load Raw file in Picture", "[capiPicture]")
 
         //Verify Size
         float w, h;
-        REQUIRE(tvg_picture_get_viewbox(picture, nullptr, nullptr, &w, &h) == TVG_RESULT_SUCCESS);
+        REQUIRE(tvg_picture_get_size(picture, &w, &h) == TVG_RESULT_SUCCESS);
         REQUIRE(w == Approx(200).epsilon(0.0000001));
         REQUIRE(h == Approx(300).epsilon(0.0000001));
     }
@@ -116,7 +116,7 @@ TEST_CASE("Load Png file in Picture", "[capiPicture]")
 
     //Verify Size
     float w, h;
-    REQUIRE(tvg_picture_get_viewbox(picture, nullptr, nullptr, &w, &h) == TVG_RESULT_SUCCESS);
+    REQUIRE(tvg_picture_get_size(picture, &w, &h) == TVG_RESULT_SUCCESS);
 
     REQUIRE(tvg_paint_del(picture) == TVG_RESULT_SUCCESS);
 }


### PR DESCRIPTION
picture provides size() interface to return the image size,
viewbox() is conceptually not correct with the Picture.

Remove it under the beta api.