### PR TITLE
common loader: code refactoring.

### DIFF
--- a/src/lib/tvgLoadModule.h
+++ b/src/lib/tvgLoadModule.h
@@ -40,13 +40,13 @@ public:
 
     virtual ~LoadModule() {}
 
-    virtual bool open(const string& path) { /* Not supported */ return false; };
-    virtual bool open(const char* data, uint32_t size, bool copy) { /* Not supported */ return false; };
-    virtual bool open(const uint32_t* data, uint32_t w, uint32_t h, bool copy) { /* Not supported */ return false; };
+    virtual bool open(const string& path) { return false; };
+    virtual bool open(const char* data, uint32_t size, bool copy) { return false; };
+    virtual bool open(const uint32_t* data, uint32_t w, uint32_t h, bool copy) { return false; };
     virtual bool read() = 0;
     virtual bool close() = 0;
     virtual const uint32_t* pixels() { return nullptr; };
-    virtual unique_ptr<Scene> scene() { return nullptr; };
+    virtual unique_ptr<Paint> paint() { return nullptr; };
 };
 
 }

--- a/src/lib/tvgPictureImpl.h
+++ b/src/lib/tvgPictureImpl.h
@@ -112,9 +112,8 @@ struct Picture::Impl
     {
         if (loader) {
             if (!paint) {
-                auto scene = loader->scene();
-                if (scene) {
-                    paint = scene.release();
+                if (auto p = loader->paint()) {
+                    paint = p.release();
                     loader->close();
                     if (w != loader->w && h != loader->h) resize();
                     if (paint) return RenderUpdateFlag::None;

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -2885,7 +2885,7 @@ bool SvgLoader::close()
 }
 
 
-unique_ptr<Scene> SvgLoader::scene()
+unique_ptr<Paint> SvgLoader::paint()
 {
     this->done();
     if (root) return move(root);

--- a/src/loaders/svg/tvgSvgLoader.h
+++ b/src/loaders/svg/tvgSvgLoader.h
@@ -49,7 +49,7 @@ public:
     bool close() override;
     void run(unsigned tid) override;
 
-    unique_ptr<Scene> scene() override;
+    unique_ptr<Paint> paint() override;
 
 private:
     void clear();

--- a/src/loaders/tvg/tvgTvgLoader.cpp
+++ b/src/loaders/tvg/tvgTvgLoader.cpp
@@ -125,7 +125,7 @@ void TvgLoader::run(unsigned tid)
     if (!root) clear();
 }
 
-unique_ptr<Scene> TvgLoader::scene()
+unique_ptr<Paint> TvgLoader::paint()
 {
     this->done();
     if (root) return move(root);

--- a/src/loaders/tvg/tvgTvgLoader.h
+++ b/src/loaders/tvg/tvgTvgLoader.h
@@ -45,7 +45,7 @@ public:
     bool close() override;
 
     void run(unsigned tid) override;
-    unique_ptr<Scene> scene() override;
+    unique_ptr<Paint> paint() override;
 
 private:
     void clear();


### PR DESCRIPTION
replace from Scene to Paint at the internal interface.

Picture doesn't need to know the returned Node type.
base class, Paint is enough to in the data passing.