### PR TITLE
sw_engine: flush memory pool after drawing.

### DIFF
--- a/src/lib/sw_engine/tvgSwMemPool.cpp
+++ b/src/lib/sw_engine/tvgSwMemPool.cpp
@@ -95,37 +95,33 @@ bool mpoolClear(SwMpool* mpool)
 
     for (unsigned i = 0; i < mpool->allocSize; ++i) {
 
+        //Outline
         p = &mpool->outline[i];
 
-        if (p->cntrs) {
-            free(p->cntrs);
-            p->cntrs = nullptr;
-        }
-        if (p->pts) {
-            free(p->pts);
-            p->pts = nullptr;
-        }
-        if (p->types) {
-            free(p->types);
-            p->types = nullptr;
-        }
+        free(p->cntrs);
+        p->cntrs = nullptr;
+
+        free(p->pts);
+        p->pts = nullptr;
+
+        free(p->types);
+        p->types = nullptr;
+
         p->cntrsCnt = p->reservedCntrsCnt = 0;
         p->ptsCnt = p->reservedPtsCnt = 0;
 
+        //StrokeOutline
         p = &mpool->strokeOutline[i];
 
-        if (p->cntrs) {
-            free(p->cntrs);
-            p->cntrs = nullptr;
-        }
-        if (p->pts) {
-            free(p->pts);
-            p->pts = nullptr;
-        }
-        if (p->types) {
-            free(p->types);
-            p->types = nullptr;
-        }
+        free(p->cntrs);
+        p->cntrs = nullptr;
+
+        free(p->pts);
+        p->pts = nullptr;
+
+        free(p->types);
+        p->types = nullptr;
+
         p->cntrsCnt = p->reservedCntrsCnt = 0;
         p->ptsCnt = p->reservedPtsCnt = 0;
     }

--- a/src/lib/sw_engine/tvgSwRenderer.cpp
+++ b/src/lib/sw_engine/tvgSwRenderer.cpp
@@ -223,7 +223,6 @@ static void _termEngine()
 
 SwRenderer::~SwRenderer()
 {
-    clear();
     clearCompositors();
 
     if (surface) delete(surface);
@@ -240,6 +239,8 @@ bool SwRenderer::clear()
 {
     for (auto task = tasks.data; task < (tasks.data + tasks.count); ++task) (*task)->done();
     tasks.clear();
+
+    if (!sharedMpool) mpoolClear(mpool);
 
     if (surface) {
         vport.x = vport.y = 0;

--- a/src/lib/sw_engine/tvgSwStroke.cpp
+++ b/src/lib/sw_engine/tvgSwStroke.cpp
@@ -56,7 +56,7 @@ static void _growBorder(SwStrokeBorder* border, uint32_t newPts)
 
     while (maxCur < maxNew)
         maxCur += (maxCur >> 1) + 16;
-
+    //OPTIMIZE: use mempool!
     border->pts = static_cast<SwPoint*>(realloc(border->pts, maxCur * sizeof(SwPoint)));
     border->tags = static_cast<uint8_t*>(realloc(border->tags, maxCur * sizeof(uint8_t)));
     border->maxPts = maxCur;


### PR DESCRIPTION
if many canvas instances own private memory pool,
the memory usage can be increased linearly.

To prevent memory usage, flush out memory pool from the clear()
if the canvas uses private memory pool.