### PR TITLE
svg_loader: allow multiple defs tags

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -1087,7 +1087,7 @@ static SvgNode* _createNode(SvgNode* parent, SvgNodeType type)
 
 static SvgNode* _createDefsNode(TVG_UNUSED SvgLoaderData* loader, TVG_UNUSED SvgNode* parent, const char* buf, unsigned bufLength)
 {
-    if (loader->def && loader->doc->node.doc.defs) return nullptr;
+    if (loader->def && loader->doc->node.doc.defs) return loader->def;
     SvgNode* node = _createNode(nullptr, SvgNodeType::Defs);
     return node;
 }
@@ -2342,18 +2342,18 @@ static void _svgLoaderParserXmlOpen(SvgLoaderData* loader, const char* content, 
             node = method(loader, nullptr, attrs, attrsLength);
             loader->doc = node;
         } else {
-            if (!strcmp(tagName, "svg")) return; //Already loadded <svg>(SvgNodeType::Doc) tag
+            if (!strcmp(tagName, "svg")) return; //Already loaded <svg>(SvgNodeType::Doc) tag
             if (loader->stack.count > 0) parent = loader->stack.data[loader->stack.count - 1];
             else parent = loader->doc;
             node = method(loader, parent, attrs, attrsLength);
         }
 
         if (!node) return;
-        if (node->type == SvgNodeType::Defs) {
+        if (node->type == SvgNodeType::Defs && !loader->def) {
             loader->doc->node.doc.defs = node;
             loader->def = node;
-            if (!empty) loader->stack.push(node);
-        } else {
+        }
+        if (node->type != SvgNodeType::Defs || !empty) {
             loader->stack.push(node);
         }
     } else if ((method = _findGraphicsFactory(tagName))) {

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -1089,6 +1089,9 @@ static SvgNode* _createDefsNode(TVG_UNUSED SvgLoaderData* loader, TVG_UNUSED Svg
 {
     if (loader->def && loader->doc->node.doc.defs) return loader->def;
     SvgNode* node = _createNode(nullptr, SvgNodeType::Defs);
+
+    loader->def = node;
+    loader->doc->node.doc.defs = node;
     return node;
 }
 
@@ -2349,10 +2352,6 @@ static void _svgLoaderParserXmlOpen(SvgLoaderData* loader, const char* content, 
         }
 
         if (!node) return;
-        if (node->type == SvgNodeType::Defs && !loader->def) {
-            loader->doc->node.doc.defs = node;
-            loader->def = node;
-        }
         if (node->type != SvgNodeType::Defs || !empty) {
             loader->stack.push(node);
         }


### PR DESCRIPTION
If svg contained multiple defs tags only the first one was handled correctly.
Every next 'defs' tag was skipped and its inner elements parsed as it was
outside the defs.

This pr fixes the requested svg files:
before:
![Screenshot from 2021-07-28 10-53-11](https://user-images.githubusercontent.com/71131832/127293937-24b61913-ee9b-4b00-8638-d0993564771b.png)
after:
![Screenshot from 2021-07-28 10-37-30](https://user-images.githubusercontent.com/71131832/127293927-e668cc8d-7562-4548-bde1-eafb6a488335.png)
