### PR TITLE
common picture: correct non-working size() behavior.

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -1048,7 +1048,7 @@ public:
      *
      * @BETA_API
      */
-    const uint32_t* data() const noexcept;
+    const uint32_t* data(uint32_t* w, uint32_t* h) const noexcept;
 
     /**
      * Must remove it!

--- a/src/examples/PictureJpg.cpp
+++ b/src/examples/PictureJpg.cpp
@@ -40,7 +40,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
         }
         picture->translate(i* 150, i * 150);
         picture->rotate(30 * i);
-        picture->scale(0.25);
+        picture->size(200, 200);
         if (canvas->push(move(picture)) != tvg::Result::Success) return;
     }
 

--- a/src/examples/PicturePng.cpp
+++ b/src/examples/PicturePng.cpp
@@ -38,7 +38,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
         }
         picture->translate(i* 150, i * 150);
         picture->rotate(30 * i);
-        picture->scale(0.25);
+        picture->size(200, 200);
         if (canvas->push(move(picture)) != tvg::Result::Success) return;
     }
 }

--- a/src/lib/sw_engine/tvgSwCommon.h
+++ b/src/lib/sw_engine/tvgSwCommon.h
@@ -266,7 +266,7 @@ struct SwMpool
 
 static inline SwCoord TO_SWCOORD(float val)
 {
-    return SwCoord(val * 64);
+    return SwCoord(val * 64.0f);
 }
 
 static inline uint32_t ALPHA_BLEND(uint32_t c, uint32_t a)
@@ -289,7 +289,7 @@ static inline uint32_t ALPHA_MULTIPLY(uint32_t c, uint32_t a)
 
 static inline SwCoord HALF_STROKE(float width)
 {
-    return TO_SWCOORD(width * 0.5);
+    return TO_SWCOORD(width * 0.5f);
 }
 
 int64_t mathMultiply(int64_t a, int64_t b);
@@ -329,7 +329,7 @@ bool strokeParseOutline(SwStroke* stroke, const SwOutline& outline);
 SwOutline* strokeExportOutline(SwStroke* stroke, SwMpool* mpool, unsigned tid);
 void strokeFree(SwStroke* stroke);
 
-bool imagePrepare(SwImage* image, const Picture* pdata, const Matrix* transform, const SwBBox& clipRegion, SwBBox& renderRegion, SwMpool* mpool, unsigned tid);
+bool imagePrepare(SwImage* image, const Matrix* transform, const SwBBox& clipRegion, SwBBox& renderRegion, SwMpool* mpool, unsigned tid);
 bool imagePrepared(const SwImage* image);
 bool imageGenRle(SwImage* image, TVG_UNUSED const Picture* pdata, const SwBBox& renderRegion, bool antiAlias);
 void imageDelOutline(SwImage* image, SwMpool* mpool, uint32_t tid);

--- a/src/lib/sw_engine/tvgSwImage.cpp
+++ b/src/lib/sw_engine/tvgSwImage.cpp
@@ -26,12 +26,8 @@
 /* Internal Class Implementation                                        */
 /************************************************************************/
 
-static bool _genOutline(SwImage* image, const Picture* pdata, const Matrix* transform, SwMpool* mpool,  unsigned tid)
+static bool _genOutline(SwImage* image, const Matrix* transform, SwMpool* mpool,  unsigned tid)
 {
-    float w, h;
-    pdata->size(&w, &h);
-    if (w == 0 || h == 0) return false;
-
     image->outline = mpoolReqOutline(mpool, tid);
     auto outline = image->outline;
 
@@ -41,6 +37,9 @@ static bool _genOutline(SwImage* image, const Picture* pdata, const Matrix* tran
 
     outline->reservedCntrsCnt = 1;
     outline->cntrs = static_cast<uint32_t*>(realloc(outline->cntrs, outline->reservedCntrsCnt * sizeof(uint32_t)));
+
+    auto w = static_cast<float>(image->w);
+    auto h = static_cast<float>(image->h);
 
     Point to[4] = {{0 ,0}, {w, 0}, {w, h}, {0, h}};
     for (int i = 0; i < 4; i++) {
@@ -59,8 +58,6 @@ static bool _genOutline(SwImage* image, const Picture* pdata, const Matrix* tran
     outline->opened = false;
 
     image->outline = outline;
-    image->w = w;
-    image->h = h;
 
     return true;
 }
@@ -71,9 +68,9 @@ static bool _genOutline(SwImage* image, const Picture* pdata, const Matrix* tran
 /************************************************************************/
 
 
-bool imagePrepare(SwImage* image, const Picture* pdata, const Matrix* transform, const SwBBox& clipRegion, SwBBox& renderRegion, SwMpool* mpool, unsigned tid)
+bool imagePrepare(SwImage* image, const Matrix* transform, const SwBBox& clipRegion, SwBBox& renderRegion, SwMpool* mpool, unsigned tid)
 {
-    if (!_genOutline(image, pdata, transform, mpool, tid)) return false;
+    if (!_genOutline(image, transform, mpool, tid)) return false;
     return mathUpdateOutlineBBox(image->outline, clipRegion, renderRegion);
 }
 

--- a/src/lib/sw_engine/tvgSwRenderer.cpp
+++ b/src/lib/sw_engine/tvgSwRenderer.cpp
@@ -181,7 +181,11 @@ struct SwImageTask : SwTask
 
         if (prepareImage) {
             imageReset(&image);
-            if (!imagePrepare(&image, pdata, transform, clipRegion, bbox, mpool, tid)) goto end;
+
+            image.data = const_cast<uint32_t*>(pdata->data(&image.w, &image.h));
+            if (!image.data || image.w == 0 || image.h == 0) goto end;            
+
+            if (!imagePrepare(&image, transform, clipRegion, bbox, mpool, tid)) goto end;
 
             //Clip Path?
             if (clips.count > 0) {
@@ -194,8 +198,7 @@ struct SwImageTask : SwTask
                     }
                 }
             }
-        }
-        image.data = const_cast<uint32_t*>(pdata->data());
+        }        
     end:
         imageDelOutline(&image, mpool, tid);
     }

--- a/src/lib/tvgPicture.cpp
+++ b/src/lib/tvgPicture.cpp
@@ -85,11 +85,18 @@ Result Picture::size(float* w, float* h) const noexcept
 }
 
 
-const uint32_t* Picture::data() const noexcept
+const uint32_t* Picture::data(uint32_t* w, uint32_t* h) const noexcept
 {
     //Try it, If not loaded yet.
-    if (pImpl->loader) return pImpl->loader->pixels();
+    pImpl->reload();
 
+    if (pImpl->loader) {
+        if (w) *w = static_cast<uint32_t>(pImpl->loader->w);
+        if (h) *h = static_cast<uint32_t>(pImpl->loader->h);
+    } else {
+        if (w) *w = 0;
+        if (h) *h = 0;
+    }
     return pImpl->pixels;
 }
 

--- a/src/savers/tvg/tvgTvgSaver.cpp
+++ b/src/savers/tvg/tvgTvgSaver.cpp
@@ -319,13 +319,9 @@ TvgBinCounter TvgSaver::serializePicture(const Picture* picture)
     TvgBinCounter cnt = 0;
 
     //Bitmap Image
-    if (auto pixels = picture->data()) {
-        //TODO: Loader expects uints
-        float fw, fh;
-        picture->size(&fw, &fh);
+    uint32_t w, h;
 
-        auto w = static_cast<uint32_t>(fw);
-        auto h = static_cast<uint32_t>(fh);
+    if (auto pixels = picture->data(&w, &h)) {
         TvgBinCounter sizeCnt = sizeof(w);
         TvgBinCounter imgSize = w * h * sizeof(pixels[0]);
 


### PR DESCRIPTION
Pixel-based image picture doesn't work at size() method.
Obvisouly, we missed to implement it properly.

This patch correct it.

@Issue: https://github.com/Samsung/thorvg/issues/656