### PR TITLE
sw_engine raster: code refactoring.

### DIFF
--- a/src/lib/sw_engine/meson.build
+++ b/src/lib/sw_engine/meson.build
@@ -1,5 +1,8 @@
 source_file = [
    'tvgSwCommon.h',
+   'tvgSwRasterC.h',
+   'tvgSwRasterAvx.h',
+   'tvgSwRasterNeon.h',
    'tvgSwFill.cpp',
    'tvgSwImage.cpp',
    'tvgSwMath.cpp',

--- a/src/lib/sw_engine/tvgSwCommon.h
+++ b/src/lib/sw_engine/tvgSwCommon.h
@@ -25,14 +25,6 @@
 #include "tvgCommon.h"
 #include "tvgRender.h"
 
-#ifdef THORVG_AVX_VECTOR_SUPPORT
-    #include <immintrin.h>
-#endif
-
-#ifdef THORVG_NEON_VECTOR_SUPPORT
-    #include <arm_neon.h>
-#endif
-
 #if 0
 #include <sys/time.h>
 static double timeStamp()

--- a/src/lib/sw_engine/tvgSwRasterAvx.h
+++ b/src/lib/sw_engine/tvgSwRasterAvx.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifdef THORVG_AVX_VECTOR_SUPPORT
+
+#include <immintrin.h>
+
+
+static inline void avxRasterRGBA32(uint32_t *dst, uint32_t val, uint32_t offset, int32_t len)
+{
+    //1. calculate how many iterations we need to cover length
+    uint32_t iterations = len / 8;
+    uint32_t avxFilled = iterations * 8;
+
+    //2. set beginning of the array
+    dst += offset;
+    __m256i_u* avxDst = (__m256i_u*) dst;
+
+    //3. fill octets
+    for (uint32_t i = 0; i < iterations; ++i) {
+        *avxDst = _mm256_set1_epi32(val);
+        avxDst++;
+    }
+
+    //4. fill leftovers (in first step we have to set pointer to place where avx job is done)
+    int32_t leftovers = len - avxFilled;
+    dst += avxFilled;
+
+    while (leftovers--) *dst++ = val;
+}
+
+#endif

--- a/src/lib/sw_engine/tvgSwRasterC.h
+++ b/src/lib/sw_engine/tvgSwRasterC.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+
+static inline void cRasterRGBA32(uint32_t *dst, uint32_t val, uint32_t offset, int32_t len)
+{
+    dst += offset;
+    while (len--) *dst++ = val;
+}
+
+
+static inline bool cRasterTranslucentRle(SwSurface* surface, const SwRleData* rle, uint32_t color)
+{
+    auto span = rle->spans;
+    uint32_t src;
+
+    for (uint32_t i = 0; i < rle->size; ++i) {
+        auto dst = &surface->buffer[span->y * surface->stride + span->x];
+
+        if (span->coverage < 255) src = ALPHA_BLEND(color, span->coverage);
+        else src = color;
+
+        auto ialpha = 255 - surface->blender.alpha(src);
+
+        for (uint32_t x = 0; x < span->len; ++x)
+            dst[x] = src + ALPHA_BLEND(dst[x], ialpha);
+
+        ++span;
+    }
+    return true;
+}

--- a/src/lib/sw_engine/tvgSwRasterNeon.h
+++ b/src/lib/sw_engine/tvgSwRasterNeon.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifdef THORVG_NEON_VECTOR_SUPPORT
+
+#include <arm_neon.h>
+
+
+static inline void neonRasterRGBA32(uint32_t *dst, uint32_t val, uint32_t offset, int32_t len)
+{
+    uint32_t iterations = len / 4;
+    uint32_t neonFilled = iterations * 4;
+
+    dst += offset;
+    uint32x4_t vectorVal = {val, val, val, val};
+
+    for (uint32_t i = 0; i < iterations; ++i) {
+        vst1q_u32(dst, vectorVal);
+        dst += 4;
+    }
+
+    int32_t leftovers = len - neonFilled;
+    while (leftovers--) *dst++ = val;
+}
+
+
+static inline bool neonRasterTranslucentRle(SwSurface* surface, const SwRleData* rle, uint32_t color)
+{
+    auto span = rle->spans;
+    uint32_t src;
+
+    for (uint32_t i = 0; i < rle->size; ++i) {
+        auto dst = &surface->buffer[span->y * surface->stride + span->x];
+
+        uint8x8_t *vDst = (uint8x8_t*) dst;
+
+        if (span->coverage < 255) src = ALPHA_BLEND(color, span->coverage);
+        else src = color;
+        auto ialpha = 255 - surface->blender.alpha(src);
+
+        uint8x8_t vSrc = (uint8x8_t) vdup_n_u32(src);
+        uint8x8_t vIalpha = (uint8x8_t) vdup_n_u32(ialpha);
+
+        uint32_t iterations = span->len / 2;
+        uint32_t left = span->len % 2;
+
+        for (uint32_t x = 0; x < iterations; x+=2) {
+            vDst[x] = vadd_u8(vSrc, ALPHA_BLEND_NEON(vDst[x], vIalpha));
+        }
+
+        if (left) {
+            dst[span->len] = src + ALPHA_BLEND(dst[span->len], ialpha);
+        }
+        ++span;
+    }
+    return true;
+}
+
+
+#endif


### PR DESCRIPTION
Separate simd implementation by files to maintain them easier.

Now we have avx, c, neon version implementation base.
we can add implementations to them.