### PR TITLE
tvg_loader: introduce tvg interpreter base class for future extension.

### DIFF
--- a/src/loaders/tvg/meson.build
+++ b/src/loaders/tvg/meson.build
@@ -1,8 +1,8 @@
 source_file = [
    'tvgTvgLoader.h',
+   'tvgTvgCommon.h',
    'tvgTvgLoader.cpp',
-   'tvgTvgLoadParser.h',
-   'tvgTvgLoadParser.cpp',
+   'tvgTvgBinInterpreter.cpp',
 ]
 
 subloader_dep += [declare_dependency(

--- a/src/loaders/tvg/tvgTvgBinInterpreter.cpp
+++ b/src/loaders/tvg/tvgTvgBinInterpreter.cpp
@@ -19,9 +19,8 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 #include <memory.h>
-#include "tvgTvgLoadParser.h"
+#include "tvgTvgCommon.h"
 
 
 /************************************************************************/
@@ -465,7 +464,7 @@ static Paint* _parsePaint(TvgBinBlock baseBlock)
 /* External Class Implementation                                        */
 /************************************************************************/
 
-unique_ptr<Scene> tvgLoadData(const char *ptr, const char* end)
+unique_ptr<Scene> TvgBinInterpreter::run(const char *ptr, const char* end)
 {
     auto scene = Scene::gen();
     if (!scene) return nullptr;

--- a/src/loaders/tvg/tvgTvgCommon.h
+++ b/src/loaders/tvg/tvgTvgCommon.h
@@ -20,8 +20,8 @@
  * SOFTWARE.
  */
 
-#ifndef _TVG_TVG_LOAD_PARSER_H_
-#define _TVG_TVG_LOAD_PARSER_H_
+#ifndef _TVG_TVG_COMMON_H_
+#define _TVG_TVG_COMMON_H_
 
 #include "tvgCommon.h"
 #include "tvgBinaryDesc.h"
@@ -30,6 +30,25 @@
 #define READ_UI32(dst, src) memcpy(dst, (src), sizeof(uint32_t))
 #define READ_FLOAT(dst, src) memcpy(dst, (src), sizeof(float))
 
-unique_ptr<Scene> tvgLoadData(const char* ptr, const char* end);
 
-#endif //_TVG_TVG_LOAD_PARSER_H_
+/* Interface for Tvg Binary Interpreter */
+class TvgBinInterpreterBase
+{
+public:
+    virtual ~TvgBinInterpreterBase() {}
+
+    /* ptr: points the tvg binary body (after header)
+       end: end of the tvg binary data */
+    virtual unique_ptr<Scene> run(const char* ptr, const char* end) = 0;
+};
+
+
+/* Version 0 */
+class TvgBinInterpreter : public TvgBinInterpreterBase
+{
+public:
+    unique_ptr<Scene> run(const char* ptr, const char* end) override;
+};
+
+
+#endif  //_TVG_TVG_COMMON_H_

--- a/src/loaders/tvg/tvgTvgLoader.h
+++ b/src/loaders/tvg/tvgTvgLoader.h
@@ -24,6 +24,8 @@
 #define _TVG_TVG_LOADER_H_
 
 #include "tvgTaskScheduler.h"
+#include "tvgTvgCommon.h"
+
 
 class TvgLoader : public LoadModule, public Task
 {
@@ -33,6 +35,7 @@ public:
     uint32_t size = 0;
     uint16_t version = 0;
     unique_ptr<Scene> root = nullptr;
+    TvgBinInterpreterBase* interpreter = nullptr;
     bool copy = false;
 
     ~TvgLoader();


### PR DESCRIPTION
tvg binary format might break the compatibility if any major features have been changed.
It's allowed to do it when the major version is upgraded.

In that case, still we need to support the backward compatibility,
we can provide multiple binary interpreters and choose the proper one
based on the current loading tvg binary format version.

Thus, you can add further interpreters if it's necessary in the future.
Our policy is to derive the TvgBinInterpreterBase class to make it running on
the interface.

for example, if the major version is upgraded 1.x, you can implement TvgBinInterpreter1.