### PR TITLE
common picture: return bounding box size with the current image size.

### DIFF
--- a/src/lib/tvgPictureImpl.h
+++ b/src/lib/tvgPictureImpl.h
@@ -147,8 +147,10 @@ struct Picture::Impl
 
     bool bounds(float* x, float* y, float* w, float* h) const
     {
-        if (!paint) return false;
-        return paint->pImpl->bounds(x, y, w, h);
+        if (paint) return paint->pImpl->bounds(x, y, w, h);
+        if (w) *w = this->w;
+        if (h) *h = this->h;
+        return true;
     }
 
     RenderRegion bounds(RenderMethod& renderer)


### PR DESCRIPTION
if the picture has a bitmap-based image,
it can return the bounding box size with the current image size.