### PR TITLE
JPG loader: print error string on failure

### DIFF
--- a/src/loaders/jpg/tvgJpgLoader.cpp
+++ b/src/loaders/jpg/tvgJpgLoader.cpp
@@ -78,7 +78,7 @@ bool JpgLoader::open(const string& path)
 
     int width, height, subSample, colorSpace;
     if (tjDecompressHeader3(jpegDecompressor, data, size, &width, &height, &subSample, &colorSpace) < 0) {
-        TVGLOG("JPG LOADER", "%s", tjGetErrorStr());
+        TVGERR("JPG LOADER", "%s", tjGetErrorStr());
         goto failure;
     }
 
@@ -130,7 +130,7 @@ bool JpgLoader::read()
 
     //decompress jpg image
     if (tjDecompress2(jpegDecompressor, data, size, image, static_cast<int>(w), 0, static_cast<int>(h), TJPF_BGRX, 0) < 0) {
-        TVGLOG("JPG LOADER", "%s", tjGetErrorStr());
+        TVGERR("JPG LOADER", "%s", tjGetErrorStr());
         tjFree(image);
         image = nullptr;
         return false;

--- a/src/loaders/jpg/tvgJpgLoader.cpp
+++ b/src/loaders/jpg/tvgJpgLoader.cpp
@@ -77,7 +77,13 @@ bool JpgLoader::open(const string& path)
     if (fread(data, size, 1, jpegFile) < 1) goto failure;
 
     int width, height, subSample, colorSpace;
-    if (tjDecompressHeader3(jpegDecompressor, data, size, &width, &height, &subSample, &colorSpace) < 0) goto failure;
+    if (tjDecompressHeader3(jpegDecompressor, data, size, &width, &height, &subSample, &colorSpace) < 0) {
+#ifdef THORVG_LOG_ENABLED
+        const char* error = tjGetErrorStr();
+        fprintf(stdout, "JPG LOADER: %s\n", error);
+#endif
+        goto failure;
+    }
 
     w = static_cast<float>(width);
     h = static_cast<float>(height);
@@ -127,6 +133,10 @@ bool JpgLoader::read()
 
     //decompress jpg image
     if (tjDecompress2(jpegDecompressor, data, size, image, static_cast<int>(w), 0, static_cast<int>(h), TJPF_BGRX, 0) < 0) {
+#ifdef THORVG_LOG_ENABLED
+        const char* error = tjGetErrorStr();
+        fprintf(stdout, "JPG LOADER: %s\n", error);
+#endif
         tjFree(image);
         image = nullptr;
         return false;

--- a/src/loaders/jpg/tvgJpgLoader.cpp
+++ b/src/loaders/jpg/tvgJpgLoader.cpp
@@ -78,10 +78,7 @@ bool JpgLoader::open(const string& path)
 
     int width, height, subSample, colorSpace;
     if (tjDecompressHeader3(jpegDecompressor, data, size, &width, &height, &subSample, &colorSpace) < 0) {
-#ifdef THORVG_LOG_ENABLED
-        const char* error = tjGetErrorStr();
-        fprintf(stdout, "JPG LOADER: %s\n", error);
-#endif
+        TVGLOG("JPG LOADER", "%s", tjGetErrorStr());
         goto failure;
     }
 
@@ -133,10 +130,7 @@ bool JpgLoader::read()
 
     //decompress jpg image
     if (tjDecompress2(jpegDecompressor, data, size, image, static_cast<int>(w), 0, static_cast<int>(h), TJPF_BGRX, 0) < 0) {
-#ifdef THORVG_LOG_ENABLED
-        const char* error = tjGetErrorStr();
-        fprintf(stdout, "JPG LOADER: %s\n", error);
-#endif
+        TVGLOG("JPG LOADER", "%s", tjGetErrorStr());
         tjFree(image);
         image = nullptr;
         return false;


### PR DESCRIPTION
Added error string printing on jpg image loading failure.
The error message help developer find the corrupted jpg file.
Error message is not printed for open from char* data as there the
loaders are tried on by one.