### PR TITLE
common picture: recover viewbox() api.

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -1091,6 +1091,15 @@ public:
     Result load(uint32_t* data, uint32_t w, uint32_t h, bool copy) noexcept;
 
     /**
+     * @brief Gets the position and the size of the loaded SVG picture.
+     *
+     * @warning Please do not use it, this API is not official one. It could be modified in the next version.
+     *
+     * @BETA_API
+     */
+    Result viewbox(float* x, float* y, float* w, float* h) const noexcept;
+
+    /**
      * @brief Creates a new Picture object.
      *
      * @return A new Picture object.

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -1696,6 +1696,14 @@ TVG_EXPORT Tvg_Result tvg_picture_load_data(Tvg_Paint* paint, const char *data, 
 TVG_EXPORT Tvg_Result tvg_picture_get_size(const Tvg_Paint* paint, float* w, float* h);
 
 
+/*!
+* \brief Gets the position and the size of the loaded picture. (BETA version)
+*
+* \warning Please do not use it, this API is not official one. It can be modified in the next version.
+*/
+TVG_EXPORT Tvg_Result tvg_picture_get_viewbox(const Tvg_Paint* paint, float* x, float* y, float* w, float* h);
+
+
 /** \} */   // end defgroup ThorVGCapi_Picture
 
 

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -476,6 +476,13 @@ TVG_EXPORT Tvg_Result tvg_picture_get_size(const Tvg_Paint* paint, float* w, flo
     return (Tvg_Result) reinterpret_cast<Picture*>(CCP(paint))->size(w, h);
 }
 
+
+TVG_EXPORT Tvg_Result tvg_picture_get_viewbox(const Tvg_Paint* paint, float* x, float* y, float* w, float* h)
+{
+    if (!paint) return TVG_RESULT_INVALID_ARGUMENT;
+    return (Tvg_Result) reinterpret_cast<Picture*>(CCP(paint))->viewbox(x, y, w, h);
+}
+
 /************************************************************************/
 /* Gradient API                                                         */
 /************************************************************************/

--- a/src/lib/tvgLoadModule.h
+++ b/src/lib/tvgLoadModule.h
@@ -30,7 +30,13 @@ namespace tvg
 class LoadModule
 {
 public:
+    //default view box, if any.
+    float vx = 0;
+    float vy = 0;
+    float vw = 0;
+    float vh = 0;
     float w = 0, h = 0;         //default image size
+    bool preserveAspect = true; //keep aspect ratio by default.
 
     virtual ~LoadModule() {}
 

--- a/src/lib/tvgPicture.cpp
+++ b/src/lib/tvgPicture.cpp
@@ -74,6 +74,13 @@ Result Picture::load(uint32_t* data, uint32_t w, uint32_t h, bool copy) noexcept
 }
 
 
+Result Picture::viewbox(float* x, float* y, float* w, float* h) const noexcept
+{
+    if (pImpl->viewbox(x, y, w, h)) return Result::Success;
+    return Result::InsufficientCondition;
+}
+
+
 Result Picture::size(float w, float h) noexcept
 {
     if (pImpl->size(w, h)) return Result::Success;

--- a/src/lib/tvgPictureImpl.h
+++ b/src/lib/tvgPictureImpl.h
@@ -137,6 +137,16 @@ struct Picture::Impl
         return false;
     }
 
+    bool viewbox(float* x, float* y, float* w, float* h) const
+    {
+        if (!loader) return false;
+        if (x) *x = loader->vx;
+        if (y) *y = loader->vy;
+        if (w) *w = loader->vw;
+        if (h) *h = loader->vh;
+        return true;
+    }
+
     bool size(uint32_t w, uint32_t h)
     {
         this->w = w;

--- a/src/loaders/svg/tvgSvgLoader.h
+++ b/src/loaders/svg/tvgSvgLoader.h
@@ -35,14 +35,7 @@ public:
     SvgLoaderData loaderData;
     unique_ptr<Scene> root;
 
-    //default view box, if any.
-    float vx = 0;
-    float vy = 0;
-    float vw = 0;
-    float vh = 0;
-
     bool copy = false;
-    bool preserveAspect = true;      //aspect ratio option
 
     SvgLoader();
     ~SvgLoader();


### PR DESCRIPTION
though picture has size() api, we have a regression issue in tizen,
we can't remove this api until we resolve any regression conditions.