### PR TITLE
common: meson.build added default_options cpp_std=gnu++14

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('thorvg',
         'cpp',
-        default_options : ['buildtype=debugoptimized', 'b_sanitize=none', 'werror=false', 'optimization=s'],
+        default_options : ['buildtype=debugoptimized', 'b_sanitize=none', 'werror=false', 'optimization=s', 'cpp_std=gnu++14'],
         version : '0.4.99',
         license : 'MIT')
 


### PR DESCRIPTION
@issue: #681