### PR TITLE
common: RenderRegion x, y protect against negative value in unsigned int

### DIFF
--- a/src/lib/tvgPaint.cpp
+++ b/src/lib/tvgPaint.cpp
@@ -77,6 +77,9 @@ static bool _clipPathFastTrack(Paint* cmpTarget, const RenderTransform* pTransfo
             y2 = y2 * pTransform->m.e22 + pTransform->m.e23;
         }
 
+        if (x1 < 0.0f) x1 = 0.0f;
+        if (y1 < 0.0f) y1 = 0.0f;
+
         viewport.x = static_cast<uint32_t>(x1);
         viewport.y = static_cast<uint32_t>(y1);
         viewport.w = static_cast<uint32_t>(roundf(x2 - x1 + 0.5f));

--- a/src/lib/tvgPictureImpl.h
+++ b/src/lib/tvgPictureImpl.h
@@ -89,7 +89,7 @@ struct Picture::Impl
                 if (auto p = loader->paint()) {
                     paint = p.release();
                     loader->close();
-                    if (w != loader->w && h != loader->h) {
+                    if (w != loader->w || h != loader->h) {
                         loader->resize(paint, w, h);
                         resizing = false;
                     }

--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -523,7 +523,7 @@ unique_ptr<Scene> svgSceneBuild(SvgNode* node, float vx, float vy, float vw, flo
     auto docNode = _sceneBuildHelper(node, vx, vy, vw, vh);
 
     auto viewBoxClip = Shape::gen();
-    viewBoxClip->appendRect(vx, vy ,vw, vh, 0, 0);
+    viewBoxClip->appendRect(vx, vy, vw, vh, 0, 0);
     viewBoxClip->fill(0, 0, 0, 255);
 
     auto compositeLayer = Scene::gen();


### PR DESCRIPTION
This change protects against negative value in unsigned int of
RenderRegion.x/y. This fixes a problem of invisible paint if ClipPath
bounds was negative.

@issue: fixes #704