### PR TITLE
sw_engine: allow sharing shapes & connected strokes all in one.

### DIFF
--- a/src/lib/sw_engine/tvgSwCommon.h
+++ b/src/lib/sw_engine/tvgSwCommon.h
@@ -105,8 +105,8 @@ struct SwOutline
     uint32_t      ptsCnt;           //number of points in the glyph
     uint32_t      reservedPtsCnt;
     uint8_t*      types;            //curve type
+    bool*         closed;           //opened or closed path?
     FillRule      fillRule;
-    bool          opened;           //opened path?
 };
 
 struct SwSpan
@@ -190,7 +190,7 @@ struct SwStroke
     float sx, sy;
 
     bool firstPt;
-    bool openSubPath;
+    bool closedSubPath;
     bool handleWideStrokes;
 };
 

--- a/src/lib/sw_engine/tvgSwImage.cpp
+++ b/src/lib/sw_engine/tvgSwImage.cpp
@@ -31,12 +31,18 @@ static bool _genOutline(SwImage* image, const Matrix* transform, SwMpool* mpool,
     image->outline = mpoolReqOutline(mpool, tid);
     auto outline = image->outline;
 
-    outline->reservedPtsCnt = 5;
-    outline->pts = static_cast<SwPoint*>(realloc(outline->pts, outline->reservedPtsCnt * sizeof(SwPoint)));
-    outline->types = static_cast<uint8_t*>(realloc(outline->types, outline->reservedPtsCnt * sizeof(uint8_t)));
+     if (outline->reservedPtsCnt < 5) {
+        outline->reservedPtsCnt = 5;
+        outline->pts = static_cast<SwPoint*>(realloc(outline->pts, outline->reservedPtsCnt * sizeof(SwPoint)));
+        outline->types = static_cast<uint8_t*>(realloc(outline->types, outline->reservedPtsCnt * sizeof(uint8_t)));
+     }
 
-    outline->reservedCntrsCnt = 1;
-    outline->cntrs = static_cast<uint32_t*>(realloc(outline->cntrs, outline->reservedCntrsCnt * sizeof(uint32_t)));
+    if (outline->reservedCntrsCnt < 1) {
+        outline->reservedCntrsCnt = 1;
+        outline->cntrs = static_cast<uint32_t*>(realloc(outline->cntrs, outline->reservedCntrsCnt * sizeof(uint32_t)));
+        outline->closed = static_cast<bool*>(realloc(outline->closed, outline->reservedCntrsCnt * sizeof(bool)));
+        outline->closed[0] = true;
+    }
 
     auto w = static_cast<float>(image->w);
     auto h = static_cast<float>(image->h);
@@ -54,8 +60,6 @@ static bool _genOutline(SwImage* image, const Matrix* transform, SwMpool* mpool,
 
     outline->cntrs[outline->cntrsCnt] = outline->ptsCnt - 1;
     ++outline->cntrsCnt;
-
-    outline->opened = false;
 
     image->outline = outline;
 

--- a/src/lib/sw_engine/tvgSwMemPool.cpp
+++ b/src/lib/sw_engine/tvgSwMemPool.cpp
@@ -107,6 +107,9 @@ bool mpoolClear(SwMpool* mpool)
         free(p->types);
         p->types = nullptr;
 
+        free(p->closed);
+        p->closed = nullptr;
+
         p->cntrsCnt = p->reservedCntrsCnt = 0;
         p->ptsCnt = p->reservedPtsCnt = 0;
 
@@ -121,6 +124,9 @@ bool mpoolClear(SwMpool* mpool)
 
         free(p->types);
         p->types = nullptr;
+
+        free(p->closed);
+        p->closed = nullptr;
 
         p->cntrsCnt = p->reservedCntrsCnt = 0;
         p->ptsCnt = p->reservedPtsCnt = 0;


### PR DESCRIPTION
This patch enhanced the sw raster engine to allow the both closed & open pathes
in one shape rendering.

@issue: #266