### PR TITLE
sw_engine: memory optimization.

### DIFF
--- a/src/lib/sw_engine/tvgSwCommon.h
+++ b/src/lib/sw_engine/tvgSwCommon.h
@@ -98,12 +98,12 @@ struct SwSize
 
 struct SwOutline
 {
-    uint32_t*     cntrs;            //the contour end points
-    uint32_t      cntrsCnt;         //number of contours in glyph
-    uint32_t      reservedCntrsCnt;
     SwPoint*      pts;              //the outline's points
-    uint32_t      ptsCnt;           //number of points in the glyph
-    uint32_t      reservedPtsCnt;
+    uint16_t      ptsCnt;           //number of points in the glyph
+    uint16_t      reservedPtsCnt;
+    uint16_t*     cntrs;            //the contour end points
+    uint16_t      cntrsCnt;         //number of contours in glyph
+    uint16_t      reservedCntrsCnt;
     uint8_t*      types;            //curve type
     bool*         closed;           //opened or closed path?
     FillRule      fillRule;

--- a/src/lib/sw_engine/tvgSwImage.cpp
+++ b/src/lib/sw_engine/tvgSwImage.cpp
@@ -39,7 +39,7 @@ static bool _genOutline(SwImage* image, const Matrix* transform, SwMpool* mpool,
 
     if (outline->reservedCntrsCnt < 1) {
         outline->reservedCntrsCnt = 1;
-        outline->cntrs = static_cast<uint32_t*>(realloc(outline->cntrs, outline->reservedCntrsCnt * sizeof(uint32_t)));
+        outline->cntrs = static_cast<uint16_t*>(realloc(outline->cntrs, outline->reservedCntrsCnt * sizeof(uint16_t)));
         outline->closed = static_cast<bool*>(realloc(outline->closed, outline->reservedCntrsCnt * sizeof(bool)));
         outline->closed[0] = true;
     }

--- a/src/lib/sw_engine/tvgSwShape.cpp
+++ b/src/lib/sw_engine/tvgSwShape.cpp
@@ -62,7 +62,7 @@ static bool _growOutlineContour(SwOutline& outline, uint32_t n)
 {
     if (outline.reservedCntrsCnt >= outline.cntrsCnt + n) return false;
     outline.reservedCntrsCnt = outline.cntrsCnt + n;
-    outline.cntrs = static_cast<uint32_t*>(realloc(outline.cntrs, outline.reservedCntrsCnt * sizeof(uint32_t)));
+    outline.cntrs = static_cast<uint16_t*>(realloc(outline.cntrs, outline.reservedCntrsCnt * sizeof(uint16_t)));
     return true;
 }
 

--- a/src/lib/sw_engine/tvgSwStroke.cpp
+++ b/src/lib/sw_engine/tvgSwStroke.cpp
@@ -921,7 +921,7 @@ SwOutline* strokeExportOutline(SwStroke* stroke, SwMpool* mpool, unsigned tid)
         outline->reservedPtsCnt = ptsCnt;
     }
     if (outline->reservedCntrsCnt < cntrsCnt) {
-        outline->cntrs = static_cast<uint32_t*>(realloc(outline->cntrs, sizeof(uint32_t) * cntrsCnt));
+        outline->cntrs = static_cast<uint16_t*>(realloc(outline->cntrs, sizeof(uint16_t) * cntrsCnt));
         outline->reservedCntrsCnt = cntrsCnt;
     }
 


### PR DESCRIPTION
Save the size of the Countour array,
16 bits is large enough to count the points number in one Shape.