### PR TITLE
saver: added saving into a buffer

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -1391,6 +1391,24 @@ public:
     Result save(std::unique_ptr<Paint> paint, const std::string& path) noexcept;
 
     /**
+     * @brief Export the given @p paint data to the given @p buffer.
+     * If export success, buffer size is returned in @p size.
+     *
+     * @param[in] paint The paint to be saved with all its associated properties.
+     * @param[in] mimeType Mimetype of a data, eg. "tvg".
+     * @param[out] buffer An empty buffer, in which the paint data is to be saved.
+     * @param[out] size Size of a buffer.
+     *
+     * @retval Result::Success When succeed.
+     * @retval Result::Unknown Others.
+     *
+     * @note Saving into a buffer is synchronous. No need to call sync().
+     *
+     * @BETA_API
+     */
+    Result save(std::unique_ptr<Paint> paint, const std::string& mimeType, uint8_t** buffer, uint32_t* size) noexcept;
+
+    /**
      * @brief Guarantees that the saving task is finished.
      *
      * The behavior of the saver will work on a sync/async basis, depending on the threading setting of the Initializer.

--- a/src/lib/tvgSaveModule.h
+++ b/src/lib/tvgSaveModule.h
@@ -33,6 +33,7 @@ public:
     virtual ~SaveModule() {}
 
     virtual bool save(Paint* paint, const string& path) = 0;
+    virtual bool save(Paint* paint, uint8_t** buffer, uint32_t* size) = 0;
     virtual bool close() = 0;
 
     //Utility Method: Iterator Delegator

--- a/src/savers/tvg/tvgTvgSaver.h
+++ b/src/savers/tvg/tvgTvgSaver.h
@@ -35,6 +35,7 @@ private:
     Array<TvgBinByte> buffer;
     Paint* paint = nullptr;
     char *path = nullptr;
+    bool saveToPath = true;
     float vsize[2] = {0.0f, 0.0f};
 
     bool flushTo(const std::string& path);
@@ -65,6 +66,7 @@ public:
     ~TvgSaver();
 
     bool save(Paint* paint, const string& path) override;
+    bool save(Paint* paint, uint8_t** buffer, uint32_t* size) override;
     bool close() override;
     void run(unsigned tid) override;
 };


### PR DESCRIPTION
This patch adds saving into a buffer functionality into a Saver.
Main purpose of this api now is adding export functionality into ThorVG Viewer

@API Additions:
Result save(std::unique_ptr<Paint> paint, const std::string& mimeType, uint8_t** buffer, uint32_t* size);