### PR TITLE
wasm: fix loading for binary files

### DIFF
--- a/src/wasm/thorvgwasm.cpp
+++ b/src/wasm/thorvgwasm.cpp
@@ -66,9 +66,7 @@ public:
         mSwCanvas->clear();
 
         if (data.empty()) data = defaultData;
-        const char *cdata = data.c_str();
-        if (mPicture->load(cdata, strlen(cdata)) != Result::Success) {
-
+        if (mPicture->load(data.c_str(), data.size()) != Result::Success) {
             /* mPicture is not handled as unique_ptr yet, so delete here */
             delete(mPicture);
             mPicture = nullptr;


### PR DESCRIPTION
This patch changes load function in thorvgwasm.cpp for using size()
instead of strlen(). It fixes loading of binary files like .tvg.