### PR TITLE
sw_engine avx: addad ALPHA_BLEND_AVX and avxRasterTranslucentRect fun…

### DIFF
--- a/src/lib/sw_engine/tvgSwRaster.cpp
+++ b/src/lib/sw_engine/tvgSwRaster.cpp
@@ -121,7 +121,7 @@ static uint32_t _applyBilinearInterpolation(const uint32_t *img, uint32_t w, uin
 static bool _translucentRect(SwSurface* surface, const SwBBox& region, uint32_t color)
 {
     #if defined(THORVG_AVX_VECTOR_SUPPORT)
-        return cRasterTranslucentRect(surface, region, color);
+        return avxRasterTranslucentRect(surface, region, color);
     #elif defined(THORVG_NEON_VECTOR_SUPPORT)
         return neonRasterTranslucentRect(surface, region, color);
     #else

--- a/src/lib/sw_engine/tvgSwRasterAvx.h
+++ b/src/lib/sw_engine/tvgSwRasterAvx.h
@@ -24,28 +24,107 @@
 
 #include <immintrin.h>
 
+#define N_32BITS_IN_128REG 4
+
+static inline __m128i ALPHA_BLEND(__m128i c, __m128i a)
+{
+    //1. set the masks for the A/G and R/B channels
+    auto AG = _mm_set1_epi32(0xff00ff00);
+    auto RB = _mm_set1_epi32(0x00ff00ff);
+
+    //2. mask the alpha vector - originally quartet [a, a, a, a]
+    auto aAG = _mm_and_si128(a, AG);
+    auto aRB = _mm_and_si128(a, RB);
+
+    //3. calculate the alpha blending of the 2nd and 4th channel
+    //- mask the color vector
+    //- multiply it by the masked alpha vector
+    //- add the correction to compensate bit shifting used instead of dividing by 255
+    //- shift bits - corresponding to division by 256
+    auto even = _mm_and_si128(c, RB);
+    even = _mm_mullo_epi16(even, aRB);
+    even =_mm_add_epi16(even, RB);
+    even = _mm_srli_epi16(even, 8);
+
+    //4. calculate the alpha blending of the 1st and 3rd channel:
+    //- mask the color vector
+    //- multiply it by the corresponding masked alpha vector and store the high bits of the result
+    //- add the correction to compensate division by 256 instead of by 255 (next step)
+    //- remove the low 8 bits to mimic the division by 256
+    auto odd = _mm_and_si128(c, AG);
+    odd = _mm_mulhi_epu16(odd, aAG);
+    odd = _mm_add_epi16(odd, RB);
+    odd = _mm_and_si128(odd, AG);
+
+    //5. the final result
+    return _mm_or_si128(odd, even);
+}
+
 
 static inline void avxRasterRGBA32(uint32_t *dst, uint32_t val, uint32_t offset, int32_t len)
 {
-    //1. calculate how many iterations we need to cover length
+    //1. calculate how many iterations we need to cover the length
     uint32_t iterations = len / 8;
     uint32_t avxFilled = iterations * 8;
 
-    //2. set beginning of the array
+    //2. set the beginning of the array
     dst += offset;
     __m256i_u* avxDst = (__m256i_u*) dst;
 
-    //3. fill octets
+    //3. fill the octets
     for (uint32_t i = 0; i < iterations; ++i) {
         *avxDst = _mm256_set1_epi32(val);
         avxDst++;
     }
 
-    //4. fill leftovers (in first step we have to set pointer to place where avx job is done)
+    //4. fill leftovers (in the first step we have to set the pointer to the place where the avx job is done)
     int32_t leftovers = len - avxFilled;
     dst += avxFilled;
 
     while (leftovers--) *dst++ = val;
+}
+
+
+static inline bool avxRasterTranslucentRect(SwSurface* surface, const SwBBox& region, uint32_t color)
+{
+    auto buffer = surface->buffer + (region.min.y * surface->stride) + region.min.x;
+    auto h = static_cast<uint32_t>(region.max.y - region.min.y);
+    auto w = static_cast<uint32_t>(region.max.x - region.min.x);
+
+    auto ialpha = 255 - static_cast<uint8_t>(surface->blender.alpha(color));
+
+    auto avxColor = _mm_set1_epi32(color);
+    auto avxIalpha = _mm_set1_epi8(ialpha);
+
+    for (uint32_t y = 0; y < h; ++y) {
+        auto dst = &buffer[y * surface->stride];
+
+        //1. fill the not aligned memory (for 128-bit registers a 16-bytes alignment is required)
+        auto notAligned = ((uintptr_t)dst & 0xf) / 4;
+        if (notAligned) {
+            notAligned = (N_32BITS_IN_128REG - notAligned > w ? w : N_32BITS_IN_128REG - notAligned);
+            for (uint32_t x = 0; x < notAligned; ++x, ++dst) {
+                *dst = color + ALPHA_BLEND(*dst, ialpha);
+            }
+        }
+
+        //2. fill the aligned memory - N_32BITS_IN_128REG pixels processed at once
+        uint32_t iterations = (w - notAligned) / N_32BITS_IN_128REG;
+        uint32_t avxFilled = iterations * N_32BITS_IN_128REG;
+        auto avxDst = (__m128i*)dst;
+        for (uint32_t x = 0; x < iterations; ++x, ++avxDst) {
+            *avxDst = _mm_add_epi32(avxColor, ALPHA_BLEND(*avxDst, avxIalpha));
+        }
+
+        //3. fill the remaining pixels
+        int32_t leftovers = w - notAligned - avxFilled;
+        dst += avxFilled;
+        while (leftovers--) {
+            *dst = color + ALPHA_BLEND(*dst, ialpha);
+            dst++;
+        }
+    }
+    return true;
 }
 
 #endif


### PR DESCRIPTION
…ctions

Implemented using 128-bit registers.
avxRasterTranslucentRect is around 5 times faster than cRasterTranslucentRect (i7-8700 CPU - Coffe Lake)
