### PR TITLE
wasm: intoduce saveTvg via File System API

### DIFF
--- a/src/wasm/thorvgwasm.cpp
+++ b/src/wasm/thorvgwasm.cpp
@@ -139,6 +139,25 @@ public:
         return val(typed_memory_view(mWidth * mHeight * 4, mBuffer.get()));
     }
 
+    bool saveTvg()
+    {
+        mErrorMsg = "None";
+
+        auto saver = tvg::Saver::gen();
+        auto duplicate = unique_ptr<tvg::Picture>(static_cast<tvg::Picture*>(mPicture->duplicate()));
+        if (!saver || !duplicate) {
+            mErrorMsg = "Saving initialization failed";
+            return false;
+        }
+        if (saver->save(move(duplicate), "file.tvg") != tvg::Result::Success) {
+            mErrorMsg = "Tvg saving failed";
+            return false;
+        }
+        saver->sync();
+
+        return true;
+    }
+
 private:
     explicit ThorvgWasm()
     {
@@ -183,5 +202,7 @@ EMSCRIPTEN_BINDINGS(thorvg_bindings) {
     .function("getDefaultData", &ThorvgWasm::getDefaultData, allow_raw_pointers())
     .function("load", &ThorvgWasm::load)
     .function("update", &ThorvgWasm::update)
-    .function("render", &ThorvgWasm::render);
+    .function("render", &ThorvgWasm::render)
+
+    .function("saveTvg", &ThorvgWasm::saveTvg);
 }

--- a/wasm_cross.txt
+++ b/wasm_cross.txt
@@ -5,8 +5,8 @@ ar = 'EMSDK:upstream/emscripten/emar.py'
 
 [properties]
 root = 'EMSDK:upstream/emscripten/system'
-cpp_args = ['--bind' , '-s' , 'WASM=1' , '-s' , 'ALLOW_MEMORY_GROWTH=1' , '-s' , 'FILESYSTEM=0' , '-O2']
-cpp_link_args = ['--bind' , '-s' , 'WASM=1' , '-s' , 'ALLOW_MEMORY_GROWTH=1' , '-s' , 'FILESYSTEM=0' , '-O2']
+cpp_args = ['--bind' , '-s' , 'WASM=1' , '-s' , 'ALLOW_MEMORY_GROWTH=1' , '-s' , 'FORCE_FILESYSTEM=1' , '-O2']
+cpp_link_args = ['--bind' , '-s' , 'WASM=1' , '-s' , 'ALLOW_MEMORY_GROWTH=1' , '-s' , 'FORCE_FILESYSTEM=1' , '-O2']
 shared_lib_suffix = 'js'
 static_lib_suffix = 'js'
 shared_module_suffix = 'js'


### PR DESCRIPTION
This patch adds saveTvg() function into thorvgwasm.cpp.
Functions saves tvg using File System API.
To enable fs, changed build flag: -s FORCE_FILESYSTEM=1.
Increase in result thorvg-wasm.js size: about 68kB to about 125kB.