### PR TITLE
tvg format: added validation flag (0x80) always set

### DIFF
--- a/src/lib/tvgBinaryDesc.h
+++ b/src/lib/tvgBinaryDesc.h
@@ -46,6 +46,7 @@ using TvgBinFlag = TvgBinByte;
 #define TVG_HEADER_COMPRESSED_SIZE 4       //SIZE (TvgBinCounter)
 #define TVG_HEADER_COMPRESSED_SIZE_BITS 4  //SIZE (TvgBinCounter)
 //Reserved Flag
+#define TVG_HEAD_FLAG_VALIDATION                    0x80 //Validation flag always set
 #define TVG_HEAD_FLAG_COMPRESSED                    0x01
 
 //Paint Type

--- a/src/loaders/tvg/tvgTvgLoader.cpp
+++ b/src/loaders/tvg/tvgTvgLoader.cpp
@@ -70,6 +70,7 @@ bool TvgLoader::readHeader()
     ptr += SIZE(float);
 
     //4. Reserved
+    if (!(*ptr & TVG_HEAD_FLAG_VALIDATION)) return false;
     if (*ptr & TVG_HEAD_FLAG_COMPRESSED) compressed = true;
     ptr += TVG_HEADER_RESERVED_LENGTH;
 

--- a/src/savers/tvg/tvgTvgSaver.cpp
+++ b/src/savers/tvg/tvgTvgSaver.cpp
@@ -231,6 +231,7 @@ bool TvgSaver::writeHeader()
 
     //4. Reserved data + Compress size
     memset(ptr, 0x00, TVG_HEADER_RESERVED_LENGTH + TVG_HEADER_COMPRESS_SIZE);
+    *(buffer.ptr()) = TVG_HEAD_FLAG_VALIDATION;
     buffer.count += (TVG_HEADER_RESERVED_LENGTH + TVG_HEADER_COMPRESS_SIZE);
 
     return true;


### PR DESCRIPTION
Added single validation flag (always set, 0x80) that may help against the problems described in thread [#733](https://github.com/Samsung/thorvg/pull/733)