### PR TITLE
tvg saver: enabling gradient transformation

### DIFF
--- a/src/savers/tvg/tvgTvgSaver.h
+++ b/src/savers/tvg/tvgTvgSaver.h
@@ -57,8 +57,8 @@ private:
     TvgBinCounter serializeShape(const Shape* shape, const Matrix* pTransform);
     TvgBinCounter serializePicture(const Picture* picture, const Matrix* pTransform);
     TvgBinCounter serializePaint(const Paint* paint, const Matrix* pTransform);
-    TvgBinCounter serializeFill(const Fill* fill, TvgBinTag tag);
-    TvgBinCounter serializeStroke(const Shape* shape);
+    TvgBinCounter serializeFill(const Fill* fill, TvgBinTag tag, const Matrix* pTransform);
+    TvgBinCounter serializeStroke(const Shape* shape, const Matrix* pTransform);
     TvgBinCounter serializePath(const Shape* shape, const Matrix* pTransform);
     TvgBinCounter serializeComposite(const Paint* cmpTarget, CompositeMethod cmpMethod, const Matrix* pTransform);
     TvgBinCounter serializeChildren(Iterator* it, const Matrix* transform);


### PR DESCRIPTION
A gradient transformation was omitted when saving
into the tvg format. Fixed

Before:
![11before](https://user-images.githubusercontent.com/67589014/131267765-e49ffa38-7bd8-44b5-8abf-6cc6c76f56c6.PNG)

After:
![11after](https://user-images.githubusercontent.com/67589014/131267770-2574275f-9a0e-4a7a-9fa7-2569fa970ec4.PNG)

SVG:
```
<svg width="500" height="300">
    <radialGradient cx="80" cy="150" r="40" id="radGrad" gradientUnits="userSpaceOnUse">
      <stop style="stop-color:#ff0000" offset="0.0"/>
      <stop style="stop-color:#00ff00" offset="0.7"/>
      <stop style="stop-color:#0000ff" offset="1.0"/>
    </radialGradient>
    <path d="M 0 0 h 100 v 200 h -100 z" transform="matrix(1, 0, 0, 1, 100, 0)" style="fill:url(#radGrad)"/>
</svg>
```
