### PR TITLE
sw_engine: calling avxRasterTranslucentRect instead of its c version

### DIFF
--- a/src/lib/sw_engine/tvgSwRaster.cpp
+++ b/src/lib/sw_engine/tvgSwRaster.cpp
@@ -174,7 +174,7 @@ static bool _rasterTranslucentRect(SwSurface* surface, const SwBBox& region, uin
     }
 
 #if defined(THORVG_AVX_VECTOR_SUPPORT)
-    return cRasterTranslucentRect(surface, region, color);
+    return avxRasterTranslucentRect(surface, region, color);
 #elif defined(THORVG_NEON_VECTOR_SUPPORT)
     return neonRasterTranslucentRect(surface, region, color);
 #else


### PR DESCRIPTION
For avx vector support the avxRasterTranslucentRect should be called
instead of cRasterTranslucentRect (mischanged in 01e1fec367e0ed7cf2bb052089b12e9c406f30d8).