### PR TITLE
sw_engine: handling clips from outside the rendering region

### DIFF
--- a/src/lib/sw_engine/tvgSwRenderer.cpp
+++ b/src/lib/sw_engine/tvgSwRenderer.cpp
@@ -143,11 +143,13 @@ struct SwShapeTask : SwTask
             if (shape.rle) {
                 if (clipper->rect) rleClipRect(shape.rle, &clipper->bbox);
                 else if (clipper->rle) rleClipPath(shape.rle, clipper->rle);
+                else goto err;
             }
             //Clip stroke rle
             if (shape.strokeRle) {
                 if (clipper->rect) rleClipRect(shape.strokeRle, &clipper->bbox);
                 else if (clipper->rle) rleClipPath(shape.strokeRle, clipper->rle);
+                else goto err;
             }
         }
         goto end;
@@ -183,7 +185,7 @@ struct SwImageTask : SwTask
             imageReset(&image);
 
             image.data = const_cast<uint32_t*>(pdata->data(&image.w, &image.h));
-            if (!image.data || image.w == 0 || image.h == 0) goto end;            
+            if (!image.data || image.w == 0 || image.h == 0) goto end;
 
             if (!imagePrepare(&image, transform, clipRegion, bbox, mpool, tid)) goto end;
 
@@ -195,10 +197,15 @@ struct SwImageTask : SwTask
                         auto clipper = &static_cast<SwShapeTask*>(*clip)->shape;
                         if (clipper->rect) rleClipRect(image.rle, &clipper->bbox);
                         else if (clipper->rle) rleClipPath(image.rle, clipper->rle);
+                        else goto err;
                     }
                 }
             }
-        }        
+        }
+        goto end;
+
+    err:
+        rleReset(image.rle);
     end:
         imageDelOutline(&image, mpool, tid);
     }

--- a/src/lib/tvgPaint.cpp
+++ b/src/lib/tvgPaint.cpp
@@ -82,8 +82,8 @@ static bool _clipPathFastTrack(Paint* cmpTarget, const RenderTransform* pTransfo
 
         viewport.x = static_cast<uint32_t>(x1);
         viewport.y = static_cast<uint32_t>(y1);
-        viewport.w = static_cast<uint32_t>(roundf(x2 - x1 + 0.5f));
-        viewport.h = static_cast<uint32_t>(roundf(y2 - y1 + 0.5f));
+        viewport.w = static_cast<uint32_t>(x2 - x1 < 0 ? 0 : roundf(x2 - x1 + 0.5f));
+        viewport.h = static_cast<uint32_t>(x2 - x1 < 0 ? 0 : roundf(y2 - y1 + 0.5f));
 
         return true;
     }


### PR DESCRIPTION
Clips from outside the rendering region were ignored resulting
in rendering shapes, which should be completely clipped.
In case of the clip fast track, the bounding box width/height
overflow occured and shape, that should be clipped, could be
visible (not always).

before:
![15before](https://user-images.githubusercontent.com/67589014/131822895-bc741e80-f275-4376-88ca-921d88aade3b.PNG)

after (black screen, as expected):
![15after](https://user-images.githubusercontent.com/67589014/131822911-de61b09d-53e3-4835-b82c-62e22d396fc5.PNG)

code:
```
    if (!canvas) return;

    auto star1 = tvg::Shape::gen();
    star1->appendRect(400, 400, 300, 300, 30, 30);
    star1->fill(255, 255, 0, 255);
    star1->stroke(255 ,0, 0, 255);
    star1->stroke(10);

    auto clipStar = tvg::Shape::gen();
    clipStar->appendRect(-450, 430, 110, 110, 0, 0);
    clipStar->fill(255, 255, 255, 255);

    star1->composite(move(clipStar), tvg::CompositeMethod::ClipPath);
    canvas->push(move(star1));


    string path(EXAMPLE_DIR"/rawimage_200x300.raw");

    ifstream file(path);
    if (!file.is_open()) return ;
    auto data = (uint32_t*)malloc(sizeof(uint32_t) * (200*300));
    file.read(reinterpret_cast<char *>(data), sizeof (uint32_t) * 200 * 300);
    file.close();

    auto picture = tvg::Picture::gen();
    if (picture->load(data, 200, 300, true) != tvg::Result::Success) return;
    free(data);

    auto clipPath = tvg::Shape::gen();
    clipPath->appendRect(-19, 30, 10, 100, 10, 10);
    clipPath->fill(255, 255, 255, 255); // clip object must have alpha.

    picture->composite(move(clipPath), tvg::CompositeMethod::ClipPath);
    canvas->push(move(picture));


    auto shape1 = tvg::Shape::gen();
    shape1->appendRect(300, 0, 400, 400, 0, 0);
    shape1->fill(255, 0, 255, 255);
    shape1->stroke(255, 0, 255, 255);
    shape1->stroke(5);

    auto clipShape1 = tvg::Shape::gen();
    clipShape1->appendRect(-19, 30, 10, 100, 10, 10);
    clipShape1->fill(255, 0, 0, 255);

    shape1->composite(move(clipShape1), tvg::CompositeMethod::ClipPath);
    canvas->push(move(shape1));
```