### PR TITLE
svg_loader: parsing flags in the elliptical arc curve

### DIFF
--- a/src/loaders/svg/tvgSvgPath.cpp
+++ b/src/loaders/svg/tvgSvgPath.cpp
@@ -62,7 +62,6 @@ static bool _parseFlag(char** content, int* number)
     *number = *(*content) - '0';
     *content += 1;
     end = *content;
-    if (end && *end == '.') return false;
     *content = _skipComma(end);
 
     return true;


### PR DESCRIPTION
Since the arc flags can have values 0 or 1, we reported as
an error cases, when a float value was given.
Since the EBNF grammar can be used, we misread some paths.
Removing the condition that prevents giving a float as a flag solves
this problem and is in agreement with the w3 specs.

before:
![18before](https://user-images.githubusercontent.com/67589014/132209323-9e5c9575-ac4d-429d-94db-e8b07bfa6117.PNG)

after:
![18after](https://user-images.githubusercontent.com/67589014/132209335-3270676d-51b1-4ef7-b197-c82d37d86f9f.PNG)

code:
```
<svg viewBox="0 0 4 4">
<path d="M.604.605L.75.922C.754.896.77.877.783.855l.356.354a.9.9 0 00-.239.535H.7c-.081-.006-.081.118 0 .111h1.1c.03 0 .055-.024.055-.054V.699A.056.056 0 001.8.643a.056.056 0 00-.055.056V.9a.9.9 0 00-.535.239L.857.785C.88.773.897.755.922.752L.604.605zM1.744 1v.674l-.463-.465A.832.832 0 011.744 1zm-.537.28l.467.464H1a.778.778 0 01.207-.465z" stroke="#F00" stroke-width="0.05" fill="blue"/>
</svg>
```

It was reported as an issue in nanoSVG:
https://github.com/memononen/nanosvg/issues/167