### PR TITLE
tvg_saver: fix the incorrect stroke transformation

### DIFF
--- a/src/savers/tvg/tvgTvgSaver.h
+++ b/src/savers/tvg/tvgTvgSaver.h
@@ -58,8 +58,8 @@ private:
     TvgBinCounter serializePicture(const Picture* picture, const Matrix* pTransform);
     TvgBinCounter serializePaint(const Paint* paint, const Matrix* pTransform);
     TvgBinCounter serializeFill(const Fill* fill, TvgBinTag tag, const Matrix* pTransform);
-    TvgBinCounter serializeStroke(const Shape* shape, const Matrix* pTransform);
-    TvgBinCounter serializePath(const Shape* shape, const Matrix* pTransform);
+    TvgBinCounter serializeStroke(const Shape* shape, const Matrix* pTransform, bool preTransform);
+    TvgBinCounter serializePath(const Shape* shape, const Matrix& transform, bool preTransform);
     TvgBinCounter serializeComposite(const Paint* cmpTarget, CompositeMethod cmpMethod, const Matrix* pTransform);
     TvgBinCounter serializeChildren(Iterator* it, const Matrix* transform, bool reserved);
     TvgBinCounter serializeChild(const Paint* parent, const Paint* child, const Matrix* pTransform);


### PR DESCRIPTION
Saver tries to pre-transfom to skip the matrix data,
but it missed the case - transformed stroking,

we skip it also only when xy scaling factors are same excluding the dash properties,
because scaled of the stroking is depent on the engines,
we have no idea of the proper input data in advance.

@Issues: https://github.com/Samsung/thorvg/issues/773