### PR TITLE
sw_engine: overlaping stroke cap

### DIFF
--- a/src/lib/sw_engine/tvgSwShape.cpp
+++ b/src/lib/sw_engine/tvgSwShape.cpp
@@ -21,6 +21,7 @@
  */
 #include "tvgSwCommon.h"
 #include "tvgBezier.h"
+#include <float.h>
 
 /************************************************************************/
 /* Internal Class Implementation                                        */
@@ -234,11 +235,14 @@ static void _dashCubicTo(SwDashStroke& dash, const Point* ctrl1, const Point* ct
             Bezier left, right;
             len -= dash.curLen;
             bezSplitAt(cur, dash.curLen, left, right);
-            dash.curIdx = (dash.curIdx + 1) % dash.cnt;
             if (!dash.curOpGap) {
-                _outlineMoveTo(*dash.outline, &left.start, transform);
+                // leftovers from a previous command don't require moveTo
+                if (dash.pattern[dash.curIdx] - dash.curLen < FLT_EPSILON) {
+                    _outlineMoveTo(*dash.outline, &left.start, transform);
+                }
                 _outlineCubicTo(*dash.outline, &left.ctrl1, &left.ctrl2, &left.end, transform);
             }
+            dash.curIdx = (dash.curIdx + 1) % dash.cnt;
             dash.curLen = dash.pattern[dash.curIdx];
             dash.curOpGap = !dash.curOpGap;
             cur = right;


### PR DESCRIPTION
A square or a round cap was mistakenly added to the parts
of the dashed lines that should be continuous. Fixed

@Issues: Samsung#777

before:
![21before](https://user-images.githubusercontent.com/67589014/132353943-be5c7651-a4c5-4724-bd5c-5ca8d90d559a.PNG)

after:
![21after](https://user-images.githubusercontent.com/67589014/132353962-a8a3b255-6d3b-4b70-a169-dcf20c400728.PNG)
