### PR TITLE
tvg_saver: fix the stroke width scaling factor

### DIFF
--- a/src/savers/tvg/tvgTvgSaver.cpp
+++ b/src/savers/tvg/tvgTvgSaver.cpp
@@ -451,7 +451,7 @@ TvgBinCounter TvgSaver::serializeStroke(const Shape* shape, const Matrix* pTrans
 
     //width
     auto width = shape->strokeWidth();
-    if (preTransform) width *= pTransform->e11;  //we know x/y scaling factors are same.
+    if (preTransform) width *= sqrt(pow(pTransform->e11, 2) + pow(pTransform->e21, 2));  //we know x/y scaling factors are same.
     auto cnt = writeTagProperty(TVG_TAG_SHAPE_STROKE_WIDTH, SIZE(width), &width);
 
     //cap


### PR DESCRIPTION
To get the scaling factor from the transformation matrix we have
to use two of its elements.

this patch fixes the gradient_stroke.tvg problem from 
issue: #783 