### PR TITLE
sw_engine image: fix the clipped image issue.

### DIFF
--- a/src/lib/sw_engine/tvgSwCommon.h
+++ b/src/lib/sw_engine/tvgSwCommon.h
@@ -322,7 +322,6 @@ SwOutline* strokeExportOutline(SwStroke* stroke, SwMpool* mpool, unsigned tid);
 void strokeFree(SwStroke* stroke);
 
 bool imagePrepare(SwImage* image, const Matrix* transform, const SwBBox& clipRegion, SwBBox& renderRegion, SwMpool* mpool, unsigned tid);
-bool imagePrepared(const SwImage* image);
 bool imageGenRle(SwImage* image, TVG_UNUSED const Picture* pdata, const SwBBox& renderRegion, bool antiAlias);
 void imageDelOutline(SwImage* image, SwMpool* mpool, uint32_t tid);
 void imageReset(SwImage* image);

--- a/src/lib/sw_engine/tvgSwImage.cpp
+++ b/src/lib/sw_engine/tvgSwImage.cpp
@@ -79,12 +79,6 @@ bool imagePrepare(SwImage* image, const Matrix* transform, const SwBBox& clipReg
 }
 
 
-bool imagePrepared(const SwImage* image)
-{
-    return image->rle ? true : false;
-}
-
-
 bool imageGenRle(SwImage* image, TVG_UNUSED const Picture* pdata, const SwBBox& renderRegion, bool antiAlias)
 {
     if ((image->rle = rleRender(image->rle, image->outline, renderRegion, antiAlias))) return true;

--- a/src/lib/sw_engine/tvgSwRenderer.cpp
+++ b/src/lib/sw_engine/tvgSwRenderer.cpp
@@ -178,10 +178,7 @@ struct SwImageTask : SwTask
         auto clipRegion = bbox;
 
         //Invisible shape turned to visible by alpha.
-        auto prepareImage = false;
-        if (!imagePrepared(&image) && ((flags & RenderUpdateFlag::Image) || (opacity > 0))) prepareImage = true;
-
-        if (prepareImage) {
+        if ((flags & (RenderUpdateFlag::Image | RenderUpdateFlag::Transform | RenderUpdateFlag::Color)) && (opacity > 0)) {
             imageReset(&image);
 
             image.data = const_cast<uint32_t*>(pdata->data(&image.w, &image.h));


### PR DESCRIPTION
there was a wrong condition introduced the bug that image was not updated,
because transformation is not re-applied after the first created the internal image data.

@Issues: https://github.com/Samsung/thorvg/issues/751