### PR TITLE
common picture: changed x and y values returned by the bounds api

### DIFF
--- a/src/lib/tvgPictureImpl.h
+++ b/src/lib/tvgPictureImpl.h
@@ -169,10 +169,10 @@ struct Picture::Impl
 
     bool bounds(float* x, float* y, float* w, float* h) const
     {
-        if (x) *x = 0;
-        if (y) *y = 0;
-        if (w) *w = this->w;
-        if (h) *h = this->h;
+        if (x) *x = loader->vx;
+        if (y) *y = loader->vy;
+        if (w) *w = loader->vw;
+        if (h) *h = loader->vh;
  
         return true;
     }


### PR DESCRIPTION
For an svg file, the bounds are established by the viewbox values.

For shapes we establish not only the width and height as the bounds, but also the starting points.
For raw pictures or pngs, the starting points are zeros, but for an svg it can be any value.
This change could help us with removing in the future the viewbox api.
