### PR TITLE
tvg saver: centering tvg images

### DIFF
--- a/src/savers/tvg/tvgTvgSaver.cpp
+++ b/src/savers/tvg/tvgTvgSaver.cpp
@@ -712,7 +712,12 @@ TvgBinCounter TvgSaver::serialize(const Paint* paint, const Matrix* pTransform, 
 void TvgSaver::run(unsigned tid)
 {
     if (!writeHeader()) return;
-    if (serialize(paint, nullptr) == 0) return;
+    if (fabsf(vstart[0]) > FLT_EPSILON || fabsf(vstart[1]) > FLT_EPSILON) {
+       Matrix transform = {1, 0, -vstart[0], 0, 1, -vstart[1], 0, 0, 1};
+       if (serialize(paint, &transform) == 0) return;
+    } else {
+       if (serialize(paint, nullptr) == 0) return;
+    }
     if (!saveEncoding(path)) return;
 }
 
@@ -751,7 +756,7 @@ bool TvgSaver::save(Paint* paint, const string& path, bool compress)
     this->path = strdup(path.c_str());
     if (!this->path) return false;
 
-    paint->bounds(nullptr, nullptr, &vsize[0], &vsize[1]);
+    paint->bounds(&vstart[0], &vstart[1], &vsize[0], &vsize[1]);
     if (vsize[0] <= FLT_EPSILON || vsize[1] <= FLT_EPSILON) {
         TVGLOG("TVG_SAVER", "Saving paint(%p) has zero view size.", paint);
         return false;

--- a/src/savers/tvg/tvgTvgSaver.h
+++ b/src/savers/tvg/tvgTvgSaver.h
@@ -37,6 +37,7 @@ private:
     char *path = nullptr;
     uint32_t headerSize;
     float vsize[2] = {0.0f, 0.0f};
+    float vstart[2] = {0.0f, 0.0f}; //top left corner of the paint's bbox
     bool compress;
 
     bool flushTo(const std::string& path);


### PR DESCRIPTION
This change resolves issue with scaling images, that had
negative width or height values in the viewbox svg attribute.
Works after bounds api is fixed (separate commit).

the result can be seen after #793 is applied.
issue :#746 