### PR TITLE
tvg_saver: proper serialization of a grad fill

### DIFF
--- a/src/savers/tvg/tvgTvgSaver.h
+++ b/src/savers/tvg/tvgTvgSaver.h
@@ -57,7 +57,7 @@ private:
     TvgBinCounter serializeShape(const Shape* shape, const Matrix* pTransform);
     TvgBinCounter serializePicture(const Picture* picture, const Matrix* pTransform);
     TvgBinCounter serializePaint(const Paint* paint, const Matrix* pTransform);
-    TvgBinCounter serializeFill(const Fill* fill, TvgBinTag tag, const Matrix* pTransform);
+    TvgBinCounter serializeFill(const Fill* fill, TvgBinTag tag);
     TvgBinCounter serializeStroke(const Shape* shape, const Matrix* pTransform, bool preTransform);
     TvgBinCounter serializePath(const Shape* shape, const Matrix& transform, bool preTransform);
     TvgBinCounter serializeComposite(const Paint* cmpTarget, CompositeMethod cmpMethod, const Matrix* pTransform);


### PR DESCRIPTION
In the case when a gradinet fill is present, the transformation matrix
can't be preapplied.

issue #783 pt 5 (gallardo.svg)