### PR TITLE
common Picutre: Call resize when image loadded.

### DIFF
--- a/src/lib/tvgPictureImpl.h
+++ b/src/lib/tvgPictureImpl.h
@@ -173,7 +173,7 @@ struct Picture::Impl
         if (y) *y = 0;
         if (w) *w = this->w;
         if (h) *h = this->h;
- 
+
         return true;
     }
 
@@ -197,6 +197,7 @@ struct Picture::Impl
         if (!loader->read()) return Result::Unknown;
         w = loader->w;
         h = loader->h;
+        if (w != loader->vw || h != loader->vh) resizing = true;
         return Result::Success;
     }
 
@@ -209,6 +210,7 @@ struct Picture::Impl
         if (!loader->read()) return Result::Unknown;
         w = loader->w;
         h = loader->h;
+        if (w != loader->vw || h != loader->vh) resizing = true;
         return Result::Success;
     }
 


### PR DESCRIPTION
If the size is not set in the picture,
SvgLoader and SvgSceneBuilder build the scene based on the viewbox.
An appropriate size set is required for the width and height set afterwards,
but it is inappropriate to transform the root at the loader level.
This is because the paint object of the picture is the root.

Therefore, when load() is finished, resizing can be called according
to the width, height, and size of the viewbox.

issue: https://github.com/Samsung/thorvg/issues/799