### PR TITLE
svg_loader: proper svg resizing

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -2770,7 +2770,7 @@ void SvgLoader::run(unsigned tid)
 
         if (loaderData.cloneNodes.count > 0) _clonePostponedNodes(&loaderData.cloneNodes);
     }
-    root = svgSceneBuild(loaderData.doc, vx, vy, vw, vh);
+    root = svgSceneBuild(loaderData.doc, vx, vy, vw, vh, w, h, preserveAspect);
 };
 
 
@@ -2855,31 +2855,31 @@ bool SvgLoader::resize(Paint* paint, float w, float h)
 {
     if (!paint) return false;
 
-    auto sx = w / vw;
-    auto sy = h / vh;
+    auto sx = w / this->w;
+    auto sy = h / this->h;
 
     if (preserveAspect) {
         //Scale
         auto scale = sx < sy ? sx : sy;
         paint->scale(scale);
         //Align
-        auto vx = this->vx * scale;
-        auto vy = this->vy * scale;
-        auto vw = this->vw * scale;
-        auto vh = this->vh * scale;
-        if (vw > vh) vy -= (h - vh) * 0.5f;
-        else vx -= (w - vw) * 0.5f;
-        paint->translate(-vx, -vy);
+        auto tx = 0.0f;
+        auto ty = 0.0f;
+        auto tw = this->w * scale;
+        auto th = this->h * scale;
+        if (tw > th) ty -= (h - th) * 0.5f;
+        else tx -= (w - tw) * 0.5f;
+        paint->translate(-tx, -ty);
     } else {
         //Align
-        auto vx = this->vx * sx;
-        auto vy = this->vy * sy;
-        auto vw = this->vw * sx;
-        auto vh = this->vh * sy;
-        if (vw > vh) vy -= (h - vh) * 0.5f;
-        else vx -= (w - vw) * 0.5f;
+        auto tx = 0.0f;
+        auto ty = 0.0f;
+        auto tw = this->w * sx;
+        auto th = this->h * sy;
+        if (tw > th) ty -= (h - th) * 0.5f;
+        else tx -= (w - tw) * 0.5f;
 
-        Matrix m = {sx, 0, -vx, 0, sy, -vy, 0, 0, 1};
+        Matrix m = {sx, 0, -tx, 0, sy, -ty, 0, 0, 1};
         paint->transform(m);
     }
     return true;

--- a/src/loaders/svg/tvgSvgSceneBuilder.h
+++ b/src/loaders/svg/tvgSvgSceneBuilder.h
@@ -25,6 +25,6 @@
 
 #include "tvgCommon.h"
 
-unique_ptr<Scene> svgSceneBuild(SvgNode* node, float vx, float vy, float vw, float vh);
+unique_ptr<Scene> svgSceneBuild(SvgNode* node, float vx, float vy, float vw, float vh, float w, float h, bool preserveAspect);
 
 #endif //_TVG_SVG_SCENE_BUILDER_H_


### PR DESCRIPTION
Solves the problem of 'vx' and 'vy' < 0 and cases with 'width'
and 'height' values different than width and height from the 'viewBox'
attribute.

after:
![26after_2](https://user-images.githubusercontent.com/67589014/133349682-23dfcfd1-9488-4a52-a57a-79d106da1a2e.PNG)

code (in 3 variations: viewBox + width/height, only viewBox, only widht/height):
```
<svg viewBox="-20 -20  80 80" width="200" height="100">
<path d="M -100 -100 h 200 v 200 h -100 z" fill="black" />
<path d="M -10 -10 h 10 v 10 h -10 z" fill="blue" />
<path fill="#FFB400" d="M 35 35 h 10 v 10 h -10 z"/>
</svg>
```