### PR TITLE
common: change args type in the internal size() implementation

### DIFF
--- a/src/lib/tvgPictureImpl.h
+++ b/src/lib/tvgPictureImpl.h
@@ -159,7 +159,7 @@ struct Picture::Impl
         return true;
     }
 
-    bool size(uint32_t w, uint32_t h)
+    bool size(float w, float h)
     {
         this->w = w;
         this->h = h;


### PR DESCRIPTION
The API expected floats, whereas the called impl function expected
ints. The values were saved as floats, so the float->int->float conversion
is not needed.