### PR TITLE
api: remove the redundant api, Picture::paint().

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -1077,12 +1077,6 @@ public:
     const uint32_t* data(uint32_t* w, uint32_t* h) const noexcept;
 
     /**
-     * Must remove it!
-     * @BETA_API
-     */
-    Result paint(std::unique_ptr<Paint> paint) noexcept;
-
-    /**
      * @brief Loads a raw data from a memory block with a given size.
      *
      * @warning Please do not use it, this API is not official one. It could be modified in the next version.

--- a/src/lib/tvgPicture.cpp
+++ b/src/lib/tvgPicture.cpp
@@ -111,13 +111,3 @@ const uint32_t* Picture::data(uint32_t* w, uint32_t* h) const noexcept
     }
     return pImpl->pixels;
 }
-
-
-Result Picture::paint(unique_ptr<Paint> paint) noexcept
-{
-    if (pImpl->paint) return Result::InsufficientCondition;
-    auto p = paint.release();
-    if (!p) return Result::MemoryCorruption;
-    pImpl->paint = p;
-    return Result::Success;
-}

--- a/src/loaders/tvg/tvgTvgBinInterpreter.cpp
+++ b/src/loaders/tvg/tvgTvgBinInterpreter.cpp
@@ -347,12 +347,7 @@ static bool _parsePicture(TvgBinBlock block, Paint* paint)
     //Case2: Base Paint Properties
     if (_parsePaintProperty(block, picture)) return true;
 
-    //Case3: Vector Picture
-    if (auto paint = _parsePaint(block)) {
-        picture->paint(unique_ptr<Paint>(paint));
-        return true;
-    }
-
+    //Vector Picture won't be requested since Saver replaces it with the Scene
     return false;
 }
 


### PR DESCRIPTION
tvg::Picture is replaced to tvg::Scene if the picture has the vector tree,
Thus it's useless since it won't be reached logically.