### PR TITLE
common: fixing warnings on windows

### DIFF
--- a/src/lib/tvgInitializer.cpp
+++ b/src/lib/tvgInitializer.cpp
@@ -43,25 +43,31 @@ static uint16_t _version = 0;
 static bool _buildVersionInfo()
 {
     auto SRC = THORVG_VERSION_STRING;   //ex) 0.3.99
-    auto p = SRC;
     const char* x;
+    auto p = SRC;
+
+    x = p;
+    while (*x != '\0') ++x;
+    auto len = x - SRC;
 
     char major[3];
-    x = strchr(p, '.');
-    if (!x) return false;
+    x = p;
+    while (*x != '.' && (x - SRC < len - 1)) x++;
+    if (x - SRC == len - 1) return false;
     memcpy(major, p, x - p);
     major[x - p] = '\0';
     p = x + 1;
 
     char minor[3];
-    x = strchr(p, '.');
-    if (!x) return false;
+    x = p;
+    while (*x != '.' && (x - SRC < len - 1)) x++;
+    if (x - SRC == len - 1) return false;
     memcpy(minor, p, x - p);
     minor[x - p] = '\0';
     p = x + 1;
 
     char micro[3];
-    x = SRC + strlen(THORVG_VERSION_STRING);
+    x = SRC + len;
     memcpy(micro, p, x - p);
     micro[x - p] = '\0';
 

--- a/src/loaders/svg/tvgSvgLoaderCommon.h
+++ b/src/loaders/svg/tvgSvgLoaderCommon.h
@@ -24,6 +24,7 @@
 
 #include "tvgCommon.h"
 #include "tvgArray.h"
+#include <string.h>
 
 struct SvgNode;
 struct SvgStyleGradient;

--- a/src/loaders/svg/tvgSvgUtil.cpp
+++ b/src/loaders/svg/tvgSvgUtil.cpp
@@ -263,7 +263,9 @@ string svgUtilURLDecode(const char *src)
 {
     if (!src) return nullptr;
 
-    auto length = strlen(src);
+    auto x = src;
+    while (*x != '\0') ++x;
+    auto length = x - src;
     if (length == 0) return nullptr;
 
     string decoded;
@@ -290,7 +292,10 @@ string svgUtilBase64Decode(const char *src)
 {
     if (!src) return nullptr;
 
-    auto length = strlen(src);
+    auto x = src;
+    while (*x != '\0') ++x;
+    auto length = x - src;
+
     if (length == 0) return nullptr;
 
     string decoded;


### PR DESCRIPTION
cstring was not included