### PR TITLE
common: allow composition on empty scene without Result::InsufficientCondition error

### DIFF
--- a/src/lib/tvgCanvasImpl.h
+++ b/src/lib/tvgCanvasImpl.h
@@ -114,10 +114,12 @@ struct Canvas::Impl
     {
         if (drawing || paints.count == 0 || !renderer || !renderer->preRender()) return Result::InsufficientCondition;
 
+        bool rendered = false;
         for (auto paint = paints.data; paint < (paints.data + paints.count); ++paint) {
-            if (!(*paint)->pImpl->render(*renderer)) return Result::InsufficientCondition;
+            if ((*paint)->pImpl->render(*renderer)) rendered = true;
         }
 
+        if (!rendered) return Result::InsufficientCondition;
         if (!renderer->postRender()) return Result::InsufficientCondition;
 
         drawing = true;


### PR DESCRIPTION
If there was an empty scene (empty scene, so bounds equal zero) with a mask composition applied,
Paint::Impl::render failed on checking size and Canvas::draw() returned Result::InsufficientCondition.
As a result no other paints was rendered.

@issue: fixes #842