### PR TITLE
portability: Changes to support MSVC

### DIFF
--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -27,11 +27,14 @@
 #endif
 
 #ifdef TVG_BUILD
-    #define TVG_EXPORT __attribute__ ((visibility ("default")))
+    #ifdef _WIN32
+        #define TVG_EXPORT __declspec(dllexport)
+    #else
+        #define TVG_EXPORT __attribute__ ((visibility ("default")))
+    #endif
 #else
     #define TVG_EXPORT
 #endif
-
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/loaders/tvg/tvgTvgBinInterpreter.cpp
+++ b/src/loaders/tvg/tvgTvgBinInterpreter.cpp
@@ -20,6 +20,13 @@
  * SOFTWARE.
  */
 #include <memory.h>
+
+#ifdef _WIN32
+    #include <malloc.h>
+#else
+    #include <alloca.h>
+#endif
+
 #include "tvgTvgCommon.h"
 
 
@@ -139,7 +146,7 @@ static bool _parseShapePath(const char *ptr, const char *end, Shape *shape)
     if (ptr > end) return false;
 
     /* Recover to PathCommand(4 bytes) from TvgBinFlag(1 byte) */
-    PathCommand inCmds[cmdCnt];
+    PathCommand* inCmds = (PathCommand*)alloca(sizeof(PathCommand) * cmdCnt);
     for (uint32_t i = 0; i < cmdCnt; ++i) {
         inCmds[i] = static_cast<PathCommand>(cmds[i]);
     }
@@ -206,7 +213,7 @@ static unique_ptr<Fill> _parseShapeFill(const char *ptr, const char *end)
                 if (block.length == 0 || block.length & 0x07) return nullptr;
                 uint32_t stopsCnt = block.length >> 3; // 8 bytes per ColorStop
                 if (stopsCnt > 1023) return nullptr;
-                Fill::ColorStop stops[stopsCnt];
+                Fill::ColorStop* stops = (Fill::ColorStop*)alloca(sizeof(Fill::ColorStop) * stopsCnt);
                 auto p = block.data;
                 for (uint32_t i = 0; i < stopsCnt; i++, p += 8) {
                     READ_FLOAT(&stops[i].offset, p);

--- a/src/savers/tvg/tvgTvgSaver.cpp
+++ b/src/savers/tvg/tvgTvgSaver.cpp
@@ -25,6 +25,12 @@
 #include "tvgTvgSaver.h"
 #include "tvgLzw.h"
 
+#ifdef _WIN32
+    #include <malloc.h>
+#else
+    #include <alloca.h>
+#endif
+
 #define SIZE(A) sizeof(A)
 
 /************************************************************************/
@@ -497,7 +503,7 @@ TvgBinCounter TvgSaver::serializePath(const Shape* shape, const Matrix* transfor
 
     /* Reduce the binary size.
        Convert PathCommand(4 bytes) to TvgBinFlag(1 byte) */
-    TvgBinFlag outCmds[cmdCnt];
+    TvgBinFlag* outCmds = (TvgBinFlag*)alloca(SIZE(TvgBinFlag) * cmdCnt);
     for (uint32_t i = 0; i < cmdCnt; ++i) {
         outCmds[i] = static_cast<TvgBinFlag>(cmds[i]);
     }

--- a/test/capi/capiLinearGradient.cpp
+++ b/test/capi/capiLinearGradient.cpp
@@ -78,8 +78,8 @@ TEST_CASE("Linear Gradient color stops", "[capiLinearGradient]")
 
     Tvg_Color_Stop color_stops[2] =
     {
-        {.offset=0.0, .r=0, .g=0,   .b=0, .a=255},
-        {.offset=1,   .r=0, .g=255, .b=0, .a=255},
+        {0.0, 0, 0,   0, 255},
+        {1.0, 0, 255, 0, 255},
     };
 
     const Tvg_Color_Stop *color_stops_ret;
@@ -105,8 +105,8 @@ TEST_CASE("Linear Gradient clear data", "[capiLinearGradient]")
 
     Tvg_Color_Stop color_stops[2] =
     {
-        {.offset=0.0, .r=0, .g=0,   .b=0, .a=255},
-        {.offset=1,   .r=0, .g=255, .b=0, .a=255},
+        {0.0, 0, 0,   0, 255},
+        {1.0, 0, 255, 0, 255},
     };
 
     const Tvg_Color_Stop *color_stops_ret = NULL;
@@ -150,8 +150,8 @@ TEST_CASE("Stroke Linear Gradient", "[capiLinearGradient]")
 
     Tvg_Color_Stop color_stops[2] =
     {
-        {.offset=0.0, .r=0, .g=0,   .b=0, .a=255},
-        {.offset=1,   .r=0, .g=255, .b=0, .a=255},
+        {0.0, 0, 0,   0, 255},
+        {1.0, 0, 255, 0, 255},
     };
 
     Tvg_Gradient *gradient_ret = NULL;

--- a/test/capi/capiRadialGradient.cpp
+++ b/test/capi/capiRadialGradient.cpp
@@ -75,8 +75,8 @@ TEST_CASE("Set/Get color stops", "[capiRadialGradient]")
     REQUIRE(gradient);
 
     Tvg_Color_Stop color_stops[2] = {
-        {.offset=0.0, .r=0, .g=0,   .b=0, .a=255},
-        {.offset=1,   .r=0, .g=255, .b=0, .a=255},
+        {0.0, 0, 0,   0, 255},
+        {1.0, 0, 255, 0, 255},
     };
 
     const Tvg_Color_Stop *color_stops_ret;
@@ -102,8 +102,8 @@ TEST_CASE("Clear gradient data", "[capiRadialGradient]")
     REQUIRE(gradient);
 
     Tvg_Color_Stop color_stops[2] = {
-        {.offset=0.0, .r=0, .g=0,   .b=0, .a=255},
-        {.offset=1,   .r=0, .g=255, .b=0, .a=255},
+        {0.0, 0, 0,   0, 255},
+        {1.0, 0, 255, 0, 255},
     };
 
     const Tvg_Color_Stop *color_stops_ret;
@@ -148,10 +148,9 @@ TEST_CASE("Stroke Radial Gradient", "[capiRadialGradient]")
 
     REQUIRE(tvg_radial_gradient_set(gradient, 10.0, 15.0, 30.0) == TVG_RESULT_SUCCESS);
 
-    Tvg_Color_Stop color_stops[2] =
-    {
-        {.offset=0.0, .r=0, .g=0,   .b=0, .a=255},
-        {.offset=1,   .r=0, .g=255, .b=0, .a=255},
+    Tvg_Color_Stop color_stops[2] = {
+        {0.0, 0, 0,   0, 255},
+        {1.0, 0, 255, 0, 255},
     };
 
     Tvg_Gradient *gradient_ret = NULL;


### PR DESCRIPTION
Recommend the following changes to support building on MSVC:
- Define capi export visibility for WIN32. Equivalent to `__attribute__ ((visibility ("default")))` is `__declspec(dllexport)`
- Replace variable length arrays (not supported by MSVC) with stack allocation via `alloca` (note: same code used as already found in `tvgXmlParser`)
- Changed designated initlializers in arrays of structs (`test/capi/capi[Linear/Radial]Gradient` to avoid `error C7555: use of designated initializers requires at least '/std:c++latest'` since default for thorvg is c++14

Happy for any feedback and further changes you recommend!
Relates to #844 