### PR TITLE
capi: replaced bounds() api with the latest.

### DIFF
--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -813,21 +813,21 @@ TVG_EXPORT Tvg_Paint* tvg_paint_duplicate(Tvg_Paint* paint);
 
 
 /*!
-* \brief Gets the bounding box of the Tvg_Paint object before any transformation. (BETA_API)
+* \brief Gets the axis-aligned bounding box of the Tvg_Paint object. (BETA_API)
 *
 * \param[in] paint The Tvg_Paint object of which to get the bounds.
 * \param[out] x The x coordinate of the upper left corner of the object.
 * \param[out] y The y coordinate of the upper left corner of the object.
 * \param[out] w The width of the object.
 * \param[out] h The height of the object.
-* \param[in] transformed if @c true, apply the transformation of the paint.
+* \param[in] transformed If @c true, the transformation of the paint is taken into account, otherwise it isn't.
 *
 * \return Tvg_Result enumeration.
 * \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Paint pointer.
 * \retval TVG_RESULT_INSUFFICIENT_CONDITION Other errors.
 *
-* \note Transformation of an object changes the returned values.
+* \note The bounding box doesn't indicate the actual drawing region. It's the smallest rectangle that encloses the object.
 */
 TVG_EXPORT Tvg_Result tvg_paint_get_bounds(const Tvg_Paint* paint, float* x, float* y, float* w, float* h, bool transformed);
 

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -813,13 +813,14 @@ TVG_EXPORT Tvg_Paint* tvg_paint_duplicate(Tvg_Paint* paint);
 
 
 /*!
-* \brief Gets the bounding box of the Tvg_Paint object before any transformation.
+* \brief Gets the bounding box of the Tvg_Paint object before any transformation. (BETA_API)
 *
 * \param[in] paint The Tvg_Paint object of which to get the bounds.
 * \param[out] x The x coordinate of the upper left corner of the object.
 * \param[out] y The y coordinate of the upper left corner of the object.
 * \param[out] w The width of the object.
 * \param[out] h The height of the object.
+* \param[in] transformed if @c true, apply the transformation of the paint.
 *
 * \return Tvg_Result enumeration.
 * \retval TVG_RESULT_SUCCESS Succeed.
@@ -828,7 +829,7 @@ TVG_EXPORT Tvg_Paint* tvg_paint_duplicate(Tvg_Paint* paint);
 *
 * \note Transformation of an object changes the returned values.
 */
-TVG_EXPORT Tvg_Result tvg_paint_get_bounds(const Tvg_Paint* paint, float* x, float* y, float* w, float* h);
+TVG_EXPORT Tvg_Result tvg_paint_get_bounds(const Tvg_Paint* paint, float* x, float* y, float* w, float* h, bool transformed);
 
 
 /*!

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -191,10 +191,10 @@ TVG_EXPORT Tvg_Result tvg_paint_get_opacity(Tvg_Paint* paint, uint8_t* opacity)
 }
 
 
-TVG_EXPORT Tvg_Result tvg_paint_get_bounds(const Tvg_Paint* paint, float* x, float* y, float* w, float* h)
+TVG_EXPORT Tvg_Result tvg_paint_get_bounds(const Tvg_Paint* paint, float* x, float* y, float* w, float* h, bool transformed)
 {
    if (!paint) return TVG_RESULT_INVALID_ARGUMENT;
-   return (Tvg_Result) reinterpret_cast<const Paint*>(paint)->bounds(x, y, w, h, true);
+   return (Tvg_Result) reinterpret_cast<const Paint*>(paint)->bounds(x, y, w, h, transformed);
 }
 
 

--- a/test/capi/capiPaint.cpp
+++ b/test/capi/capiPaint.cpp
@@ -142,7 +142,7 @@ TEST_CASE("Paint Bounds", "[capiPaint]")
     float x, y, w, h;
 
     REQUIRE(tvg_shape_append_rect(paint, 0, 10, 20, 100, 0, 0) == TVG_RESULT_SUCCESS);
-    REQUIRE(tvg_paint_get_bounds(paint, &x, &y, &w, &h) == TVG_RESULT_SUCCESS);
+    REQUIRE(tvg_paint_get_bounds(paint, &x, &y, &w, &h, true) == TVG_RESULT_SUCCESS);
 
     REQUIRE(x == 0);
     REQUIRE(y == 10);
@@ -151,14 +151,24 @@ TEST_CASE("Paint Bounds", "[capiPaint]")
 
     REQUIRE(tvg_shape_reset(paint) == TVG_RESULT_SUCCESS);
 
+    REQUIRE(tvg_paint_translate(paint, 100, 100) == TVG_RESULT_SUCCESS);
+    REQUIRE(tvg_paint_scale(paint, 2) == TVG_RESULT_SUCCESS);
+
     REQUIRE(tvg_shape_move_to(paint, 0, 10) == TVG_RESULT_SUCCESS);
     REQUIRE(tvg_shape_line_to(paint, 20, 110) == TVG_RESULT_SUCCESS);
-    REQUIRE(tvg_paint_get_bounds(paint, &x, &y, &w, &h) == TVG_RESULT_SUCCESS);
+    REQUIRE(tvg_paint_get_bounds(paint, &x, &y, &w, &h, false) == TVG_RESULT_SUCCESS);
 
     REQUIRE(x == 0);
     REQUIRE(y == 10);
     REQUIRE(w == 20);
     REQUIRE(h == 100);
+
+    REQUIRE(tvg_paint_get_bounds(paint, &x, &y, &w, &h, true) == TVG_RESULT_SUCCESS);
+
+    REQUIRE(x == Approx(100.0f).margin(0.000001));
+    REQUIRE(y == Approx(120.0f).margin(0.000001));
+    REQUIRE(w == Approx(40.0f).margin(0.000001));
+    REQUIRE(h == Approx(200.0f).margin(0.000001));
 
     REQUIRE(tvg_paint_del(paint) == TVG_RESULT_SUCCESS);
 }


### PR DESCRIPTION
The next api of c++ version has been deprecated

Tvg_Result tvg_paint_get_bounds(const Tvg_Paint* paint, float* x, float* y, float* w, float* h);

instead, we introduce the next one under the beta.

Tvg_Result tvg_paint_get_bounds(const Tvg_Paint* paint, float* x, float* y, float* w, float* h, bool transformed);