### PR TITLE
common, gl_engine: portable fallthrough attribute

### DIFF
--- a/src/lib/gl_engine/tvgGlGeometry.cpp
+++ b/src/lib/gl_engine/tvgGlGeometry.cpp
@@ -80,7 +80,7 @@ bool GlGeometry::decomposeOutline(const Shape& shape)
                 mPrimitives.push_back(GlPrimitive());
                 curPrimitive = &mPrimitives.back();
             }
-            __attribute__ ((fallthrough));
+            TVG_FALLTHROUGH
             case PathCommand::LineTo: {
                 if (curPrimitive) addPoint(*curPrimitive, pts[0], min, max);
                 pts++;

--- a/src/lib/tvgCommon.h
+++ b/src/lib/tvgCommon.h
@@ -37,6 +37,16 @@ using namespace tvg;
     #define TVG_UNUSED __attribute__ ((__unused__))
 #endif
 
+// Portable 'fallthrough' attribute
+#if __has_cpp_attribute(fallthrough)
+    #ifdef _MSC_VER
+        #define TVG_FALLTHROUGH [[fallthrough]];
+    #else
+        #define TVG_FALLTHROUGH __attribute__ ((fallthrough));
+    #endif
+#else
+    #define TVG_FALLTHROUGH
+#endif
 
 //TVG class identifier values
 #define TVG_CLASS_ID_UNDEFINED 0


### PR DESCRIPTION
Define a portable version of  `__attribute__ ((fallthrough))` to `tvgCommon.h` and replaced it's use in `gl_engine/tvgGlGeometry.cpp`.

The attribute is only available from c++17 onward and has a different syntax in MSVC.

See #863

Could somebody please test this change on non-windows systems, please?