### PR TITLE
all: fixing clang warnings

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -18,7 +18,7 @@
 #include <string>
 
 #ifdef TVG_BUILD
-    #ifdef _MSC_VER
+    #if defined(_MSC_VER) && !defined(__clang__)
         #define TVG_EXPORT __declspec(dllexport)
         #define TVG_DEPRECATED __declspec(deprecated)
     #else
@@ -306,7 +306,7 @@ public:
      * @return Result::Success when succeed, Result::InsufficientCondition otherwise.
      *
      * @note The bounding box doesn't indicate the actual drawing region. It's the smallest rectangle that encloses the object.
-     * 
+     *
      * @BETA_API
      */
     Result bounds(float* x, float* y, float* w, float* h, bool transformed) const noexcept;

--- a/src/lib/sw_engine/tvgSwMath.cpp
+++ b/src/lib/sw_engine/tvgSwMath.cpp
@@ -28,7 +28,7 @@
 /************************************************************************/
 
 //clz: count leading zero’s
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(__clang__)
     #include <intrin.h>
     static uint32_t __inline _clz(uint32_t value)
     {

--- a/src/lib/tvgCommon.h
+++ b/src/lib/tvgCommon.h
@@ -48,6 +48,11 @@ using namespace tvg;
     #define TVG_FALLTHROUGH
 #endif
 
+#ifdef __clang__
+    #define strncpy strncpy_s
+    #define strdup _strdup
+#endif
+
 //TVG class identifier values
 #define TVG_CLASS_ID_UNDEFINED 0
 #define TVG_CLASS_ID_SHAPE     1


### PR DESCRIPTION
fopen->fopen_s, strdup -> _strdup, strncpy -> strncpy_s
__declspec(dllexport) -> __attribute__ ((visibility ("default")))

I didn;t want to define _CRT_NONSTDC_NO_DEPRECATE to eliminate some warnings.


![e1](https://user-images.githubusercontent.com/67589014/135754475-54d6d540-d201-4457-bb9d-57da9d951a03.PNG)
![e2](https://user-images.githubusercontent.com/67589014/135754476-83ddf2ac-9589-433d-9f05-1f789ada5138.PNG)
![e3](https://user-images.githubusercontent.com/67589014/135754478-24635961-a99d-4322-94cd-9a855f574b6f.PNG)
![e4](https://user-images.githubusercontent.com/67589014/135754482-b1fd8348-a473-43cc-ad72-990838da3e12.PNG)


