### PR TITLE
sw_engine: border cases for gradients

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -6,9 +6,15 @@ project('thorvg',
 
 config_h = configuration_data()
 
+if host_machine.system() != 'windows'
 add_project_arguments('-DEXAMPLE_DIR="@0@/src/examples/images"'.format(meson.current_source_dir()),
                       '-DTEST_DIR="@0@/test/images"'.format(meson.current_source_dir()),
                       language : 'cpp')
+else
+add_project_arguments('-DEXAMPLE_DIR="@0@\src\examples\images"'.format(meson.current_source_dir()),
+                      '-DTEST_DIR="@0@\test\images"'.format(meson.current_source_dir()),
+                      language : 'cpp')
+endif
 
 config_h.set_quoted('THORVG_VERSION_STRING', meson.project_version())
 

--- a/src/lib/sw_engine/tvgSwRenderer.cpp
+++ b/src/lib/sw_engine/tvgSwRenderer.cpp
@@ -20,6 +20,7 @@
  * SOFTWARE.
  */
 #include <math.h>
+#include <float.h>
 #include "tvgSwCommon.h"
 #include "tvgTaskScheduler.h"
 #include "tvgSwRenderer.h"
@@ -224,6 +225,18 @@ static void _termEngine()
 }
 
 
+bool _monochromaticGradient(const Fill* fill)
+{
+    float x1, x2, y1, y2, r;
+
+    if ((fill->id() == TVG_CLASS_ID_LINEAR && static_cast<const LinearGradient*>(fill)->linear(&x1, &y1, &x2, &y2) == Result::Success &&
+         fabsf(x1 - x2) < FLT_EPSILON && fabsf(y1 - y2) < FLT_EPSILON) ||
+        (fill->id() == TVG_CLASS_ID_RADIAL && static_cast<const RadialGradient*>(fill)->radial(nullptr, nullptr, &r) == Result::Success &&
+         r < FLT_EPSILON)) return true;
+
+    return false;
+}
+
 /************************************************************************/
 /* External Class Implementation                                        */
 /************************************************************************/
@@ -364,7 +377,16 @@ bool SwRenderer::renderShape(RenderData data)
     uint8_t r, g, b, a;
 
     if (auto fill = task->sdata->fill()) {
-        rasterGradientShape(surface, &task->shape, fill->id());
+        if (_monochromaticGradient(fill)) {
+            const Fill::ColorStop* stop;
+            auto cnt = fill->colorStops(&stop);
+            if (cnt > 0 && stop) {
+                a = static_cast<uint8_t>((opacity * static_cast<uint32_t>(stop[cnt - 1].a)) / 255);
+                if (a > 0) rasterSolidShape(surface, &task->shape, stop[cnt - 1].r, stop[cnt - 1].g, stop[cnt - 1].b, a);
+            }
+        } else {
+            rasterGradientShape(surface, &task->shape, fill->id());
+        }
     } else {
         task->sdata->fillColor(&r, &g, &b, &a);
         a = static_cast<uint8_t>((opacity * (uint32_t) a) / 255);
@@ -372,7 +394,16 @@ bool SwRenderer::renderShape(RenderData data)
     }
 
     if (auto strokeFill = task->sdata->strokeFill()) {
-        rasterGradientStroke(surface, &task->shape, strokeFill->id());
+        if (_monochromaticGradient(strokeFill)) {
+            const Fill::ColorStop* stop;
+            auto cnt = strokeFill->colorStops(&stop);
+            if (cnt > 0 && stop) {
+                a = static_cast<uint8_t>((opacity * static_cast<uint32_t>(stop[cnt - 1].a)) / 255);
+                if (a > 0) rasterStroke(surface, &task->shape, stop[cnt - 1].r, stop[cnt - 1].g, stop[cnt - 1].b, a);
+            }
+        } else {
+            rasterGradientStroke(surface, &task->shape, strokeFill->id());
+        }
     } else {
         if (task->sdata->strokeColor(&r, &g, &b, &a) == Result::Success) {
             a = static_cast<uint8_t>((opacity * (uint32_t) a) / 255);


### PR DESCRIPTION
According to the svg standard, in a case when 'x1==x2 and y1==y2'
for a linear gradient or when 'r==0' for a radial gradient, the area
should be painted as a single color - the last gradient stop color.

before:
empty plot

after:
![31after](https://user-images.githubusercontent.com/67589014/135938008-34ea81ca-db34-49db-a4d7-baa8f06aa418.PNG)

code:
```
<svg viewBox="0 0 100 100">
  <defs>
    <linearGradient id="lin" x1="0" y1="0" x2="0" y2="0">
      <stop style="stop-color:#ff0000;" offset="0"/>
      <stop style="stop-color:#0000ff;" offset="1"/>
    </linearGradient>
    <radialGradient id="rad" r="0" cx="0.3" cy="0.3">
      <stop style="stop-color:#ffff00;" offset="0"/>
      <stop style="stop-color:#00ffff;" offset="1"/>
    </radialGradient>
  </defs>
  <rect x="0" y="0" width="100" height="50" fill="url(#lin)"/>
  <rect x="0" y="50" width="100" height="50" fill="url(#rad)"/>
</svg>
```
