### PR TITLE
tests: ++LOC svg loader, tvg saver

### DIFF
--- a/test/images/tag.svg
+++ b/test/images/tag.svg
@@ -1,8 +1,8 @@
 <svg width="1000" height="1000" viewBox="0 0 1000 1000"
 	xmlns="http://www.w3.org/2000/svg">
-	<g fill="url(#grad1)" mask="url(#vg)" transform="rotate(0 0 0) translate(0 0) scale(1.0)">
+	<g fill="url(#grad1)" mask="url(#vg)" transform="rotate(0 0 0) translate(2 0) scale(1.0)" style="color:blue">
 		<path d="M420.82388 380H588.68467V422.805317H420.82388Z" stroke-width="0" stroke-dasharray="100%" stroke-dashoffset="0" />
-		<path d="m420.82403 440.7101v63.94623l167.86079 25.5782V440.7101Z"/>
+		<path d="m420.82403 440.7101v63.94623l167.86079 25.5782V440.7101Z" style="opacity:0.9;color:black;fill:red;fill-rule:evenodd;stroke-width:10;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.9;stroke:black;display:inline;" transform="matrix(1,0,0,1,20,0)"/>
 		<path d="M420.82403 523.07258V673.47362L588.68482 612.59701V548.13942Z"/>
 		<g stroke-width="3.864492">
 			<path d="M256.61221 100.51736H752.8963V386.99554H256.61221Z"/>
@@ -29,13 +29,13 @@
 	<path d="M885.834 872.086A45 45 0 1 1 885.834 919.815L909.698 895.95Z" fill="#223" opacity="0.6" stroke-linejoin="miter" stroke-linecap="round" id="man"/>
 	<use href="#man" x="0" y="0" />
 	<defs>
-		<linearGradient id="grad1" gradientTransform="translate(0, 0)">
+		<linearGradient id="grad1" gradientTransform="translate(0, 0)" x1="0" y1="0" x2="100%" y2="0">
 			<stop offset="0%" stop-color="#50585d"/>
 			<stop offset="100%" stop-color="#252f35"/>
 		</linearGradient>
-		<radialGradient id="grad2" cx="100%" cy="0.25" r="1.5" gradientTransform="scale(1)">
+		<radialGradient id="grad2" cx="100%" cy="0.25" fx="0.5" fy="0.5" r="1.5" gradientTransform="scale(0.2)" spreadMethod="reflect">
 			<stop offset="0%" stop-color="#252f35" stop-opacity="80%"/>
-			<stop offset="100%" stop-color="#252f35"/>
+			<stop offset="100%" style="stop-color:#000000;stop-opacity:1;"/>
 		</radialGradient>
 		<mask id="vg">
 			<circle style="stroke: black;" cx="50%" cy="50%" r="50%" />

--- a/test/testPicture.cpp
+++ b/test/testPicture.cpp
@@ -276,6 +276,7 @@ TEST_CASE("Load SVG file and render", "[tvgPicture]")
     REQUIRE(picture);
 
     REQUIRE(picture->load(TEST_DIR"/tag.svg") == Result::Success);
+    REQUIRE(picture->size(100, 100) == Result::Success);
 
     REQUIRE(canvas->push(move(picture)) == Result::Success);
     REQUIRE(canvas->draw() == Result::Success);


### PR DESCRIPTION
before:
![32before](https://user-images.githubusercontent.com/67589014/136061168-6b22394e-e03a-48d6-a76d-a0710cc4fc9c.PNG)

after
![32after](https://user-images.githubusercontent.com/67589014/136061177-e7ee8bc8-f02e-44c4-bbe1-675ab904d9ef.PNG)
:
