### PR TITLE
examples, tests: replace backslashes with forward slashes for portability

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -6,8 +6,8 @@ project('thorvg',
 
 config_h = configuration_data()
 
-add_project_arguments('-DEXAMPLE_DIR="@0@/src/examples/images"'.format(meson.current_source_dir()),
-                      '-DTEST_DIR="@0@/test/images"'.format(meson.current_source_dir()),
+add_project_arguments('-DEXAMPLE_DIR="@0@/src/examples/images"'.format(meson.current_source_dir()).replace('\\','/'),
+                      '-DTEST_DIR="@0@/test/images"'.format(meson.current_source_dir()).replace('\\','/'),
                       language : 'cpp')
 
 config_h.set_quoted('THORVG_VERSION_STRING', meson.project_version())

--- a/meson.build
+++ b/meson.build
@@ -6,8 +6,9 @@ project('thorvg',
 
 config_h = configuration_data()
 
-add_project_arguments('-DEXAMPLE_DIR="@0@/src/examples/images"'.format(meson.current_source_dir()).replace('\\','/'),
-                      '-DTEST_DIR="@0@/test/images"'.format(meson.current_source_dir()).replace('\\','/'),
+src_dir = '/'.join(meson.current_source_dir().split('\\'))
+add_project_arguments('-DEXAMPLE_DIR="@0@/src/examples/images"'.format(src_dir),
+                      '-DTEST_DIR="@0@/test/images"'.format(src_dir),
                       language : 'cpp')
 
 config_h.set_quoted('THORVG_VERSION_STRING', meson.project_version())


### PR DESCRIPTION
Replace backslashes with forward slashes in `EXAMPLE_DIR` and `TEST_DIR` (meson).
These path defines had backslashes in windows, which were acting as escape characters in strings.
