### PR TITLE
tvg_saver/tvg_loader: gradient fill in the tvg format

### DIFF
--- a/src/lib/tvgBinaryDesc.h
+++ b/src/lib/tvgBinaryDesc.h
@@ -87,6 +87,7 @@ using TvgBinFlag = TvgBinByte;
 #define TVG_TAG_FILL_RADIAL_GRADIENT                (TvgBinTag)0x61
 #define TVG_TAG_FILL_COLORSTOPS                     (TvgBinTag)0x62
 #define TVG_TAG_FILL_FILLSPREAD                     (TvgBinTag)0x63
+#define TVG_TAG_FILL_TRANSFORM                      (TvgBinTag)0x64
 
 
 //Picture

--- a/src/loaders/tvg/tvgTvgBinInterpreter.cpp
+++ b/src/loaders/tvg/tvgTvgBinInterpreter.cpp
@@ -225,6 +225,13 @@ static unique_ptr<Fill> _parseShapeFill(const char *ptr, const char *end)
                 fillGrad->colorStops(stops, stopsCnt);
                 break;
             }
+            case TVG_TAG_FILL_TRANSFORM: {
+                if (!fillGrad || block.length != SIZE(Matrix)) return nullptr;
+                Matrix gradTransform;
+                memcpy(&gradTransform, block.data, SIZE(Matrix));
+                fillGrad->transform(gradTransform);
+                break;
+            }
             default: {
                 TVGLOG("TVG", "Unsupported tag %d (0x%x) used as one of the fill properties, %d bytes skipped", block.type, block.type, block.length);
                 break;

--- a/src/savers/tvg/tvgTvgSaver.h
+++ b/src/savers/tvg/tvgTvgSaver.h
@@ -50,14 +50,14 @@ private:
     void writeReservedCount(TvgBinCounter cnt);
     TvgBinCounter writeData(const void* data, TvgBinCounter cnt);
     TvgBinCounter writeTagProperty(TvgBinTag tag, TvgBinCounter cnt, const void* data);
-    TvgBinCounter writeTransform(const Matrix* transform);
+    TvgBinCounter writeTransform(const Matrix* transform, TvgBinTag tag);
 
     TvgBinCounter serialize(const Paint* paint, const Matrix* pTransform, bool compTarget = false);
     TvgBinCounter serializeScene(const Scene* scene, const Matrix* pTransform, const Matrix* cTransform);
     TvgBinCounter serializeShape(const Shape* shape, const Matrix* pTransform, const Matrix* cTransform);
     TvgBinCounter serializePicture(const Picture* picture, const Matrix* pTransform, const Matrix* cTransform);
     TvgBinCounter serializePaint(const Paint* paint, const Matrix* pTransform);
-    TvgBinCounter serializeFill(const Fill* fill, TvgBinTag tag);
+    TvgBinCounter serializeFill(const Fill* fill, TvgBinTag tag, const Matrix* pTransform);
     TvgBinCounter serializeStroke(const Shape* shape, const Matrix* pTransform, bool preTransform);
     TvgBinCounter serializePath(const Shape* shape, const Matrix* transform, bool preTransform);
     TvgBinCounter serializeComposite(const Paint* cmpTarget, CompositeMethod cmpMethod, const Matrix* pTransform);


### PR DESCRIPTION
Introducing the gradient transform() apis and changing the grad
algorithms made it possible to apply the shape's transformation
before saving the tvg file, in case the shape (or its stroke)
has a fill.