### PR TITLE
capi: Fixed initialization docs

### DIFF
--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -269,7 +269,7 @@ TVG_EXPORT Tvg_Result tvg_engine_init(Tvg_Engine engine_method, unsigned threads
 * tvg_engine_term(TVG_ENGINE_SW);
 * \endcode
 *
-* \param engine_method The engine types to terminate. This is relative to the Canvas types, in which it will be used. For multiple backends bitwise operation is allowed
+* \param engine_method The engine types to terminate. This is relative to the Canvas types, in which it will be used.
 *   - TVG_ENGINE_SW: CPU rasterizer
 *   - TVG_ENGINE_GL: OpenGL rasterizer (not supported yet)
 *

--- a/src/examples/Capi.cpp
+++ b/src/examples/Capi.cpp
@@ -269,7 +269,7 @@ void resize_cb(void *data, Evas *e, Evas_Object *obj, void *event_info)
 int main(int argc, char **argv)
 {
     elm_init(argc, argv);
-    tvg_engine_init(Tvg_Engine(TVG_ENGINE_SW | TVG_ENGINE_GL), 0);
+    tvg_engine_init(TVG_ENGINE_SW, 0);
 
     buffer = (uint32_t*)malloc(sizeof(uint32_t) * WIDTH * HEIGHT);
 


### PR DESCRIPTION
Changes: 
- Fixed `tvg_engine_init` API documentation. C++ code don't allows to initialize multiple backend and one time. 
- Fixed `tvg_engine_init` call in CAPI examples. 