### PR TITLE
common: code refactoring

### DIFF
--- a/src/lib/gl_engine/tvgGlRenderer.cpp
+++ b/src/lib/gl_engine/tvgGlRenderer.cpp
@@ -197,7 +197,6 @@ RenderData GlRenderer::prepare(const Shape& shape, RenderData data, const Render
     GlShape* sdata = static_cast<GlShape*>(data);
     if (!sdata) {
         sdata = new GlShape;
-        if (!sdata) return nullptr;
         sdata->shape = &shape;
     }
 

--- a/src/lib/sw_engine/tvgSwMemPool.cpp
+++ b/src/lib/sw_engine/tvgSwMemPool.cpp
@@ -59,11 +59,9 @@ void mpoolRetStrokeOutline(SwMpool* mpool, unsigned idx)
 
 SwMpool* mpoolInit(unsigned threads)
 {
-    auto mpool = new SwMpool;
-    if (!mpool) return nullptr;
-
     if (threads == 0) threads = 1;
 
+    auto mpool = new SwMpool;
     mpool->outline = static_cast<SwOutline*>(calloc(1, sizeof(SwOutline) * threads));
     if (!mpool->outline) goto err;
 

--- a/src/lib/sw_engine/tvgSwRenderer.cpp
+++ b/src/lib/sw_engine/tvgSwRenderer.cpp
@@ -283,10 +283,7 @@ bool SwRenderer::target(uint32_t* buffer, uint32_t stride, uint32_t w, uint32_t 
 {
     if (!buffer || stride == 0 || w == 0 || h == 0 || w > stride) return false;
 
-    if (!surface) {
-        surface = new SwSurface;
-        if (!surface) return false;
-    }
+    if (!surface) surface = new SwSurface;
 
     surface->buffer = buffer;
     surface->stride = stride;

--- a/src/lib/tvgFill.cpp
+++ b/src/lib/tvgFill.cpp
@@ -90,7 +90,6 @@ FillSpread Fill::spread() const noexcept
 Result Fill::transform(const Matrix& m) noexcept
 {
     if (!pImpl->transform) pImpl->transform = new Matrix();
-    if (!pImpl->transform) return Result::FailedAllocation;
     *pImpl->transform = m;
     return Result::Success;
 }

--- a/src/lib/tvgFill.h
+++ b/src/lib/tvgFill.h
@@ -78,7 +78,7 @@ struct Fill::Impl
         memcpy(ret->pImpl->colorStops, colorStops, sizeof(ColorStop) * cnt);
         if (transform) {
             ret->pImpl->transform = new Matrix;
-            if (ret->pImpl->transform) *ret->pImpl->transform = *transform;
+            *ret->pImpl->transform = *transform;
         }
         return ret;
     }

--- a/src/lib/tvgLoader.cpp
+++ b/src/lib/tvgLoader.cpp
@@ -206,9 +206,8 @@ shared_ptr<LoadModule> LoaderMgr::loader(const uint32_t *data, uint32_t w, uint3
 {
     //function is dedicated for raw images only
     auto loader = new RawLoader;
-    if (loader) {
-        if (loader->open(data, w, h, copy)) return shared_ptr<LoadModule>(loader);
-        else delete(loader);
-    }
+    if (loader->open(data, w, h, copy)) return shared_ptr<LoadModule>(loader);
+    else delete(loader);
+
     return nullptr;
 }

--- a/src/lib/tvgPaint.cpp
+++ b/src/lib/tvgPaint.cpp
@@ -99,10 +99,8 @@ Paint* Paint::Impl::duplicate()
     //duplicate Transform
     if (rTransform) {
         ret->pImpl->rTransform = new RenderTransform();
-        if (ret->pImpl->rTransform) {
-            *ret->pImpl->rTransform = *rTransform;
-            ret->pImpl->flag |= RenderUpdateFlag::Transform;
-        }
+        *ret->pImpl->rTransform = *rTransform;
+        ret->pImpl->flag |= RenderUpdateFlag::Transform;
     }
 
     ret->pImpl->opacity = opacity;
@@ -122,7 +120,6 @@ bool Paint::Impl::rotate(float degree)
     } else {
         if (fabsf(degree) <= FLT_EPSILON) return true;
         rTransform = new RenderTransform();
-        if (!rTransform) return false;
     }
     rTransform->degree = degree;
     if (!rTransform->overriding) flag |= RenderUpdateFlag::Transform;
@@ -138,7 +135,6 @@ bool Paint::Impl::scale(float factor)
     } else {
         if (fabsf(factor) <= FLT_EPSILON) return true;
         rTransform = new RenderTransform();
-        if (!rTransform) return false;
     }
     rTransform->scale = factor;
     if (!rTransform->overriding) flag |= RenderUpdateFlag::Transform;
@@ -154,7 +150,6 @@ bool Paint::Impl::translate(float x, float y)
     } else {
         if (fabsf(x) <= FLT_EPSILON && fabsf(y) <= FLT_EPSILON) return true;
         rTransform = new RenderTransform();
-        if (!rTransform) return false;
     }
     rTransform->x = x;
     rTransform->y = y;

--- a/src/lib/tvgShapeImpl.h
+++ b/src/lib/tvgShapeImpl.h
@@ -261,8 +261,6 @@ struct Shape::Impl
         //TODO: Size Exception?
 
         if (!stroke) stroke = new ShapeStroke();
-        if (!stroke) return false;
-
         stroke->width = width;
         flag |= RenderUpdateFlag::Stroke;
 
@@ -272,8 +270,6 @@ struct Shape::Impl
     bool strokeCap(StrokeCap cap)
     {
         if (!stroke) stroke = new ShapeStroke();
-        if (!stroke) return false;
-
         stroke->cap = cap;
         flag |= RenderUpdateFlag::Stroke;
 
@@ -283,8 +279,6 @@ struct Shape::Impl
     bool strokeJoin(StrokeJoin join)
     {
         if (!stroke) stroke = new ShapeStroke();
-        if (!stroke) return false;
-
         stroke->join = join;
         flag |= RenderUpdateFlag::Stroke;
 
@@ -294,8 +288,6 @@ struct Shape::Impl
     bool strokeColor(uint8_t r, uint8_t g, uint8_t b, uint8_t a)
     {
         if (!stroke) stroke = new ShapeStroke();
-        if (!stroke) return false;
-
         if (stroke->fill) {
             delete(stroke->fill);
             stroke->fill = nullptr;
@@ -318,8 +310,6 @@ struct Shape::Impl
         if (!p) return Result::MemoryCorruption;
 
         if (!stroke) stroke = new ShapeStroke();
-        if (!stroke) return Result::FailedAllocation;
-
         if (stroke->fill && stroke->fill != p) delete(stroke->fill);
         stroke->fill = p;
 
@@ -337,8 +327,6 @@ struct Shape::Impl
             stroke->dashPattern = nullptr;
         } else {
             if (!stroke) stroke = new ShapeStroke();
-            if (!stroke) return false;
-
             if (stroke->dashCnt != cnt) {
                 free(stroke->dashPattern);
                 stroke->dashPattern = nullptr;

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -1670,8 +1670,6 @@ static SvgStyleGradient* _cloneGradient(SvgStyleGradient* from)
     if (!from) return nullptr;
 
     auto grad = new SvgStyleGradient;
-    if (!grad) return nullptr;
-
     grad->type = from->type;
     grad->id = from->id ? _copyId(from->id->c_str()) : nullptr;
     grad->ref = from->ref ? _copyId(from->ref->c_str()) : nullptr;
@@ -2079,8 +2077,6 @@ static bool _attrParseRadialGradientNode(void* data, const char* key, const char
 static SvgStyleGradient* _createRadialGradient(SvgLoaderData* loader, const char* buf, unsigned bufLength)
 {
     auto grad = new SvgStyleGradient;
-    if (!grad) return nullptr;
-
     loader->svgParse->styleGrad = grad;
 
     grad->type = SvgGradientType::Radial;
@@ -2268,8 +2264,6 @@ static bool _attrParseLinearGradientNode(void* data, const char* key, const char
 static SvgStyleGradient* _createLinearGradient(SvgLoaderData* loader, const char* buf, unsigned bufLength)
 {
     auto grad = new SvgStyleGradient;
-    if (!grad) return nullptr;
-
     loader->svgParse->styleGrad = grad;
 
     grad->type = SvgGradientType::Linear;


### PR DESCRIPTION
removed invalid nullptr checks.

New allocation doesn't gurantee that returns nullptr when it's failed.
It's useless on the modern compliers and our policy respects it.