### PR TITLE
capi: init and term apis args

### DIFF
--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -255,7 +255,7 @@ typedef struct
 * \see tvg_engine_term()
 * \see Tvg_Engine
 */
-TVG_EXPORT Tvg_Result tvg_engine_init(Tvg_Engine engine_method, unsigned threads);
+TVG_EXPORT Tvg_Result tvg_engine_init(int engine_method, unsigned threads);
 
 
 /*!
@@ -283,7 +283,7 @@ TVG_EXPORT Tvg_Result tvg_engine_init(Tvg_Engine engine_method, unsigned threads
 * \see tvg_engine_init()
 * \see Tvg_Engine
 */
-TVG_EXPORT Tvg_Result tvg_engine_term(Tvg_Engine engine_method);
+TVG_EXPORT Tvg_Result tvg_engine_term(int engine_method);
 
 
 /** \} */   // end defgroup ThorVGCapi_Initializer

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -36,13 +36,13 @@ extern "C" {
 /* Engine API                                                           */
 /************************************************************************/
 
-TVG_EXPORT Tvg_Result tvg_engine_init(Tvg_Engine engine_method, unsigned threads)
+TVG_EXPORT Tvg_Result tvg_engine_init(int engine_method, unsigned threads)
 {
     return (Tvg_Result) Initializer::init(CanvasEngine(engine_method), threads);
 }
 
 
-TVG_EXPORT Tvg_Result tvg_engine_term(Tvg_Engine engine_method)
+TVG_EXPORT Tvg_Result tvg_engine_term(int engine_method)
 {
     return (Tvg_Result) Initializer::term(CanvasEngine(engine_method));
 }

--- a/src/examples/Capi.cpp
+++ b/src/examples/Capi.cpp
@@ -100,7 +100,7 @@ void testCapi()
     tvg_canvas_push(canvas, shape2);
 
 
-//////3. Radial gradient shape with a radial dashed stroke
+//////3. Radial gradient shape with a radial gradient stroke
     //Set a shape
     Tvg_Paint* shape3 = tvg_shape_new();
     tvg_shape_append_rect(shape3, 550.0f, 20.0f, 100.0f, 50.0f, 0.0f, 0.0f);
@@ -269,7 +269,7 @@ void resize_cb(void *data, Evas *e, Evas_Object *obj, void *event_info)
 int main(int argc, char **argv)
 {
     elm_init(argc, argv);
-    tvg_engine_init(Tvg_Engine(TVG_ENGINE_SW | TVG_ENGINE_GL), 0);
+    tvg_engine_init(TVG_ENGINE_SW | TVG_ENGINE_GL, 0);
 
     buffer = (uint32_t*)malloc(sizeof(uint32_t) * WIDTH * HEIGHT);
 
@@ -296,7 +296,7 @@ int main(int argc, char **argv)
 
     tvg_canvas_destroy(canvas);
     free(buffer);
-    tvg_engine_term(Tvg_Engine(TVG_ENGINE_SW | TVG_ENGINE_GL));
+    tvg_engine_term(TVG_ENGINE_SW | TVG_ENGINE_GL);
     elm_shutdown();
 
     return 0;


### PR DESCRIPTION
These two apis expected Tvg_Engine enum as an arg - bitwise
operation is allowed. The enum -> int conversion is implicit, but
not the other way. Since the bitwise OR performed on enums returns
the int type, the explicit conversion (int -> enum) was necessary.
This is fixed by changing the arg type to be int.