### PR TITLE
sw_engine: var/funct renaming

### DIFF
--- a/src/lib/sw_engine/tvgSwCommon.h
+++ b/src/lib/sw_engine/tvgSwCommon.h
@@ -215,7 +215,7 @@ struct SwShape
     SwRleData*   strokeRle = nullptr;
     SwBBox       bbox;           //Keep it boundary without stroke region. Using for optimal filling.
 
-    bool         rect = false;   //Fast Track: Othogonal rectangle?
+    bool         fastTrack = false;   //Fast Track: axis-aligned rectangle without any clips?
 };
 
 struct SwImage
@@ -298,7 +298,7 @@ SwFixed mathLength(const SwPoint& pt);
 bool mathSmallCubic(const SwPoint* base, SwFixed& angleIn, SwFixed& angleMid, SwFixed& angleOut);
 SwFixed mathMean(SwFixed angle1, SwFixed angle2);
 SwPoint mathTransform(const Point* to, const Matrix* transform);
-bool mathUpdateOutlineBBox(const SwOutline* outline, const SwBBox& clipRegion, SwBBox& renderRegion, bool rect);
+bool mathUpdateOutlineBBox(const SwOutline* outline, const SwBBox& clipRegion, SwBBox& renderRegion, bool fastTrack);
 bool mathInverse(const Matrix* m, Matrix* invM);
 bool mathMultiply(const Matrix* lhs, Matrix* rhs);
 bool mathIdentity(const Matrix* m);

--- a/src/lib/sw_engine/tvgSwImage.cpp
+++ b/src/lib/sw_engine/tvgSwImage.cpp
@@ -26,7 +26,7 @@
 /* Internal Class Implementation                                        */
 /************************************************************************/
 
-static bool _genOutline(SwImage* image, const Matrix* transform, SwMpool* mpool,  unsigned tid)
+static bool _genOutline(SwImage* image, const Matrix* transform, SwMpool* mpool, unsigned tid)
 {
     image->outline = mpoolReqOutline(mpool, tid);
     auto outline = image->outline;

--- a/src/lib/sw_engine/tvgSwMath.cpp
+++ b/src/lib/sw_engine/tvgSwMath.cpp
@@ -443,7 +443,7 @@ SwPoint mathTransform(const Point* to, const Matrix* transform)
 }
 
 
-bool mathUpdateOutlineBBox(const SwOutline* outline, const SwBBox& clipRegion, SwBBox& renderRegion, bool rect)
+bool mathUpdateOutlineBBox(const SwOutline* outline, const SwBBox& clipRegion, SwBBox& renderRegion, bool fastTrack)
 {
     if (!outline) return false;
 
@@ -471,7 +471,7 @@ bool mathUpdateOutlineBBox(const SwOutline* outline, const SwBBox& clipRegion, S
     //Since no antialiasing is applied in the Fast Track case,
     //the rasterization region has to be rearranged.
     //https://github.com/Samsung/thorvg/issues/916
-    if (rect) {
+    if (fastTrack) {
         renderRegion.min.x = static_cast<SwCoord>(round(xMin / 64.0f));
         renderRegion.max.x = static_cast<SwCoord>(round(xMax / 64.0f));
         renderRegion.min.y = static_cast<SwCoord>(round(yMin / 64.0f));

--- a/src/lib/sw_engine/tvgSwRaster.cpp
+++ b/src/lib/sw_engine/tvgSwRaster.cpp
@@ -1421,7 +1421,7 @@ bool rasterGradientShape(SwSurface* surface, SwShape* shape, unsigned id)
     auto translucent = shape->fill->translucent || (surface->compositor && surface->compositor->method != CompositeMethod::None);
 
     //Fast Track
-    if (shape->rect) {
+    if (shape->fastTrack) {
         if (id == TVG_CLASS_ID_LINEAR) {
             if (translucent) return _rasterTranslucentLinearGradientRect(surface, shape->bbox, shape->fill);
             return _rasterOpaqueLinearGradientRect(surface, shape->bbox, shape->fill);
@@ -1455,7 +1455,7 @@ bool rasterSolidShape(SwSurface* surface, SwShape* shape, uint8_t r, uint8_t g, 
     auto translucent = _translucent(surface, a);
 
     //Fast Track
-    if (shape->rect) {
+    if (shape->fastTrack) {
         if (translucent) return _rasterTranslucentRect(surface, shape->bbox, color);
         return _rasterSolidRect(surface, shape->bbox, color);
     }

--- a/src/lib/sw_engine/tvgSwRenderer.cpp
+++ b/src/lib/sw_engine/tvgSwRenderer.cpp
@@ -141,13 +141,13 @@ struct SwShapeTask : SwTask
             auto clipper = &static_cast<SwShapeTask*>(*clip)->shape;
             //Clip shape rle
             if (shape.rle) {
-                if (clipper->rect) rleClipRect(shape.rle, &clipper->bbox);
+                if (clipper->fastTrack) rleClipRect(shape.rle, &clipper->bbox);
                 else if (clipper->rle) rleClipPath(shape.rle, clipper->rle);
                 else goto err;
             }
             //Clip stroke rle
             if (shape.strokeRle) {
-                if (clipper->rect) rleClipRect(shape.strokeRle, &clipper->bbox);
+                if (clipper->fastTrack) rleClipRect(shape.strokeRle, &clipper->bbox);
                 else if (clipper->rle) rleClipPath(shape.strokeRle, clipper->rle);
                 else goto err;
             }
@@ -192,7 +192,7 @@ struct SwImageTask : SwTask
                 if (image.rle) {
                     for (auto clip = clips.data; clip < (clips.data + clips.count); ++clip) {
                         auto clipper = &static_cast<SwShapeTask*>(*clip)->shape;
-                        if (clipper->rect) rleClipRect(image.rle, &clipper->bbox);
+                        if (clipper->fastTrack) rleClipRect(image.rle, &clipper->bbox);
                         else if (clipper->rle) rleClipPath(image.rle, clipper->rle);
                         else goto err;
                     }

--- a/src/lib/sw_engine/tvgSwShape.cpp
+++ b/src/lib/sw_engine/tvgSwShape.cpp
@@ -360,9 +360,9 @@ static SwOutline* _genDashOutline(const Shape* sdata, const Matrix* transform)
 }
 
 
-static bool _fastTrack(const SwOutline* outline)
+static bool _axisAlignedRect(const SwOutline* outline)
 {
-    //Fast Track: Orthogonal rectangle?
+    //Fast Track: axis-aligned rectangle?
     if (outline->ptsCnt != 5) return false;
 
     auto pt1 = outline->pts + 0;
@@ -469,7 +469,7 @@ static bool _genOutline(SwShape* shape, const Shape* sdata, const Matrix* transf
     outline->fillRule = sdata->fillRule();
     shape->outline = outline;
 
-    shape->rect = (!hasComposite && _fastTrack(shape->outline));
+    shape->fastTrack = (!hasComposite && _axisAlignedRect(shape->outline));
     return true;
 }
 
@@ -481,7 +481,7 @@ static bool _genOutline(SwShape* shape, const Shape* sdata, const Matrix* transf
 bool shapePrepare(SwShape* shape, const Shape* sdata, const Matrix* transform,  const SwBBox& clipRegion, SwBBox& renderRegion, SwMpool* mpool, unsigned tid, bool hasComposite)
 {
     if (!_genOutline(shape, sdata, transform, mpool, tid, hasComposite)) return false;
-    if (!mathUpdateOutlineBBox(shape->outline, clipRegion, renderRegion, shape->rect)) return false;
+    if (!mathUpdateOutlineBBox(shape->outline, clipRegion, renderRegion, shape->fastTrack)) return false;
 
     //Keep it for Rasterization Region
     shape->bbox = renderRegion;
@@ -510,7 +510,7 @@ bool shapeGenRle(SwShape* shape, TVG_UNUSED const Shape* sdata, bool antiAlias)
     //if (shape.outline->opened) return true;
 
     //Case A: Fast Track Rectangle Drawing
-    if (shape->rect) return true;
+    if (shape->fastTrack) return true;
 
     //Case B: Normal Shape RLE Drawing
     if ((shape->rle = rleRender(shape->rle, shape->outline, shape->bbox, antiAlias))) return true;
@@ -530,7 +530,7 @@ void shapeReset(SwShape* shape)
 {
     rleReset(shape->rle);
     rleReset(shape->strokeRle);
-    shape->rect = false;
+    shape->fastTrack = false;
     shape->bbox.reset();
 }
 


### PR DESCRIPTION
Changed names:
shape->rect -> shape->fastTrack
_factTrack -> _axisAlignedRect

The check whether a shape is an axis aligned rectangle should be done
only if the shape has no clips.

(a shape can be a rect but still its `fastTrack` can be false)