### PR TITLE
sw_engine: fastTrack with clips

### DIFF
--- a/src/lib/sw_engine/tvgSwCommon.h
+++ b/src/lib/sw_engine/tvgSwCommon.h
@@ -304,9 +304,9 @@ bool mathMultiply(const Matrix* lhs, Matrix* rhs);
 bool mathIdentity(const Matrix* m);
 
 void shapeReset(SwShape* shape);
-bool shapePrepare(SwShape* shape, const Shape* sdata, const Matrix* transform, const SwBBox& clipRegion, SwBBox& renderRegion, SwMpool* mpool, unsigned tid);
+bool shapePrepare(SwShape* shape, const Shape* sdata, const Matrix* transform, const SwBBox& clipRegion, SwBBox& renderRegion, SwMpool* mpool, unsigned tid, bool hasComposite);
 bool shapePrepared(const SwShape* shape);
-bool shapeGenRle(SwShape* shape, const Shape* sdata, bool antiAlias, bool hasComposite);
+bool shapeGenRle(SwShape* shape, const Shape* sdata, bool antiAlias);
 void shapeDelOutline(SwShape* shape, SwMpool* mpool, uint32_t tid);
 void shapeResetStroke(SwShape* shape, const Shape* sdata, const Matrix* transform);
 bool shapeGenStrokeRle(SwShape* shape, const Shape* sdata, const Matrix* transform, const SwBBox& clipRegion, SwBBox& renderRegion, SwMpool* mpool, unsigned tid);

--- a/src/lib/sw_engine/tvgSwRenderer.cpp
+++ b/src/lib/sw_engine/tvgSwRenderer.cpp
@@ -91,7 +91,7 @@ struct SwShapeTask : SwTask
             visibleFill = (alpha > 0 || sdata->fill());
             if (visibleFill || visibleStroke) {
                 shapeReset(&shape);
-                if (!shapePrepare(&shape, sdata, transform, clipRegion, bbox, mpool, tid)) goto err;
+                if (!shapePrepare(&shape, sdata, transform, clipRegion, bbox, mpool, tid, clips.count > 0 ? true : false)) goto err;
             }
         }
 
@@ -107,7 +107,7 @@ struct SwShapeTask : SwTask
                    Thus it turns off antialising in that condition.
                    Also, it shouldn't be dash style. */
                 auto antiAlias = (strokeAlpha == 255 && sdata->strokeWidth() > 2 && sdata->strokeDash(nullptr) == 0) ? false : true;
-                if (!shapeGenRle(&shape, sdata, antiAlias, clips.count > 0 ? true : false)) goto err;
+                if (!shapeGenRle(&shape, sdata, antiAlias)) goto err;
             }
             if (auto fill = sdata->fill()) {
                 auto ctable = (flags & RenderUpdateFlag::Gradient) ? true : false;


### PR DESCRIPTION
After 362d2df the fastTrack cases were applied even for shapes with clips.
These changes fixed this - the check whether a shape is a rect should be done
only if it has no clips.