### PR TITLE
infra meson: Add -Dstatic_library option

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -47,3 +47,8 @@ option('log',
     type: 'boolean',
     value: false,
     description: 'Enable log message')
+
+option('static',
+    type: 'boolean',
+    value: false,
+    description: 'Enable to use static library(png, jpg)')

--- a/src/loaders/meson.build
+++ b/src/loaders/meson.build
@@ -9,16 +9,24 @@ if all_loaders or get_option('loaders').contains('svg') == true
 endif
 
 if all_loaders or get_option('loaders').contains('png') == true
-    subdir('external_png')
-    if not png_dep.found()
+    if get_option('static') == true
         subdir('png')
+    else
+        subdir('external_png')
+        if not png_dep.found()
+            subdir('png')
+        endif
     endif
 endif
 
 if all_loaders or get_option('loaders').contains('jpg') == true
-    subdir('external_jpg')
-    if not jpg_dep.found()
+    if get_option('static') == true
         subdir('jpg')
+    else
+        subdir('external_jpg')
+        if not jpg_dep.found()
+            subdir('jpg')
+        endif
     endif
 endif
 


### PR DESCRIPTION
Add an option for use in environments where
the use of static libraries must be enforced.