### PR TITLE
sw_engine image: fix memory leak.

### DIFF
--- a/src/lib/sw_engine/tvgSwImage.cpp
+++ b/src/lib/sw_engine/tvgSwImage.cpp
@@ -97,7 +97,6 @@ void imageDelOutline(SwImage* image, SwMpool* mpool, uint32_t tid)
 void imageReset(SwImage* image)
 {
     rleReset(image->rle);
-    image->rle = nullptr;
 }
 
 


### PR DESCRIPTION
reset rle is supposed to be reused, image should keep its pointer.

@Issue: https://github.com/Samsung/thorvg/issues/982