### PR TITLE
common Array: Add limit size check

### DIFF
--- a/src/lib/tvgArray.h
+++ b/src/lib/tvgArray.h
@@ -45,6 +45,7 @@ struct Array
 
     bool reserve(uint32_t size)
     {
+        if (size >= UINT32_MAX) return false;
         if (size > reserved) {
             reserved = size;
             data = static_cast<T*>(realloc(data, sizeof(T) * reserved));


### PR DESCRIPTION
If user have many of memory space or in certain environment,
realloc may not return NULL even after allocating as much memory as MAX.
Therefore, input more than the size allowed by the size argument's type is restricted.