### PR TITLE
tvg_saver: fix memory leaks

### DIFF
--- a/src/lib/tvgSaver.cpp
+++ b/src/lib/tvgSaver.cpp
@@ -99,11 +99,14 @@ Saver::~Saver()
 
 Result Saver::save(std::unique_ptr<Paint> paint, const string& path, bool compress) noexcept
 {
-    //Already on saving an other resource.
-    if (pImpl->saveModule) return Result::InsufficientCondition;
-
     auto p = paint.release();
     if (!p) return Result::MemoryCorruption;
+
+    //Already on saving an other resource.
+    if (pImpl->saveModule) {
+        delete(p);
+        return Result::InsufficientCondition;
+    }
 
     if (auto saveModule = _find(path)) {
         if (saveModule->save(p, path, compress)) {

--- a/src/savers/tvg/tvgTvgSaver.cpp
+++ b/src/savers/tvg/tvgTvgSaver.cpp
@@ -748,9 +748,6 @@ bool TvgSaver::save(Paint* paint, const string& path, bool compress)
 {
     close();
 
-    this->path = strdup(path.c_str());
-    if (!this->path) return false;
-
     float x, y;
     x = y = 0;
     paint->bounds(&x, &y, &vsize[0], &vsize[1], false);
@@ -763,6 +760,9 @@ bool TvgSaver::save(Paint* paint, const string& path, bool compress)
         TVGLOG("TVG_SAVER", "Saving paint(%p) has zero view size.", paint);
         return false;
     }
+
+    this->path = strdup(path.c_str());
+    if (!this->path) return false;
 
     this->paint = paint;
     this->compress = compress;


### PR DESCRIPTION
In the case save() api is called, memory is released in all
scenarios but Result::MemoryCorruption - consistent with other apis
and less confiusing for the user.