### PR TITLE
common: composition target released

### DIFF
--- a/src/lib/tvgPaint.h
+++ b/src/lib/tvgPaint.h
@@ -107,7 +107,11 @@ namespace tvg
 
         bool composite(Paint* target, CompositeMethod method)
         {
-            if ((!target && method != CompositeMethod::None) || (target && method == CompositeMethod::None)) return false;
+            if (!target && method != CompositeMethod::None) return false;
+            if (target && method == CompositeMethod::None) {
+                delete(target);
+                return false;
+            }
             if (cmpTarget) delete(cmpTarget);
             cmpTarget = target;
             cmpMethod = method;

--- a/test/capi/capiPaint.cpp
+++ b/test/capi/capiPaint.cpp
@@ -218,6 +218,9 @@ TEST_CASE("Paint Clip Path Composite Method", "[capiPaint]")
     REQUIRE(tvg_paint_set_composite_method(paint, NULL, TVG_COMPOSITE_METHOD_NONE) == TVG_RESULT_SUCCESS);
     REQUIRE(tvg_paint_set_composite_method(paint, target, TVG_COMPOSITE_METHOD_NONE) == TVG_RESULT_INVALID_ARGUMENT);
 
+    target = tvg_shape_new();
+    REQUIRE(target);
+
     REQUIRE(tvg_paint_set_composite_method(paint, NULL, TVG_COMPOSITE_METHOD_CLIP_PATH) == TVG_RESULT_INVALID_ARGUMENT);
     REQUIRE(tvg_paint_set_composite_method(paint, target, TVG_COMPOSITE_METHOD_CLIP_PATH) == TVG_RESULT_SUCCESS);
 


### PR DESCRIPTION
In the case when a composition method was set to none, the comp target
was not released. Fixed