### PR TITLE
sw_engine: fix memory leak

### DIFF
--- a/src/lib/sw_engine/tvgSwRenderer.cpp
+++ b/src/lib/sw_engine/tvgSwRenderer.cpp
@@ -540,6 +540,8 @@ bool SwRenderer::dispose(RenderData data)
     task->done();
     task->dispose();
     if (task->transform) free(task->transform);
+
+    tasks.remove(task);
     delete(task);
 
     return true;
@@ -579,7 +581,8 @@ void* SwRenderer::prepareCommon(SwTask* task, const RenderTransform* transform, 
     task->bbox.max.x = min(static_cast<SwCoord>(surface->w), static_cast<SwCoord>(vport.x + vport.w));
     task->bbox.max.y = min(static_cast<SwCoord>(surface->h), static_cast<SwCoord>(vport.y + vport.h));
 
-    tasks.push(task);
+    if (!tasks.find(task)) tasks.push(task);
+
     TaskScheduler::request(task);
 
     return task;

--- a/src/lib/tvgArray.h
+++ b/src/lib/tvgArray.h
@@ -43,6 +43,25 @@ struct Array
         data[count++] = element;
     }
 
+    void remove(T element)
+    {
+        for (uint32_t i = 0; i < count; ++i) {
+            if (data[i] == element) {
+                count--;
+                for (uint32_t j = i; j < count; ++j) data[j] = data[j + 1];
+                return;
+            }
+        }
+    }
+
+    bool find(T element)
+    {
+        for (uint32_t i = 0; i < count; ++i) {
+            if (data[i] == element) return true;
+        }
+        return false;
+    }
+
     bool reserve(uint32_t size)
     {
         if (size > reserved) {


### PR DESCRIPTION
After update the same task was pushed into the tasks array.
When one of them was released, the second pointer was invalid.