### PR TITLE
test Array: Remove too big size test

### DIFF
--- a/test/capi/capiScene.cpp
+++ b/test/capi/capiScene.cpp
@@ -59,9 +59,6 @@ TEST_CASE("Scene Reservation", "[capiScene]")
     REQUIRE(tvg_scene_reserve(scene, 100) == TVG_RESULT_SUCCESS);
     REQUIRE(tvg_scene_reserve(scene, 0) == TVG_RESULT_SUCCESS);
 
-    //Too big size
-    REQUIRE(tvg_scene_reserve(scene, -1) == TVG_RESULT_FAILED_ALLOCATION);
-
     //Invalid scene
     REQUIRE(tvg_scene_reserve(NULL, 1) == TVG_RESULT_INVALID_ARGUMENT);
 

--- a/test/testScene.cpp
+++ b/test/testScene.cpp
@@ -63,9 +63,6 @@ TEST_CASE("Scene Memory Reservation", "[tvgScene]")
     REQUIRE(scene->reserve(1000) == Result::Success);
     REQUIRE(scene->reserve(100) == Result::Success);
     REQUIRE(scene->reserve(0) == Result::Success);
-
-    //Too Big Size
-    REQUIRE(scene->reserve(UINT32_MAX) == Result::FailedAllocation);
 }
 
 TEST_CASE("Scene Clear", "[tvgScene]")

--- a/test/testSwCanvasBase.cpp
+++ b/test/testSwCanvasBase.cpp
@@ -39,9 +39,6 @@ TEST_CASE("Memory Reservation", "[tvgSwCanvasBase]")
     REQUIRE(canvas->reserve(100) == Result::Success);
     REQUIRE(canvas->reserve(0) == Result::Success);
 
-    //Too big size
-    REQUIRE(canvas->reserve(UINT32_MAX) == Result::FailedAllocation);
-
     REQUIRE(Initializer::term(CanvasEngine::Sw) == Result::Success);
 }
 


### PR DESCRIPTION
On large memory machines, if machine have enough memory,
tests failed because it doesn't return null.