### PR TITLE
tvg_saver TvgSaver: Initialize local value

### DIFF
--- a/src/savers/tvg/tvgTvgSaver.cpp
+++ b/src/savers/tvg/tvgTvgSaver.cpp
@@ -752,6 +752,7 @@ bool TvgSaver::save(Paint* paint, const string& path, bool compress)
     if (!this->path) return false;
 
     float x, y;
+    x = y = 0;
     paint->bounds(&x, &y, &vsize[0], &vsize[1], false);
 
     //cut off the negative space


### PR DESCRIPTION
If paint has no path information or stroke information,
it is not referenced inside bounds.
This will access the uninitialized variable at line 759, 760.

issue :https://github.com/Samsung/thorvg/issues/995