### PR TITLE
common paint: alpha masking optimization

### DIFF
--- a/src/lib/tvgPaint.h
+++ b/src/lib/tvgPaint.h
@@ -27,6 +27,8 @@
 
 namespace tvg
 {
+    enum ContextFlag {Invalid = 0, FastTrack = 1};
+
     struct Iterator
     {
         virtual ~Iterator() {}
@@ -51,10 +53,11 @@ namespace tvg
     struct Paint::Impl
     {
         StrategyMethod* smethod = nullptr;
-        RenderTransform *rTransform = nullptr;
+        RenderTransform* rTransform = nullptr;
         uint32_t renderFlag = RenderUpdateFlag::None;
         Paint* cmpTarget = nullptr;
         CompositeMethod cmpMethod = CompositeMethod::None;
+        uint32_t ctxFlag = ContextFlag::Invalid;
         uint8_t opacity = 255;
 
         ~Impl() {


### PR DESCRIPTION
applying fast track approach to the alpha mask when its condition is matched.
(simple rectangle alpha masking which isn't half-translucent)

From time to time, designers brutally use the alpha masking to clip simple region,
thorvg can help the situation by avoiding masking usage internally.

This can reduce the 1-step render pass composition.

@Issue: https://github.com/Samsung/thorvg/issues/344