### PR TITLE
common paint: fix invalid memory access in unit test

### DIFF
--- a/src/lib/tvgPaint.cpp
+++ b/src/lib/tvgPaint.cpp
@@ -206,7 +206,7 @@ void* Paint::Impl::update(RenderMethod& renderer, const RenderTransform* pTransf
            we can avoid regular ClipPath / AlphaMasking sequence but use viewport for performance */
         auto tryFastTrack = false;
         if (cmpMethod == CompositeMethod::ClipPath) tryFastTrack = true;
-        else if (cmpMethod == CompositeMethod::AlphaMask) {
+        else if (cmpMethod == CompositeMethod::AlphaMask && cmpTarget->identifier() == TVG_CLASS_ID_SHAPE) {
             auto shape = static_cast<Shape*>(cmpTarget);
             uint8_t a;
             shape->fillColor(nullptr, nullptr, nullptr, &a);


### PR DESCRIPTION
casting the paint to shape is not allowed if the compositor target
is not shape, here it concretely checking the the type before casting....