### PR TITLE
sw_engine image: ++optimization

### DIFF
--- a/src/lib/sw_engine/tvgSwCommon.h
+++ b/src/lib/sw_engine/tvgSwCommon.h
@@ -224,6 +224,11 @@ struct SwImage
     SwRleData*   rle = nullptr;
     uint32_t*    data = nullptr;
     uint32_t     w, h, stride;
+    int32_t      x = 0;         //shift x
+    int32_t      y = 0;         //shift y
+    float        scale;
+
+    bool         transformed = false;
 };
 
 struct SwBlender

--- a/src/lib/sw_engine/tvgSwImage.cpp
+++ b/src/lib/sw_engine/tvgSwImage.cpp
@@ -67,6 +67,13 @@ static bool _genOutline(SwImage* image, const Matrix* transform, SwMpool* mpool,
 }
 
 
+static inline bool _onlyShifted(const Matrix* m)
+{
+    if (mathEqual(m->e11, 1.0f) && mathEqual(m->e22, 1.0f) && mathZero(m->e12) && mathZero(m->e21)) return true;
+    return false;
+}
+
+
 /************************************************************************/
 /* External Class Implementation                                        */
 /************************************************************************/
@@ -74,8 +81,26 @@ static bool _genOutline(SwImage* image, const Matrix* transform, SwMpool* mpool,
 
 bool imagePrepare(SwImage* image, const Matrix* transform, const SwBBox& clipRegion, SwBBox& renderRegion, SwMpool* mpool, unsigned tid)
 {
+    image->transformed = !_onlyShifted(transform);
+    bool fastTrack;
+
+    //Figure out the scale factor by transform matrix
+    if (image->transformed) {
+        auto scaleX = sqrtf((transform->e11 * transform->e11) + (transform->e21 * transform->e21));
+        auto scaleY = sqrtf((transform->e22 * transform->e22) + (transform->e12 * transform->e12));
+        //TODO:If the x and y axis scale is different, a separate interpolation algorithm for each axis should be applied.
+        image->scale = (fabsf(scaleX - scaleY) > 0.01f) ? 1.0f : scaleX;
+        fastTrack = false;
+    //Fast track: Non-transformed image but just shifted.
+    } else {
+        image->scale = 1.0f;
+        image->x = -static_cast<uint32_t>(round(transform->e13));
+        image->y = -static_cast<uint32_t>(round(transform->e23));
+        fastTrack = true;
+    }
+
     if (!_genOutline(image, transform, mpool, tid)) return false;
-    return mathUpdateOutlineBBox(image->outline, clipRegion, renderRegion, false);
+    return mathUpdateOutlineBBox(image->outline, clipRegion, renderRegion, fastTrack);
 }
 
 


### PR DESCRIPTION
apply fast track to fast up the image rasterization.

only shifted image doesn't need to have the matrix-transform computation,
we can avoid it by just shifting offset xy by simple caculating.

@Issue: https://github.com/Samsung/thorvg/issues/206