### PR TITLE
all: fix compilation errors on non-windows clang

### DIFF
--- a/src/lib/tvgCommon.h
+++ b/src/lib/tvgCommon.h
@@ -48,7 +48,7 @@ using namespace tvg;
     #define TVG_FALLTHROUGH
 #endif
 
-#if defined(__clang__) && !defined(__EMSCRIPTEN__)
+#if defined(_MSC_VER) && defined(__clang__)
     #define strncpy strncpy_s
     #define strdup _strdup
 #endif

--- a/src/savers/tvg/tvgTvgSaver.cpp
+++ b/src/savers/tvg/tvgTvgSaver.cpp
@@ -32,7 +32,7 @@
 
 static FILE* _fopen(const char* filename, const char* mode)
 {
-#if defined(__clang__) && !defined(__EMSCRIPTEN__)
+#if defined(_MSC_VER) && defined(__clang__)
     FILE *fp;
     auto err = fopen_s(&fp, filename, mode);
     if (err != 0) return nullptr;


### PR DESCRIPTION
Thorvg couldn't be compiled on macos as non-portable microsoft calls used.
Changed definitions checking to Visual Studio only.