### PR TITLE
sw_engine image: introduced scaled image raster logics.

### DIFF
--- a/src/lib/sw_engine/tvgSwCommon.h
+++ b/src/lib/sw_engine/tvgSwCommon.h
@@ -229,6 +229,7 @@ struct SwImage
     float        scale;
 
     bool         direct = false;  //draw image directly (with offset)
+    bool         scaled = false;  //draw scaled image
 };
 
 struct SwBlender

--- a/src/lib/sw_engine/tvgSwImage.cpp
+++ b/src/lib/sw_engine/tvgSwImage.cpp
@@ -91,6 +91,9 @@ bool imagePrepare(SwImage* image, const Matrix* transform, const SwBBox& clipReg
         auto scaleX = sqrtf((transform->e11 * transform->e11) + (transform->e21 * transform->e21));
         auto scaleY = sqrtf((transform->e22 * transform->e22) + (transform->e12 * transform->e12));
         image->scale = (fabsf(scaleX - scaleY) > 0.01f) ? 1.0f : scaleX;
+
+        if (mathZero(transform->e12) && mathZero(transform->e21)) image->scaled = true;
+        else image->scaled = false;
     }
 
     if (!_genOutline(image, transform, mpool, tid)) return false;


### PR DESCRIPTION
These raster functions are accelerated only for the scaled images.
(no rotation, skrewed)