### PR TITLE
common paint: fix the wrong fast track logic.

### DIFF
--- a/src/lib/gl_engine/tvgGlRenderer.cpp
+++ b/src/lib/gl_engine/tvgGlRenderer.cpp
@@ -235,7 +235,7 @@ RenderData GlRenderer::prepare(const Shape& shape, RenderData data, const Render
 
 RenderRegion GlRenderer::viewport()
 {
-    return {0, 0, UINT32_MAX, UINT32_MAX};
+    return {0, 0, INT32_MAX, INT32_MAX};
 }
 
 

--- a/src/lib/sw_engine/tvgSwRenderer.cpp
+++ b/src/lib/sw_engine/tvgSwRenderer.cpp
@@ -287,8 +287,7 @@ RenderRegion SwRenderer::viewport()
 
 bool SwRenderer::viewport(const RenderRegion& vp)
 {
-    this->vport = vp;
-
+    vport = vp;
     return true;
 }
 
@@ -456,9 +455,11 @@ Compositor* SwRenderer::target(const RenderRegion& region)
     auto y = region.y;
     auto w = region.w;
     auto h = region.h;
+    auto sw = static_cast<int32_t>(surface->w);
+    auto sh = static_cast<int32_t>(surface->h);
 
     //Out of boundary
-    if (x > surface->w || y > surface->h) return nullptr;
+    if (x > sw || y > sh) return nullptr;
 
     SwSurface* cmp = nullptr;
 
@@ -488,8 +489,8 @@ Compositor* SwRenderer::target(const RenderRegion& region)
     }
 
     //Boundary Check
-    if (x + w > surface->w) w = (surface->w - x);
-    if (y + h > surface->h) h = (surface->h - y);
+    if (x + w > sw) w = (sw - x);
+    if (y + h > sh) h = (sh - y);
 
     TVGLOG("SW_ENGINE", "Using intermediate composition [Region: %d %d %d %d]", x, y, w, h);
 

--- a/src/lib/tvgRender.h
+++ b/src/lib/tvgRender.h
@@ -49,7 +49,7 @@ struct Compositor
 
 struct RenderRegion
 {
-    uint32_t x, y, w, h;
+    int32_t x, y, w, h;
 
     void intersect(const RenderRegion& rhs)
     {
@@ -62,6 +62,9 @@ struct RenderRegion
         y = (y > rhs.y) ? y : rhs.y;
         w = ((x1 < x2) ? x1 : x2) - x;
         h = ((y1 < y2) ? y1 : y2) - y;
+
+        if (w < 0) w = 0;
+        if (h < 0) h = 0;
     }
 };
 

--- a/src/lib/tvgSceneImpl.h
+++ b/src/lib/tvgSceneImpl.h
@@ -131,10 +131,10 @@ struct Scene::Impl
     {
         if (paints.count == 0) return {0, 0, 0, 0};
 
-        uint32_t x1 = UINT32_MAX;
-        uint32_t y1 = UINT32_MAX;
-        uint32_t x2 = 0;
-        uint32_t y2 = 0;
+        int32_t x1 = INT32_MAX;
+        int32_t y1 = INT32_MAX;
+        int32_t x2 = 0;
+        int32_t y2 = 0;
 
         for (auto paint = paints.data; paint < (paints.data + paints.count); ++paint) {
             auto region = (*paint)->pImpl->bounds(renderer);


### PR DESCRIPTION
There was a missing sorting between the left-top & right-bottom corner.
that results in the negative values of the viewport...

Now fixed it.

+ refactored to use math functions...