### PR TITLE
tvg_saver TvgBinInterpreter: Prevent misaligned memory access

### DIFF
--- a/src/loaders/tvg/tvgTvgBinInterpreter.cpp
+++ b/src/loaders/tvg/tvgTvgBinInterpreter.cpp
@@ -248,12 +248,20 @@ static bool _parseShapeStrokeDashPattern(const char *ptr, const char *end, Shape
     uint32_t dashPatternCnt;
     READ_UI32(&dashPatternCnt, ptr);
     ptr += SIZE(uint32_t);
-    const float* dashPattern = (float*) ptr;
-    ptr += SIZE(float) * dashPatternCnt;
+    if (dashPatternCnt > 0) {
+        float* dashPattern = static_cast<float*>(malloc(sizeof(float) * dashPatternCnt));
+        if (!dashPattern) return false;
+        memcpy(dashPattern, ptr, sizeof(float) * dashPatternCnt);
+        ptr += SIZE(float) * dashPatternCnt;
 
-    if (ptr > end) return false;
+        if (ptr > end) {
+            free(dashPattern);
+            return false;
+        }
 
-    shape->stroke(dashPattern, dashPatternCnt);
+        shape->stroke(dashPattern, dashPatternCnt);
+        free(dashPattern);
+    }
     return true;
 }
 


### PR DESCRIPTION
When parsing a binary stored as a char type,
interpreter can access the misaligned memory while accessing it with a pointer.
To prevent that, pass the array copied to memcpy as tvg Object.

issue: https://github.com/Samsung/thorvg/issues/1074