### PR TITLE
common: nothing was rendered after an empty masked node came across

### DIFF
--- a/src/lib/tvgPaint.cpp
+++ b/src/lib/tvgPaint.cpp
@@ -170,7 +170,7 @@ bool Paint::Impl::render(RenderMethod& renderer)
         Create a composition image. */
     if (cmpTarget && cmpMethod != CompositeMethod::ClipPath && !(cmpTarget->pImpl->ctxFlag & ContextFlag::FastTrack)) {
         auto region = smethod->bounds(renderer);
-        if (region.w == 0 || region.h == 0) return false;
+        if (region.w == 0 || region.h == 0) return true;
         cmp = renderer.target(region);
         renderer.beginComposite(cmp, CompositeMethod::None, 255);
         cmpTarget->pImpl->render(renderer);


### PR DESCRIPTION
The problem was observed for empty masked scenes (except the fastTrack
cases). Solved by immediate returning from the func without passing 'false'
as its result.

issue #1082

before:
![61before](https://user-images.githubusercontent.com/67589014/143088414-e7b39ace-5062-49c1-9e56-e79d346c626c.PNG)

after:
![61after](https://user-images.githubusercontent.com/67589014/143088404-2f88bb21-5690-454b-94e3-2e98b797ecb5.PNG)

code:
```
    if (!canvas) return;
    auto scene = tvg::Scene::gen();

    //Mask
    auto mask = tvg::Shape::gen();
    mask->appendRect(10, 10, 35, 35, 10, 10);
    mask->fill(255, 0, 0, 255);

    //Solid Rectangle
    auto shape1 = tvg::Shape::gen();
    shape1->appendRect(20, 20, 50, 50, 0, 0);
    shape1->fill(255, 0, 0, 155);
    scene->push(move(shape1));

    //Empty scene (masked)
    auto emptyScene = tvg::Scene::gen();
    emptyScene->composite(move(mask), tvg::CompositeMethod::AlphaMask);
    scene->push(move(emptyScene));

    //Solid Rectangle
    auto shape2 = tvg::Shape::gen();
    shape2->appendRect(40, 40, 50, 50, 0, 0);
    shape2->fill(0, 255, 0, 155);
    scene->push(move(shape2));

    canvas->push(move(scene));
```