### PR TITLE
sw_engine raster: remove unnecessary functions.

### DIFF
--- a/src/lib/sw_engine/tvgSwCommon.h
+++ b/src/lib/sw_engine/tvgSwCommon.h
@@ -235,8 +235,6 @@ struct SwImage
 struct SwBlender
 {
     uint32_t (*join)(uint8_t r, uint8_t g, uint8_t b, uint8_t a);
-    uint32_t (*alpha)(uint32_t rgba);
-    uint32_t (*ialpha)(uint32_t rgba);
 };
 
 struct SwCompositor;

--- a/src/lib/sw_engine/tvgSwRasterAvx.h
+++ b/src/lib/sw_engine/tvgSwRasterAvx.h
@@ -88,7 +88,7 @@ static bool avxRasterTranslucentRect(SwSurface* surface, const SwBBox& region, u
     auto h = static_cast<uint32_t>(region.max.y - region.min.y);
     auto w = static_cast<uint32_t>(region.max.x - region.min.x);
 
-    auto ialpha = 255 - static_cast<uint8_t>(surface->blender.alpha(color));
+    auto ialpha = 255 - static_cast<uint8_t>(_alpha(color));
 
     auto avxColor = _mm_set1_epi32(color);
     auto avxIalpha = _mm_set1_epi8(ialpha);
@@ -136,7 +136,7 @@ static bool avxRasterTranslucentRle(SwSurface* surface, const SwRleData* rle, ui
         if (span->coverage < 255) src = ALPHA_BLEND(color, span->coverage);
         else src = color;
 
-        auto ialpha = 255 - static_cast<uint8_t>(surface->blender.alpha(src));
+        auto ialpha = 255 - static_cast<uint8_t>(_alpha(src));
 
         //1. fill the not aligned memory (for 128-bit registers a 16-bytes alignment is required)
         auto notAligned = ((uintptr_t)dst & 0xf) / 4;

--- a/src/lib/sw_engine/tvgSwRasterC.h
+++ b/src/lib/sw_engine/tvgSwRasterC.h
@@ -40,7 +40,7 @@ static bool inline cRasterTranslucentRle(SwSurface* surface, const SwRleData* rl
         else src = color;
 
         for (uint32_t x = 0; x < span->len; ++x, ++dst) {
-            *dst = src + ALPHA_BLEND(*dst, surface->blender.ialpha(src));
+            *dst = src + ALPHA_BLEND(*dst, _ialpha(src));
         }
     }
     return true;
@@ -52,7 +52,7 @@ static bool inline cRasterTranslucentRect(SwSurface* surface, const SwBBox& regi
     auto buffer = surface->buffer + (region.min.y * surface->stride) + region.min.x;
     auto h = static_cast<uint32_t>(region.max.y - region.min.y);
     auto w = static_cast<uint32_t>(region.max.x - region.min.x);
-    auto ialpha = surface->blender.ialpha(color);
+    auto ialpha = _ialpha(color);
 
     for (uint32_t y = 0; y < h; ++y) {
         auto dst = &buffer[y * surface->stride];

--- a/src/lib/sw_engine/tvgSwRasterNeon.h
+++ b/src/lib/sw_engine/tvgSwRasterNeon.h
@@ -61,7 +61,7 @@ static bool neonRasterTranslucentRle(SwSurface* surface, const SwRleData* rle, u
         else src = color;
 
         auto dst = &surface->buffer[span->y * surface->stride + span->x];
-        auto ialpha = 255 - surface->blender.alpha(src);
+        auto ialpha = 255 - _alpha(src);
 
         if ((((uint32_t) dst) & 0x7) != 0) {
             //fill not aligned byte
@@ -93,7 +93,7 @@ static bool neonRasterTranslucentRect(SwSurface* surface, const SwBBox& region, 
     auto buffer = surface->buffer + (region.min.y * surface->stride) + region.min.x;
     auto h = static_cast<uint32_t>(region.max.y - region.min.y);
     auto w = static_cast<uint32_t>(region.max.x - region.min.x);
-    auto ialpha = 255 - surface->blender.alpha(color);
+    auto ialpha = 255 - _alpha(color);
 
     auto vColor = vdup_n_u32(color);
     auto vIalpha = vdup_n_u8((uint8_t) ialpha);

--- a/src/lib/sw_engine/tvgSwRasterTexmapInternal.h
+++ b/src/lib/sw_engine/tvgSwRasterTexmapInternal.h
@@ -107,7 +107,7 @@
 #else
             auto src = px;            
 #endif
-            *buf = src + ALPHA_BLEND(*buf, surface->blender.ialpha(src));
+            *buf = src + ALPHA_BLEND(*buf, _ialpha(src));
             ++buf;
 #ifdef TEXMAP_MASKING
             ++cmp;


### PR DESCRIPTION
These alpha/inverse alpha blender table is not useful so far,
we remove them since it just decrease the performance by by-pass addressing.