### PR TITLE
sw_engine SwCommon: Change spans's x,y value type

### DIFF
--- a/src/lib/sw_engine/tvgSwCommon.h
+++ b/src/lib/sw_engine/tvgSwCommon.h
@@ -111,7 +111,7 @@ struct SwOutline
 
 struct SwSpan
 {
-    int16_t x, y;
+    uint16_t x, y;
     uint16_t len;
     uint8_t coverage;
 };


### PR DESCRIPTION
The x and y of spans cannot be negative
because they are specified as coordinates inside the buffer.
Change the type to fix warnings and potential problems
that occur in conversion between int16_t and uint32_t.