### PR TITLE
common paint: code refactoring

### DIFF
--- a/src/lib/tvgPictureImpl.h
+++ b/src/lib/tvgPictureImpl.h
@@ -225,7 +225,6 @@ struct Picture::Impl
         reload();
 
         auto ret = Picture::gen();
-        if (!ret) return nullptr;
 
         auto dup = ret.get()->pImpl;
         if (paint) dup->paint = paint->duplicate();

--- a/src/lib/tvgSceneImpl.h
+++ b/src/lib/tvgSceneImpl.h
@@ -184,7 +184,7 @@ struct Scene::Impl
     Paint* duplicate()
     {
         auto ret = Scene::gen();
-        if (!ret) return nullptr;
+
         auto dup = ret.get()->pImpl;
 
         dup->paints.reserve(paints.count);

--- a/src/lib/tvgShapeImpl.h
+++ b/src/lib/tvgShapeImpl.h
@@ -352,7 +352,6 @@ struct Shape::Impl
     Paint* duplicate()
     {
         auto ret = Shape::gen();
-        if (!ret) return nullptr;
 
         auto dup = ret.get()->pImpl;
         dup->rule = rule;


### PR DESCRIPTION
Grouping the composite data to add source paint necessarily.

this refactoring is a prerequisite job for the texmap anti-aliasing.