### PR TITLE
png_loaders: fix the wrong premultiplying operations.

### DIFF
--- a/src/examples/PicturePng.cpp
+++ b/src/examples/PicturePng.cpp
@@ -31,6 +31,12 @@ void tvgDrawCmds(tvg::Canvas* canvas)
 {
     if (!canvas) return;
 
+    //Background                            
+    auto bg = tvg::Shape::gen();
+    bg->appendRect(0, 0, WIDTH, HEIGHT, 0, 0);    //x, y, w, h, rx, ry
+    bg->fill(255, 255, 255, 255);                 //r, g, b, a
+    canvas->push(move(bg));
+
     //Load png file from path
     auto opacity = 51;
 

--- a/src/loaders/external_png/tvgPngLoader.cpp
+++ b/src/loaders/external_png/tvgPngLoader.cpp
@@ -23,10 +23,10 @@
 #include "tvgLoader.h"
 #include "tvgPngLoader.h"
 
-static inline uint32_t ALPHA_BLEND(uint32_t c, uint32_t a)
+static inline uint32_t PREMULTIPLY(uint32_t c)
 {
-    return (((((c >> 8) & 0x00ff00ff) * a + 0x00ff00ff) & 0xff00ff00) +
-            ((((c & 0x00ff00ff) * a + 0x00ff00ff) >> 8) & 0x00ff00ff));
+    auto a = (c >> 24);
+    return (c & 0xff000000) + ((((c >> 8) & 0xff) * a) & 0xff00) + ((((c & 0x00ff00ff) * a) >> 8) & 0x00ff00ff);
 }
 
 
@@ -36,7 +36,7 @@ static void _premultiply(uint32_t* data, uint32_t w, uint32_t h)
     for (uint32_t y = 0; y < h; ++y, buffer += w) {
         auto src = buffer;
         for (uint32_t x = 0; x < w; ++x, ++src) {
-            *src = ALPHA_BLEND(*src, (*src >> 24));
+            *src = PREMULTIPLY(*src);
         }
     }
 }

--- a/src/loaders/png/tvgPngLoader.cpp
+++ b/src/loaders/png/tvgPngLoader.cpp
@@ -29,10 +29,10 @@
 /************************************************************************/
 
 
-static inline uint32_t ALPHA_BLEND(uint32_t c, uint32_t a)
+static inline uint32_t PREMULTIPLY(uint32_t c)
 {
-    return (((((c >> 8) & 0x00ff00ff) * a + 0x00ff00ff) & 0xff00ff00) +
-            ((((c & 0x00ff00ff) * a + 0x00ff00ff) >> 8) & 0x00ff00ff));
+    auto a = (c >> 24);
+    return (c & 0xff000000) + ((((c >> 8) & 0xff) * a) & 0xff00) + ((((c & 0x00ff00ff) * a) >> 8) & 0x00ff00ff);
 }
 
 
@@ -42,7 +42,7 @@ static void _premultiply(uint32_t* data, uint32_t w, uint32_t h)
     for (uint32_t y = 0; y < h; ++y, buffer += w) {
         auto src = buffer;
         for (uint32_t x = 0; x < w; ++x, ++src) {
-            *src = ALPHA_BLEND(*src, (*src >> 24));
+            *src = PREMULTIPLY(*src);
         }
     }
 }


### PR DESCRIPTION
It should not modify the alpha channel value while premultiplying
that turned out with the wrong visual result.

@Issue: https://github.com/Samsung/thorvg/issues/655