### PR TITLE
common: new api introduced to get the information about preserveAspec…

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -1184,6 +1184,15 @@ public:
     Result viewbox(float* x, float* y, float* w, float* h) const noexcept;
 
     /**
+     * @brief Gets the information about the preserveAspectRatio attribute of the loaded SVG picture.
+     *
+     * @warning Please do not use it, this API is not official one. It could be modified in the next version.
+     *
+     * @BETA_API
+     */
+    Result aspectRatio(bool* preserved) const noexcept;
+
+    /**
      * @brief Creates a new Picture object.
      *
      * @return A new Picture object.

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -1856,6 +1856,14 @@ TVG_EXPORT Tvg_Result tvg_picture_get_size(const Tvg_Paint* paint, float* w, flo
 TVG_EXPORT Tvg_Result tvg_picture_get_viewbox(const Tvg_Paint* paint, float* x, float* y, float* w, float* h);
 
 
+/*!
+* \brief Gets the information about the preserveAspectRatio attribute of the loaded SVG picture. (BETA_API)
+*
+* \warning Please do not use it, this API is not official one. It can be modified in the next version.
+*/
+TVG_EXPORT Tvg_Result tvg_picture_get_aspect_ratio(const Tvg_Paint* paint, bool* preserved);
+
+
 /** \} */   // end defgroup ThorVGCapi_Picture
 
 

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -508,6 +508,13 @@ TVG_EXPORT Tvg_Result tvg_picture_get_viewbox(const Tvg_Paint* paint, float* x, 
 }
 
 
+TVG_EXPORT Tvg_Result tvg_picture_get_aspect_ratio(const Tvg_Paint* paint, bool* preserved)
+{
+    if (!paint) return TVG_RESULT_INVALID_ARGUMENT;
+    return (Tvg_Result) reinterpret_cast<const Picture*>(paint)->aspectRatio(preserved);
+}
+
+
 /************************************************************************/
 /* Gradient API                                                         */
 /************************************************************************/

--- a/src/lib/tvgPicture.cpp
+++ b/src/lib/tvgPicture.cpp
@@ -88,6 +88,13 @@ Result Picture::viewbox(float* x, float* y, float* w, float* h) const noexcept
 }
 
 
+Result Picture::aspectRatio(bool* preserved) const noexcept
+{
+    if (pImpl->aspectRatio(preserved)) return Result::Success;
+    return Result::InsufficientCondition;
+}
+
+
 Result Picture::size(float w, float h) noexcept
 {
     if (pImpl->size(w, h)) return Result::Success;

--- a/src/lib/tvgPictureImpl.h
+++ b/src/lib/tvgPictureImpl.h
@@ -156,6 +156,13 @@ struct Picture::Impl
         return true;
     }
 
+    bool aspectRatio(bool* preserved) const
+    {
+        if (!loader) return false;
+        if (preserved) *preserved = loader->preserveAspect;
+        return true;
+    }
+
     bool size(float w, float h)
     {
         this->w = w;
@@ -170,7 +177,7 @@ struct Picture::Impl
         if (y) *y = 0;
         if (w) *w = this->w;
         if (h) *h = this->h;
- 
+
         return true;
     }
 


### PR DESCRIPTION
…tRatio

The getter returns the preserveAspectRatio attribute of the loaded svg file.
True is returned in case th aspect ratio is preseved, false otherwise.