### PR TITLE
sw_engine SwShape: Prevent null access

### DIFF
--- a/src/lib/sw_engine/tvgSwShape.cpp
+++ b/src/lib/sw_engine/tvgSwShape.cpp
@@ -594,10 +594,6 @@ bool shapeGenStrokeRle(SwShape* shape, const Shape* sdata, const Matrix* transfo
     }
 
     strokeOutline = strokeExportOutline(shape->stroke, mpool, tid);
-    if (!strokeOutline) {
-        ret = false;
-        goto fail;
-    }
 
     if (!mathUpdateOutlineBBox(strokeOutline, clipRegion, renderRegion, false)) {
         ret = false;

--- a/src/lib/sw_engine/tvgSwShape.cpp
+++ b/src/lib/sw_engine/tvgSwShape.cpp
@@ -297,7 +297,7 @@ static SwOutline* _genDashOutline(const Shape* sdata, const Matrix* transform)
     auto outlineCntrsCnt = 0;
 
     for (uint32_t i = 0; i < cmdCnt; ++i) {
-        switch(*(cmds + i)) {
+        switch (*(cmds + i)) {
             case PathCommand::Close: {
                 ++outlinePtsCnt;
                 break;
@@ -326,7 +326,7 @@ static SwOutline* _genDashOutline(const Shape* sdata, const Matrix* transform)
     _growOutlineContour(*dash.outline, outlineCntrsCnt * 20);
 
     while (cmdCnt-- > 0) {
-        switch(*cmds) {
+        switch (*cmds) {
             case PathCommand::Close: {
                 _dashLineTo(dash, &dash.ptStart, transform);
                 break;
@@ -397,7 +397,7 @@ static bool _genOutline(SwShape* shape, const Shape* sdata, const Matrix* transf
     auto closeCnt = 0;
 
     for (uint32_t i = 0; i < cmdCnt; ++i) {
-        switch(*(cmds + i)) {
+        switch (*(cmds + i)) {
             case PathCommand::Close: {
                 ++outlinePtsCnt;
                 ++closeCnt;
@@ -440,7 +440,7 @@ static bool _genOutline(SwShape* shape, const Shape* sdata, const Matrix* transf
 
     //Generate Outlines
     while (cmdCnt-- > 0) {
-        switch(*cmds) {
+        switch (*cmds) {
             case PathCommand::Close: {
                 _outlineClose(*outline);
                 break;


### PR DESCRIPTION
strokeOutline returned strokeExportOutline() is the address of mpool->strokeOutline[idx].
Assuming this value is null, mpoolRetStrokeOutline on line 617 will access mpool->strokeOutline[idx].

Logically, the logic of the mpool* functions does not occur in this case.
However, in the case of the strokeOutline pointer of shapeGenStrokeRle,
static analyzer may occur a warning depending on the implementation of mpool.