### PR TITLE
common: aspectRatio api introduced

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -148,6 +148,25 @@ enum class TVG_EXPORT CompositeMethod
 };
 
 /**
+ * @brief Enumeration indicating whether uniform scaling has to be forced and if so, how the graphic should be aligned.
+ */
+enum class TVG_EXPORT AspectRatioAlign
+{
+    None = 0,     ///< The graphic is scaled non-uniformly - it exactly matches the SVG's viewport.
+    xMidYMid,     ///< Force the uniform scaling - the midpoint X of the viewBox aligned with the midpoint X of the viewport.
+};
+
+/**
+ * @brief Enumeration indicating the method used to scale the graphic, when the aspect ratio is preserved.
+ */
+enum class TVG_EXPORT AspectRatioMethod
+{
+    Meet = 0,     ///< The entire SVG's viewBox is visible within the viewport 
+//TODO: not supported yet
+//  Slice         ///< The entire SVG's viewport is covered by the viewBox
+};
+
+/**
  * @brief Enumeration specifying the engine type used for the graphics backend. For multiple backends bitwise operation is allowed.
  */
 enum class TVG_EXPORT CanvasEngine
@@ -1182,6 +1201,18 @@ public:
      * @BETA_API
      */
     Result viewbox(float* x, float* y, float* w, float* h) const noexcept;
+
+    /**
+     * @brief Gets the information about the preserveAspectRatio attribute of the loaded SVG picture.
+     *
+     * @param[out] align Value indicating whether or not the uniform scaling of the SVG is used, if so, how it's aligned.
+     * @param[out] meetOrSlice Value indicating how the SVG is scaled if aspect ratio is preserved.
+     *
+     * @return Result::Success when succeed, Result::InsufficientCondition otherwise.
+     *
+     * @BETA_API
+     */
+    Result aspectRatio(AspectRatioAlign* align, AspectRatioMethod* meetOrSlice) const noexcept;
 
     /**
      * @brief Creates a new Picture object.

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -173,6 +173,30 @@ typedef enum {
 /** \} */   // end addtogroup ThorVGCapi_Shape
 
 
+/**
+ * \addtogroup ThorVGCapi_Picture
+ * \{
+ */
+
+/**
+ * \brief Enumeration indicating whether uniform scaling has to be forced and if so, how the graphic should be aligned.
+ */
+typedef enum {
+    TVG_ASPECT_RATIO_ALIGN_NONE = 0, ///< The graphic is scaled non-uniformly - it exactly matches the SVG's viewport.
+    TVG_ASPECT_RATIO_ALIGN_XMIDYMID  ///< Force the uniform scaling - the midpoint X of the viewBox aligned with the midpoint X of the viewport.
+} Tvg_Aspect_Ratio_Align;
+
+
+/**
+ * @brief Enumeration indicating the method used to scale the graphic, when the aspect ratio is preserved.
+ */
+typedef enum {
+    TVG_ASPECT_RATIO_METHOD_MEET = 0,  ///< The entire SVG's viewBox is visible within the viewport 
+} Tvg_Aspect_Ratio_Method;
+
+/** \} */   // end addtogroup ThorVGCapi_Picture
+
+
 /*!
 * \addtogroup ThorVGCapi_Gradient
 * \{
@@ -1854,6 +1878,21 @@ TVG_EXPORT Tvg_Result tvg_picture_get_size(const Tvg_Paint* paint, float* w, flo
 * \warning Please do not use it, this API is not official one. It can be modified in the next version.
 */
 TVG_EXPORT Tvg_Result tvg_picture_get_viewbox(const Tvg_Paint* paint, float* x, float* y, float* w, float* h);
+
+
+/*!
+* \brief Gets the information about the preserveAspectRatio attribute of the loaded SVG picture. (BETA_API)
+*
+* \param[in] paint A Tvg_Paint pointer to the picture object.
+* \param[out] align Value indicating whether or not the uniform scaling of the SVG is used, if so, how it's aligned.
+* \param[out] meetOrSlice Value indicating how the SVG is scaled if aspect ratio is preserved.
+*
+* \return Tvg_Result enumeration.
+* \retval TVG_RESULT_SUCCESS Succeed.
+* \retval TVG_RESULT_INVALID_ARGUMENT A @c nullptr passed as the argument.
+* \retval TVG_RESULT_INSUFFICIENT_CONDITION An internal error.
+*/
+TVG_EXPORT Tvg_Result tvg_picture_get_aspect_ratio(const Tvg_Paint* paint, Tvg_Aspect_Ratio_Align* align, Tvg_Aspect_Ratio_Method* meet_or_slice);
 
 
 /** \} */   // end defgroup ThorVGCapi_Picture

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -508,6 +508,13 @@ TVG_EXPORT Tvg_Result tvg_picture_get_viewbox(const Tvg_Paint* paint, float* x, 
 }
 
 
+TVG_EXPORT Tvg_Result tvg_picture_get_aspect_ratio(const Tvg_Paint* paint, Tvg_Aspect_Ratio_Align* align, Tvg_Aspect_Ratio_Method* meet_or_slice)
+{
+    if (!paint || !align || !meet_or_slice) return TVG_RESULT_INVALID_ARGUMENT;
+    return (Tvg_Result) reinterpret_cast<const Picture*>(paint)->aspectRatio((AspectRatioAlign*)align, (AspectRatioMethod*)meet_or_slice);
+}
+
+
 /************************************************************************/
 /* Gradient API                                                         */
 /************************************************************************/

--- a/src/lib/tvgPicture.cpp
+++ b/src/lib/tvgPicture.cpp
@@ -88,6 +88,13 @@ Result Picture::viewbox(float* x, float* y, float* w, float* h) const noexcept
 }
 
 
+Result Picture::aspectRatio(AspectRatioAlign* align, AspectRatioMethod* meetOrSlice) const noexcept
+{
+    if (pImpl->aspectRatio(align, meetOrSlice)) return Result::Success;
+    return Result::InsufficientCondition;
+}
+
+
 Result Picture::size(float w, float h) noexcept
 {
     if (pImpl->size(w, h)) return Result::Success;

--- a/src/lib/tvgPictureImpl.h
+++ b/src/lib/tvgPictureImpl.h
@@ -156,6 +156,14 @@ struct Picture::Impl
         return true;
     }
 
+    bool aspectRatio(AspectRatioAlign* align, AspectRatioMethod* meetOrSlice) const
+    {
+        if (!loader) return false;
+        if (align) *align = (loader->preserveAspect ? AspectRatioAlign::xMidYMid : AspectRatioAlign::None);
+        if (meetOrSlice) *meetOrSlice = AspectRatioMethod::Meet;
+        return true;
+    }
+
     bool size(float w, float h)
     {
         this->w = w;
@@ -170,7 +178,7 @@ struct Picture::Impl
         if (y) *y = 0;
         if (w) *w = this->w;
         if (h) *h = this->h;
- 
+
         return true;
     }
 


### PR DESCRIPTION
The new api gets the information about the preserveAspectRatio
attribute of the loaded svg file. Since the preserveAspectRatio
contains two fields, two enums are returned:
AspectRatioAlign and AspectRatioMethod.