### PR TITLE
sw_engine raster: ++safety of the scaled image rasterization

### DIFF
--- a/src/lib/sw_engine/tvgSwRasterTexmapInternal.h
+++ b/src/lib/sw_engine/tvgSwRasterTexmapInternal.h
@@ -62,7 +62,7 @@
              
         if (x1 < minx) x1 = minx;
         if (x2 > maxx) x2 = maxx;
-            
+
         //Anti-Aliasing frames
         ay = y - aaSpans->yStart;
         if (aaSpans->lines[ay].x[0] > x1) aaSpans->lines[ay].x[0] = x1;


### PR DESCRIPTION
Prevent out of buffer boundary access.

@Issues: https://github.com/Samsung/thorvg/issues/1118