### PR TITLE
sw_engine raster: fix a crash at the texmap clipping.

### DIFF
--- a/src/lib/sw_engine/tvgSwRenderer.cpp
+++ b/src/lib/sw_engine/tvgSwRenderer.cpp
@@ -111,13 +111,11 @@ struct SwShapeTask : SwTask
         //Fill
         if (flags & (RenderUpdateFlag::Gradient | RenderUpdateFlag::Transform | RenderUpdateFlag::Color)) {
             if (visibleFill) {
-                auto antiAlias = (flags & RenderUpdateFlag::IgnoreAliasing) ? false : true;
-
                 /* We assume that if stroke width is bigger than 2,
                    shape outline below stroke could be full covered by stroke drawing.
                    Thus it turns off antialising in that condition.
                    Also, it shouldn't be dash style. */
-                if (strokeAlpha == 255 && sdata->strokeWidth() > 2 && sdata->strokeDash(nullptr) == 0) antiAlias = false;
+                auto antiAlias = (strokeAlpha == 255 && sdata->strokeWidth() > 2 && sdata->strokeDash(nullptr) == 0) ? false : true;
 
                 if (!shapeGenRle(&shape, sdata, antiAlias)) goto err;
             }

--- a/src/lib/tvgPaint.cpp
+++ b/src/lib/tvgPaint.cpp
@@ -223,15 +223,7 @@ void* Paint::Impl::update(RenderMethod& renderer, const RenderTransform* pTransf
             }
         }
         if (!compFastTrack) {
-            //Bad design!: ignore anti-aliasing if the bitmap image is the source of the clip-path!
-            auto tempFlag = pFlag;
-
-            if (id == TVG_CLASS_ID_PICTURE) {
-                auto picture = static_cast<Picture*>(compData->source);
-                if (picture->data(nullptr, nullptr)) tempFlag |= RenderUpdateFlag::IgnoreAliasing;
-            }
-
-            tdata = target->pImpl->update(renderer, pTransform, 255, clips, tempFlag);            
+            tdata = target->pImpl->update(renderer, pTransform, 255, clips, pFlag);
             if (method == CompositeMethod::ClipPath) clips.push(tdata);
         }
     }

--- a/src/lib/tvgRender.h
+++ b/src/lib/tvgRender.h
@@ -28,7 +28,7 @@
 namespace tvg
 {
 
-enum RenderUpdateFlag {None = 0, Path = 1, Color = 2, Gradient = 4, Stroke = 8, Transform = 16, Image = 32, GradientStroke = 64, All = 255, IgnoreAliasing = 256};
+enum RenderUpdateFlag {None = 0, Path = 1, Color = 2, Gradient = 4, Stroke = 8, Transform = 16, Image = 32, GradientStroke = 64, All = 255};
 
 struct Surface
 {


### PR DESCRIPTION
Handle correctly duplicated spans from the multiple y span data.

Previous logic only expected the one single y span data from the rle.
but rle might have multiple y span data if the anti-aliasing is applied.