### PR TITLE
Hide the thorvg LZW implementation.

### DIFF
--- a/src/lib/tvgLzw.cpp
+++ b/src/lib/tvgLzw.cpp
@@ -65,6 +65,7 @@
 #include <memory.h>
 #include "tvgLzw.h"
 
+namespace {
 //LZW Dictionary helper:
 constexpr int Nil = -1;
 constexpr int MaxDictBits = 12;
@@ -333,7 +334,7 @@ static bool outputSequence(const Dictionary& dict, int code, uint8_t*& output, i
     }
     return true;
 }
-
+}
 
 
 /************************************************************************/


### PR DESCRIPTION
Use an anonymous namespace so that I can compile on Godot Engine.

Godot uses Dictionary() too.