### PR TITLE
svg_loader: mask-type attribute introduced 

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -199,6 +199,14 @@ static int _toOpacity(const char* str)
 }
 
 
+static SvgMaskType _toMaskType(const char* str)
+{
+    if (!strcmp(str, "Alpha")) return SvgMaskType::Alpha;
+
+    return SvgMaskType::Luminance;
+}
+
+
 #define _PARSE_TAG(Type, Name, Name1, Tags_Array, Default)                        \
     static Type _to##Name1(const char* str)                                       \
     {                                                                             \
@@ -921,6 +929,12 @@ static void _handleMaskAttr(TVG_UNUSED SvgLoaderData* loader, SvgNode* node, con
 }
 
 
+static void _handleMaskTypeAttr(TVG_UNUSED SvgLoaderData* loader, SvgNode* node, const char* value)
+{
+    node->node.mask.type = _toMaskType(value);
+}
+
+
 static void _handleDisplayAttr(TVG_UNUSED SvgLoaderData* loader, SvgNode* node, const char* value)
 {
     //TODO : The display attribute can have various values as well as "none".
@@ -958,6 +972,7 @@ static constexpr struct
     STYLE_DEF(transform, Transform, SvgStyleFlags::Transform),
     STYLE_DEF(clip-path, ClipPath, SvgStyleFlags::ClipPath),
     STYLE_DEF(mask, Mask, SvgStyleFlags::Mask),
+    STYLE_DEF(mask-type, MaskType, SvgStyleFlags::MaskType),
     STYLE_DEF(display, Display, SvgStyleFlags::Display)
 };
 
@@ -1062,6 +1077,8 @@ static bool _attrParseMaskNode(void* data, const char* key, const char* value)
         node->id = _copyId(value);
     } else if (!strcmp(key, "maskContentUnits")) {
         if (!strcmp(value, "objectBoundingBox")) mask->userSpace = false;
+    } else if (!strcmp(key, "mask-type")) {
+        mask->type = _toMaskType(value);
     } else {
         return _parseStyleAttr(loader, key, value, false);
     }
@@ -1172,6 +1189,7 @@ static SvgNode* _createMaskNode(SvgLoaderData* loader, SvgNode* parent, TVG_UNUS
     if (!loader->svgParse->node) return nullptr;
 
     loader->svgParse->node->node.mask.userSpace = true;
+    loader->svgParse->node->node.mask.type = SvgMaskType::Luminance;
 
     simpleXmlParseAttributes(buf, bufLength, _attrParseMaskNode, loader);
 

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -1029,7 +1029,7 @@ static bool _attrParseClipPathNode(void* data, const char* key, const char* valu
 {
     SvgLoaderData* loader = (SvgLoaderData*)data;
     SvgNode* node = loader->svgParse->node;
-    SvgCompositeNode* comp = &(node->node.comp);
+    SvgClipNode* clip = &(node->node.clip);
 
     if (!strcmp(key, "style")) {
         return simpleXmlParseW3CAttribute(value, _parseStyleAttr, loader);
@@ -1039,7 +1039,7 @@ static bool _attrParseClipPathNode(void* data, const char* key, const char* valu
         if (node->id && value) free(node->id);
         node->id = _copyId(value);
     } else if (!strcmp(key, "clipPathUnits")) {
-        if (!strcmp(value, "objectBoundingBox")) comp->userSpace = false;
+        if (!strcmp(value, "objectBoundingBox")) clip->userSpace = false;
     } else {
         return _parseStyleAttr(loader, key, value, false);
     }
@@ -1051,7 +1051,7 @@ static bool _attrParseMaskNode(void* data, const char* key, const char* value)
 {
     SvgLoaderData* loader = (SvgLoaderData*)data;
     SvgNode* node = loader->svgParse->node;
-    SvgCompositeNode* comp = &(node->node.comp);
+    SvgMaskNode* mask = &(node->node.mask);
 
     if (!strcmp(key, "style")) {
         return simpleXmlParseW3CAttribute(value, _parseStyleAttr, loader);
@@ -1061,7 +1061,7 @@ static bool _attrParseMaskNode(void* data, const char* key, const char* value)
         if (node->id && value) free(node->id);
         node->id = _copyId(value);
     } else if (!strcmp(key, "maskContentUnits")) {
-        if (!strcmp(value, "objectBoundingBox")) comp->userSpace = false;
+        if (!strcmp(value, "objectBoundingBox")) mask->userSpace = false;
     } else {
         return _parseStyleAttr(loader, key, value, false);
     }
@@ -1171,7 +1171,7 @@ static SvgNode* _createMaskNode(SvgLoaderData* loader, SvgNode* parent, TVG_UNUS
     loader->svgParse->node = _createNode(parent, SvgNodeType::Mask);
     if (!loader->svgParse->node) return nullptr;
 
-    loader->svgParse->node->node.comp.userSpace = true;
+    loader->svgParse->node->node.mask.userSpace = true;
 
     simpleXmlParseAttributes(buf, bufLength, _attrParseMaskNode, loader);
 
@@ -1185,7 +1185,7 @@ static SvgNode* _createClipPathNode(SvgLoaderData* loader, SvgNode* parent, cons
     if (!loader->svgParse->node) return nullptr;
 
     loader->svgParse->node->display = false;
-    loader->svgParse->node->node.comp.userSpace = true;
+    loader->svgParse->node->node.clip.userSpace = true;
 
     simpleXmlParseAttributes(buf, bufLength, _attrParseClipPathNode, loader);
 

--- a/src/loaders/svg/tvgSvgLoaderCommon.h
+++ b/src/loaders/svg/tvgSvgLoaderCommon.h
@@ -215,7 +215,12 @@ struct SvgPolygonNode
     float* points;
 };
 
-struct SvgCompositeNode
+struct SvgClipNode
+{
+    bool userSpace;
+};
+
+struct SvgMaskNode
 {
     bool userSpace;
 };
@@ -352,7 +357,8 @@ struct SvgNode
         SvgPathNode path;
         SvgLineNode line;
         SvgImageNode image;
-        SvgCompositeNode comp;
+        SvgMaskNode mask;
+        SvgClipNode clip;
     } node;
     bool display;
     ~SvgNode();

--- a/src/loaders/svg/tvgSvgLoaderCommon.h
+++ b/src/loaders/svg/tvgSvgLoaderCommon.h
@@ -111,7 +111,8 @@ enum class SvgStyleFlags
     Transform = 0x800,
     ClipPath = 0x1000,
     Mask = 0x2000,
-    Display = 0x4000
+    MaskType = 0x4000,
+    Display = 0x8000
 };
 
 enum class SvgStopStyleFlags
@@ -125,6 +126,12 @@ enum class SvgFillRule
 {
     Winding = 0,
     OddEven = 1
+};
+
+enum class SvgMaskType
+{
+    Luminance = 0,
+    Alpha
 };
 
 //Length type to recalculate %, pt, pc, mm, cm etc
@@ -222,6 +229,7 @@ struct SvgClipNode
 
 struct SvgMaskNode
 {
+    SvgMaskType type;
     bool userSpace;
 };
 

--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -275,7 +275,7 @@ static void _applyComposition(Paint* paint, const SvgNode* node, const Box& vBox
        Composition can be applied recursively if its children nodes have composition target to this one. */
     if (node->style->mask.applying) {
         TVGLOG("SVG", "Multiple Composition Tried! Check out Circular dependency?");
-    } else  {
+    } else {
         auto compNode = node->style->mask.node;
         if (compNode && compNode->child.count > 0) {
             node->style->mask.applying = true;
@@ -283,7 +283,12 @@ static void _applyComposition(Paint* paint, const SvgNode* node, const Box& vBox
             auto comp = _sceneBuildHelper(compNode, vBox, svgPath, true);
             if (comp) {
                 if (node->transform) comp->transform(*node->transform);
-                paint->composite(move(comp), CompositeMethod::AlphaMask);
+
+                if (compNode->node.mask.type == SvgMaskType::Luminance) {
+                    paint->composite(move(comp), CompositeMethod::LumaMask);
+                } else {
+                    paint->composite(move(comp), CompositeMethod::AlphaMask);
+                }
             }
 
             node->style->mask.applying = false;


### PR DESCRIPTION
In an svg file the mask-type attribute can be specified.
It takes one of the two values: Luminosity or Alpha.
After the LumaMask is introduced into TVG, this attribute can be
properly read by the svg loader.


Please be aware that this pr contains 2 commits - I'll change it after #1128 is merged. 

before:
![03_before](https://user-images.githubusercontent.com/67589014/147863857-b8410520-82eb-4ef5-b5b2-65da8fa7af83.PNG)

after:
![03_after](https://user-images.githubusercontent.com/67589014/147863858-cfd35889-d8cf-4c61-b74d-0bf3e31dc5c5.PNG)

code:
- test the attribute:
```
<svg viewBox="0 0 200 200">
<defs>
<mask id="ml1" mask-type="Luminance">
<rect x="10" y="10" width="80" height="80" fill="red" fill-opacity="0.7"/>
</mask>
<mask id="ml2" mask-type="Luminance">
<rect x="110" y="10" width="80" height="80" fill="blue" fill-opacity="0.5"/>
</mask>
<mask id="ma1" mask-type="Alpha">
<rect x="10" y="110" width="80" height="80" fill="green" fill-opacity="0.7"/>
</mask>
<mask id="ma2" mask-type="Alpha">
<rect x="110" y="110" width="80" height="80" fill="blue" fill-opacity="0.5"/>
</mask>
</defs>
<circle cx="50" cy="50" r="50" mask="url(#ml1)"/>
<circle cx="150" cy="50" r="50" mask="url(#ml2)"/>
<circle cx="50" cy="150" r="50" mask="url(#ma1)"/>
<circle cx="150" cy="150" r="50" mask="url(#ma2)"/>
</svg>
```
- test the attribute used in a style attr
```
<svg viewBox="0 0 200 200">
<defs>
<mask id="ml1" style="mask-type:Luminance">
<rect x="10" y="10" width="80" height="80" fill="red" fill-opacity="0.7"/>
</mask>
<mask id="ml2" style="mask-type:Luminance">
<rect x="110" y="10" width="80" height="80" fill="blue" fill-opacity="0.5"/>
</mask>
<mask id="ma1" style="mask-type:Alpha">
<rect x="10" y="110" width="80" height="80" fill="green" fill-opacity="0.7"/>
</mask>
<mask id="ma2" style="mask-type:Alpha">
<rect x="110" y="110" width="80" height="80" fill="blue" fill-opacity="0.5"/>
</mask>
</defs>
<circle cx="50" cy="50" r="50" mask="url(#ml1)"/>
<circle cx="150" cy="50" r="50" mask="url(#ml2)"/>
<circle cx="50" cy="150" r="50" mask="url(#ma1)"/>
<circle cx="150" cy="150" r="50" mask="url(#ma2)"/>
</svg>
```