### PR TITLE
sw_engine raster: fix a regression bug.

### DIFF
--- a/src/lib/sw_engine/tvgSwRaster.cpp
+++ b/src/lib/sw_engine/tvgSwRaster.cpp
@@ -500,8 +500,9 @@ static bool _scaledRleRGBAImage(SwSurface* surface, const SwImage* image, const 
 {
     Matrix itransform;
 
-    if (transform && !mathInverse(transform, &itransform)) return false;
-    else mathIdentity(&itransform);
+    if (transform) {
+        if (!mathInverse(transform, &itransform)) return false;
+    } else mathIdentity(&itransform);
 
     auto halfScale = _halfScale(image->scale);
 
@@ -847,8 +848,9 @@ static bool _scaledRGBAImage(SwSurface* surface, const SwImage* image, const Mat
 {
     Matrix itransform;
 
-    if (transform && !mathInverse(transform, &itransform)) return false;
-    else mathIdentity(&itransform);
+    if (transform) {
+        if (!mathInverse(transform, &itransform)) return false;
+    } else mathIdentity(&itransform);
 
     auto halfScale = _halfScale(image->scale);
 


### PR DESCRIPTION
Picture example were broken by 90fa26b7bb75cb938290170882e65da8d9fc5d9e

the correct condition must be like this change.