### PR TITLE
svg_loader: the color attribute properly inherited

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -2496,14 +2496,16 @@ static void _styleInherit(SvgStyleProperty* child, const SvgStyleProperty* paren
 {
     if (parent == nullptr) return;
     //Inherit the property of parent if not present in child.
+    if (!child->curColorSet) {
+        child->color = parent->color;
+        child->curColorSet = parent->curColorSet;
+    }
     //Fill
     if (!((int)child->fill.flags & (int)SvgFillFlags::Paint)) {
         child->fill.paint.color = parent->fill.paint.color;
         child->fill.paint.none = parent->fill.paint.none;
         child->fill.paint.curColor = parent->fill.paint.curColor;
         if (parent->fill.paint.url) child->fill.paint.url = _copyId(parent->fill.paint.url);
-    } else if (child->fill.paint.curColor && !child->curColorSet) {
-        child->color = parent->color;
     }
     if (!((int)child->fill.flags & (int)SvgFillFlags::Opacity)) {
         child->fill.opacity = parent->fill.opacity;
@@ -2517,8 +2519,6 @@ static void _styleInherit(SvgStyleProperty* child, const SvgStyleProperty* paren
         child->stroke.paint.none = parent->stroke.paint.none;
         child->stroke.paint.curColor = parent->stroke.paint.curColor;
         child->stroke.paint.url = parent->stroke.paint.url ? _copyId(parent->stroke.paint.url) : nullptr;
-    } else if (child->stroke.paint.curColor && !child->curColorSet) {
-        child->color = parent->color;
     }
     if (!((int)child->stroke.flags & (int)SvgStrokeFlags::Opacity)) {
         child->stroke.opacity = parent->stroke.opacity;


### PR DESCRIPTION
The color attribute hat to be inherited regardles whether it is used
in the child node or not - it may be used i.e. in the grandchild node.

before:
![04before](https://user-images.githubusercontent.com/67589014/148611551-16a7b40c-22a0-4c9c-be61-51ceb72967d1.PNG)

after:
![04after](https://user-images.githubusercontent.com/67589014/148611560-7741ad60-36c3-46ba-bb51-c5d958db2bab.PNG)

code:
```
<svg viewBox="0 0 30 10" xmlns="http://www.w3.org/2000/svg">
<g id="myCircle" color="red">
<g fill="currentColor">
<circle cx="5" cy="5" r="4" stroke="green"/>
</g>
</g>
</svg>
```