### PR TITLE
svg_loader: fix grad update

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -2855,14 +2855,14 @@ void SvgLoader::run(unsigned tid)
     if (loaderData.doc) {
         _updateStyle(loaderData.doc, nullptr);
         auto defs = loaderData.doc->node.doc.defs;
-        if (defs) _updateGradient(loaderData.doc, &defs->node.defs.gradients);
-
-        if (loaderData.gradients.count > 0) _updateGradient(loaderData.doc, &loaderData.gradients);
 
         _updateComposite(loaderData.doc, loaderData.doc);
         if (defs) _updateComposite(loaderData.doc, defs);
 
         if (loaderData.cloneNodes.count > 0) _clonePostponedNodes(&loaderData.cloneNodes);
+
+        if (loaderData.gradients.count > 0) _updateGradient(loaderData.doc, &loaderData.gradients);
+        if (defs) _updateGradient(loaderData.doc, &defs->node.defs.gradients);
     }
     root = svgSceneBuild(loaderData.doc, vx, vy, vw, vh, w, h, preserveAspect, svgPath);
 }


### PR DESCRIPTION
The grad update should be handled after the postponed nodes are cloned.