### PR TITLE
svg_loader: css style node introduced

### DIFF
--- a/src/loaders/svg/tvgSvgLoaderCommon.h
+++ b/src/loaders/svg/tvgSvgLoaderCommon.h
@@ -51,6 +51,7 @@ enum class SvgNodeType
     Video,
     ClipPath,
     Mask,
+    CssStyle,
     Unknown
 };
 
@@ -233,6 +234,10 @@ struct SvgMaskNode
     bool userSpace;
 };
 
+struct SvgCssStyleNode
+{
+};
+
 struct SvgLinearGradient
 {
     float x1;
@@ -367,6 +372,7 @@ struct SvgNode
         SvgImageNode image;
         SvgMaskNode mask;
         SvgClipNode clip;
+        SvgCssStyleNode cssStyle;
     } node;
     bool display;
     ~SvgNode();
@@ -401,6 +407,7 @@ struct SvgLoaderData
     Array<SvgNode *> stack = {nullptr, 0, 0};
     SvgNode* doc = nullptr;
     SvgNode* def = nullptr;
+    SvgNode* cssStyle = nullptr;
     Array<SvgStyleGradient*> gradients;
     SvgStyleGradient* latestGradient = nullptr; //For stops
     SvgParser* svgParse = nullptr;


### PR DESCRIPTION
For now it is assumed that only one style element is defined
in an svg file, although it can be easily changed if needed.
The style node will be used to define the style applied to a node
of a given type or in a case when a class attrib was used.