### PR TITLE
svg_loader: parsing of the css internal style sheets implemented

### DIFF
--- a/src/loaders/svg/tvgSvgLoaderCommon.h
+++ b/src/loaders/svg/tvgSvgLoaderCommon.h
@@ -407,6 +407,7 @@ struct SvgLoaderData
     Array<SvgNodeIdPair> cloneNodes;
     int level = 0;
     bool result = false;
+    bool style = false; //TODO: find a better sollution?
 };
 
 /*

--- a/src/loaders/svg/tvgXmlParser.cpp
+++ b/src/loaders/svg/tvgXmlParser.cpp
@@ -508,6 +508,47 @@ bool simpleXmlParseW3CAttribute(const char* buf, simpleXMLAttributeCb func, cons
 }
 
 
+/*
+ * Supported formats:
+ * tag {}, .name {}, tag.name{}
+ */
+const char* simpleXmlParseCSSAttribute(const char* buf, unsigned bufLength, char** tag, char** name, const char** attrs, unsigned* attrsLength)
+{
+    if (!buf) return nullptr;
+
+    *tag = *name = nullptr;
+    *attrsLength = 0;
+
+    auto itr = _simpleXmlSkipWhiteSpace(buf, buf + bufLength);
+    auto itrEnd = (const char*)memchr(buf, '{', bufLength);
+
+    if (!itrEnd || itr == itrEnd) return nullptr;
+
+    auto nextElement = (const char*)memchr(itrEnd, '}', bufLength - (itrEnd - buf));
+    if (!nextElement) return nullptr;
+
+    *attrs = itrEnd + 1;
+    *attrsLength = nextElement - *attrs;
+
+    const char *p;
+
+    itrEnd = _simpleXmlUnskipWhiteSpace(itrEnd, itr);
+    if (*(itrEnd - 1) == '.') return nullptr;
+
+    for (p = itr; p < itrEnd; p++) {
+        if (*p == '.') break;
+    }
+
+    if (p == itr) *tag = strdup("all");
+    else *tag = strndup(itr, p - itr);
+
+    if (p == itrEnd) *name = nullptr;
+    else *name = strndup(p + 1, itrEnd - p - 1);
+
+    return (nextElement ? nextElement + 1 : nullptr);
+}
+
+
 const char* simpleXmlFindAttributesTag(const char* buf, unsigned bufLength)
 {
     const char *itr = buf, *itrEnd = buf + bufLength;

--- a/src/loaders/svg/tvgXmlParser.h
+++ b/src/loaders/svg/tvgXmlParser.h
@@ -50,7 +50,8 @@ typedef bool (*simpleXMLAttributeCb)(void* data, const char* key, const char* va
 bool simpleXmlParseAttributes(const char* buf, unsigned buflen, simpleXMLAttributeCb func, const void* data);
 bool simpleXmlParse(const char* buf, unsigned buflen, bool strip, simpleXMLCb func, const void* data);
 bool simpleXmlParseW3CAttribute(const char* buf, simpleXMLAttributeCb func, const void* data);
-const char *simpleXmlFindAttributesTag(const char* buf, unsigned buflen);
+const char* simpleXmlParseCSSAttribute(const char* buf, unsigned bufLength, char** tag, char** name, const char** attrs, unsigned* attrsLength);
+const char* simpleXmlFindAttributesTag(const char* buf, unsigned buflen);
 bool isIgnoreUnsupportedLogElements(const char* tagName);
 const char* simpleXmlNodeTypeToString(SvgNodeType type);
 


### PR DESCRIPTION
The CData parser and the CSS style parser implementations added.
Both enables to read the css style from an svg file in a case, when
CDATA marker was used (it's not obligatory, so the future patches
should enables to read the scc style even if the marker was not used).