### PR TITLE
sw_engine: fix comparison of integer expressions of different signedness

### DIFF
--- a/src/lib/sw_engine/tvgSwRaster.cpp
+++ b/src/lib/sw_engine/tvgSwRaster.cpp
@@ -1539,7 +1539,7 @@ bool rasterStroke(SwSurface* surface, SwShape* shape, uint8_t r, uint8_t g, uint
 bool rasterImage(SwSurface* surface, SwImage* image, const Matrix* transform, const SwBBox& bbox, uint32_t opacity)
 {
     //Verify Boundary
-    if (bbox.max.x < 0 || bbox.max.y < 0 || bbox.min.x >= surface->w || bbox.min.y >= surface->h) return false;
+    if (bbox.max.x < 0 || bbox.max.y < 0 || bbox.min.x >= static_cast<SwCoord>(surface->w) || bbox.min.y >= static_cast<SwCoord>(surface->h)) return false;
 
     //TOOD: switch (image->format)
     //TODO: case: _rasterRGBImage()


### PR DESCRIPTION
Some gcc versions and configurations was giving an error:
error: "comparison of integer expressions of different signedness: 'const SwCoord'
{aka 'const long int'} and 'uint32_t' {aka 'unsigned int'} [-Werror=sign-compare]"
This patch should fix the error