### PR TITLE
svg_loader: fixing cyclic cloning of nodes

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -1933,7 +1933,7 @@ static void _copyAttr(SvgNode* to, const SvgNode* from)
 static void _cloneNode(SvgNode* from, SvgNode* parent)
 {
     SvgNode* newNode;
-    if (!from || !parent) return;
+    if (!from || !parent || from == parent) return;
 
     newNode = _createNode(parent, from->type);
     if (!newNode) return;


### PR DESCRIPTION
The reference node doesn't have to be placed inside the defs block,
so when reffering to it, it is necessary to search the entire node tree.
In case of invalid svg file this can lead to circular references.
Added prevention against such a situation.

issue #1148