### PR TITLE
gl_engine GlRenderer: Fix build error

### DIFF
--- a/src/lib/gl_engine/tvgGlRenderer.cpp
+++ b/src/lib/gl_engine/tvgGlRenderer.cpp
@@ -330,7 +330,7 @@ void GlRenderer::drawPrimitive(GlShape& sdata, const Fill* fill, uint32_t primit
     auto size = sdata.geometry->getPrimitiveSize(primitiveIndex);
     auto matrix = sdata.geometry->getTransforMatrix();
 
-    switch (fill->id()) {
+    switch (fill->identifier()) {
         case TVG_CLASS_ID_LINEAR: {
             float x1, y1, x2, y2;
             GlLinearGradientRenderTask *renderTask = static_cast<GlLinearGradientRenderTask*>(mRenderTasks[GlRenderTask::RenderTypes::RT_LinGradient].get());


### PR DESCRIPTION
Change id() to identifier().

error log
```
../src/lib/gl_engine/tvgGlRenderer.cpp:333:19: error: ‘const class tvg::Fill’ has no member named ‘id’
  333 |     switch (fill->id()) {
```