### PR TITLE
build: Add missing <cstring> includes for MinGW compatibility

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -51,6 +51,7 @@
 
 #define _USE_MATH_DEFINES       //Math Constants are not defined in Standard C/C++.
 
+#include <cstring>
 #include <fstream>
 #include <float.h>
 #include <math.h>

--- a/src/loaders/svg/tvgSvgPath.cpp
+++ b/src/loaders/svg/tvgSvgPath.cpp
@@ -50,6 +50,7 @@
 
 #define _USE_MATH_DEFINES       //Math Constants are not defined in Standard C/C++.
 
+#include <cstring>
 #include <math.h>
 #include <clocale>
 #include <ctype.h>

--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -49,6 +49,7 @@
 */
 
 
+#include <cstring>
 #include <string>
 #include "tvgMath.h"
 #include "tvgSvgLoaderCommon.h"

--- a/src/loaders/svg/tvgSvgUtil.cpp
+++ b/src/loaders/svg/tvgSvgUtil.cpp
@@ -20,6 +20,7 @@
  * SOFTWARE.
  */
 
+#include <cstring>
 #include <math.h>
 #include <memory.h>
 #include "tvgSvgUtil.h"

--- a/src/loaders/svg/tvgXmlParser.cpp
+++ b/src/loaders/svg/tvgXmlParser.cpp
@@ -20,6 +20,7 @@
  * SOFTWARE.
  */
 
+#include <cstring>
 #include <ctype.h>
 #include <string>
 

--- a/src/savers/tvg/tvgTvgSaver.cpp
+++ b/src/savers/tvg/tvgTvgSaver.cpp
@@ -24,6 +24,8 @@
 #include "tvgTvgSaver.h"
 #include "tvgLzw.h"
 
+#include <cstring>
+
 #ifdef _WIN32
     #include <malloc.h>
 #else


### PR DESCRIPTION
Fixes downstream issue in Godot:
- https://github.com/godotengine/godot/issues/56894

This could also go in `lib/tvgCommon.h` or `include/thorvg.h` to be available everywhere IINM. For now I chose to put it where it's used like for other standard library headers like `math.h`, but that means other missing includes might be introduced if your pipelines don't test against MinGW (as apparently it's fine without for MSVC).