### PR TITLE
introducing css internal style sheets

### DIFF
--- a/src/loaders/svg/meson.build
+++ b/src/loaders/svg/meson.build
@@ -1,10 +1,12 @@
 source_file = [
+   'tvgSvgCssStyle.h',
    'tvgSvgLoader.h',
    'tvgSvgLoaderCommon.h',
    'tvgSvgPath.h',
    'tvgSvgSceneBuilder.h',
    'tvgSvgUtil.h',
    'tvgXmlParser.h',
+   'tvgSvgCssStyle.cpp',
    'tvgSvgLoader.cpp',
    'tvgSvgPath.cpp',
    'tvgSvgSceneBuilder.cpp',

--- a/src/loaders/svg/tvgSvgCssStyle.cpp
+++ b/src/loaders/svg/tvgSvgCssStyle.cpp
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2020 - 2022 Samsung Electronics Co., Ltd. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <cstring>
+#include "tvgSvgCssStyle.h"
+
+/************************************************************************/
+/* Internal Class Implementation                                        */
+/************************************************************************/
+
+static void _cssStyleCopy(SvgStyleProperty* to, const SvgStyleProperty* from)
+{
+    if (from == nullptr) return;
+    //Copy the properties of 'from' only if they were explicitly set (not the default ones).
+    if (from->curColorSet && !((int)to->flags & (int)SvgStyleFlags::Color)) {
+        to->color = from->color;
+        to->curColorSet = true;
+        to->flags = (SvgStyleFlags)((int)to->flags | (int)SvgStyleFlags::Color);
+    }
+    //Fill
+    if (((int)from->fill.flags & (int)SvgFillFlags::Paint) && !((int)to->flags & (int)SvgStyleFlags::Fill)) {
+        to->fill.paint.color = from->fill.paint.color;
+        to->fill.paint.none = from->fill.paint.none;
+        to->fill.paint.curColor = from->fill.paint.curColor;
+        if (from->fill.paint.url) to->fill.paint.url = strdup(from->fill.paint.url);
+        to->fill.flags = (SvgFillFlags)((int)to->fill.flags | (int)SvgFillFlags::Paint);
+        to->flags = (SvgStyleFlags)((int)to->flags | (int)SvgStyleFlags::Fill);
+    }
+    if (((int)from->fill.flags & (int)SvgFillFlags::Opacity) && !((int)to->flags & (int)SvgStyleFlags::FillOpacity)) {
+        to->fill.opacity = from->fill.opacity;
+        to->fill.flags = (SvgFillFlags)((int)to->fill.flags | (int)SvgFillFlags::Opacity);
+        to->flags = (SvgStyleFlags)((int)to->flags | (int)SvgStyleFlags::FillOpacity);
+    }
+    if (((int)from->fill.flags & (int)SvgFillFlags::FillRule) && !((int)to->flags & (int)SvgStyleFlags::FillRule)) {
+        to->fill.fillRule = from->fill.fillRule;
+        to->fill.flags = (SvgFillFlags)((int)to->fill.flags | (int)SvgFillFlags::FillRule);
+        to->flags = (SvgStyleFlags)((int)to->flags | (int)SvgStyleFlags::FillRule);
+    }
+    //Stroke
+    if (((int)from->stroke.flags & (int)SvgStrokeFlags::Paint) && !((int)to->flags & (int)SvgStyleFlags::Stroke)) {
+        to->stroke.paint.color = from->stroke.paint.color;
+        to->stroke.paint.none = from->stroke.paint.none;
+        to->stroke.paint.curColor = from->stroke.paint.curColor;
+        if (from->stroke.paint.url) to->stroke.paint.url = strdup(from->stroke.paint.url);
+        to->stroke.flags = (SvgStrokeFlags)((int)to->stroke.flags | (int)SvgStrokeFlags::Paint);
+        to->flags = (SvgStyleFlags)((int)to->flags | (int)SvgStyleFlags::Stroke);
+    }
+    if (((int)from->stroke.flags & (int)SvgStrokeFlags::Opacity) && !((int)to->flags & (int)SvgStyleFlags::StrokeOpacity)) {
+        to->stroke.opacity = from->stroke.opacity;
+        to->stroke.flags = (SvgStrokeFlags)((int)to->stroke.flags | (int)SvgStrokeFlags::Opacity);
+        to->flags = (SvgStyleFlags)((int)to->flags | (int)SvgStyleFlags::StrokeOpacity);
+    }
+    if (((int)from->stroke.flags & (int)SvgStrokeFlags::Width) && !((int)to->flags & (int)SvgStyleFlags::StrokeWidth)) {
+        to->stroke.width = from->stroke.width;
+        to->stroke.flags = (SvgStrokeFlags)((int)to->stroke.flags | (int)SvgStrokeFlags::Width);
+        to->flags = (SvgStyleFlags)((int)to->flags | (int)SvgStyleFlags::StrokeWidth);
+    }
+    if (((int)from->stroke.flags & (int)SvgStrokeFlags::Dash) && !((int)to->flags & (int)SvgStyleFlags::StrokeDashArray)) {
+        if (from->stroke.dash.array.count > 0) {
+            to->stroke.dash.array.clear();
+            to->stroke.dash.array.reserve(from->stroke.dash.array.count);
+            for (uint32_t i = 0; i < from->stroke.dash.array.count; ++i) {
+                to->stroke.dash.array.push(from->stroke.dash.array.data[i]);
+            }
+            to->stroke.flags = (SvgStrokeFlags)((int)to->stroke.flags | (int)SvgStrokeFlags::Dash);
+            to->flags = (SvgStyleFlags)((int)to->flags | (int)SvgStyleFlags::StrokeDashArray);
+        }
+    }
+    if (((int)from->stroke.flags & (int)SvgStrokeFlags::Cap) && !((int)to->flags & (int)SvgStyleFlags::StrokeLineCap)) {
+        to->stroke.cap = from->stroke.cap;
+        to->stroke.flags = (SvgStrokeFlags)((int)to->stroke.flags | (int)SvgStrokeFlags::Cap);
+        to->flags = (SvgStyleFlags)((int)to->flags | (int)SvgStyleFlags::StrokeLineCap);
+    }
+    if (((int)from->stroke.flags & (int)SvgStrokeFlags::Join) && !((int)to->flags & (int)SvgStyleFlags::StrokeLineJoin)) {
+        to->stroke.join = from->stroke.join;
+        to->stroke.flags = (SvgStrokeFlags)((int)to->stroke.flags | (int)SvgStrokeFlags::Join);
+        to->flags = (SvgStyleFlags)((int)to->flags | (int)SvgStyleFlags::StrokeLineJoin);
+    }
+    //Opacity
+    //TODO: it can be set to be 255 and shouldn't be changed by attribute 'opacity'
+    if (from->opacity < 255 && !((int)to->flags & (int)SvgStyleFlags::Opacity)) {
+        to->opacity = from->opacity;
+        to->flags = (SvgStyleFlags)((int)to->flags | (int)SvgStyleFlags::Opacity);
+    }
+    //TODO: support clip-path, mask, mask-type, display
+}
+
+
+/************************************************************************/
+/* External Class Implementation                                        */
+/************************************************************************/
+
+void copyCssStyleAttr(SvgNode* to, const SvgNode* from)
+{
+    //Copy matrix attribute
+    if (from->transform && !((int)to->style->flags & (int)SvgStyleFlags::Transform)) {
+        to->transform = (Matrix*)malloc(sizeof(Matrix));
+        if (to->transform) {
+            *to->transform = *from->transform;
+            to->style->flags = (SvgStyleFlags)((int)to->style->flags | (int)SvgStyleFlags::Transform);
+        }
+    }
+    //Copy style attribute
+    _cssStyleCopy(to->style, from->style);
+    //TODO: clips and masks are not supported yet in css style
+    if (from->style->clipPath.url) to->style->clipPath.url = strdup(from->style->clipPath.url);
+    if (from->style->mask.url) to->style->mask.url = strdup(from->style->mask.url);
+}
+
+
+SvgNode* findCssStyleNode(const SvgNode* cssStyle, const char* title, SvgNodeType type)
+{
+    if (!cssStyle) return nullptr;
+
+    auto child = cssStyle->child.data;
+    for (uint32_t i = 0; i < cssStyle->child.count; ++i, ++child) {
+        if ((*child)->type == type) {
+            if ((!title && !(*child)->id) || (title && (*child)->id && !strcmp((*child)->id, title))) return (*child);
+        }
+    }
+    return nullptr;
+}
+
+
+SvgNode* findCssStyleNode(const SvgNode* cssStyle, const char* title)
+{
+    if (!cssStyle) return nullptr;
+
+    auto child = cssStyle->child.data;
+    for (uint32_t i = 0; i < cssStyle->child.count; ++i, ++child) {
+        if ((*child)->type == SvgNodeType::CssStyle) {
+            if ((title && (*child)->id && !strcmp((*child)->id, title))) return (*child);
+        }
+    }
+    return nullptr;
+}
+
+
+void updateCssStyle(SvgNode* doc, SvgNode* cssStyle)
+{
+    if (doc->child.count > 0) {
+        auto child = doc->child.data;
+        for (uint32_t i = 0; i < doc->child.count; ++i, ++child) {
+            if (auto cssNode = findCssStyleNode(cssStyle, nullptr, (*child)->type)) {
+                copyCssStyleAttr(*child, cssNode);
+            }
+            if (auto cssNode = findCssStyleNode(cssStyle, nullptr)) {
+                copyCssStyleAttr(*child, cssNode);
+            }
+            updateCssStyle(*child, cssStyle);
+        }
+    }
+}
+
+
+void stylePostponedNodes(Array<SvgNodeIdPair>* nodesToStyle, SvgNode* cssStyle)
+{
+    for (uint32_t i = 0; i < nodesToStyle->count; ++i) {
+        auto nodeIdPair = nodesToStyle->data[i];
+
+        //css styling: tag.name has higher priority than .name
+        if (auto cssNode = findCssStyleNode(cssStyle, nodeIdPair.id, nodeIdPair.node->type)) {
+            copyCssStyleAttr(nodeIdPair.node, cssNode);
+        }
+        if (auto cssNode = findCssStyleNode(cssStyle, nodeIdPair.id)) {
+            copyCssStyleAttr(nodeIdPair.node, cssNode);
+        }
+    }
+}
+

--- a/src/loaders/svg/tvgSvgCssStyle.cpp
+++ b/src/loaders/svg/tvgSvgCssStyle.cpp
@@ -101,7 +101,6 @@ static void _cssStyleCopy(SvgStyleProperty* to, const SvgStyleProperty* from)
         to->opacity = from->opacity;
         to->flags = (SvgStyleFlags)((int)to->flags | (int)SvgStyleFlags::Opacity);
     }
-    //TODO: support clip-path, mask, mask-type, display
 }
 
 
@@ -121,7 +120,7 @@ void copyCssStyleAttr(SvgNode* to, const SvgNode* from)
     }
     //Copy style attribute
     _cssStyleCopy(to->style, from->style);
-    //TODO: clips and masks are not supported yet in css style
+
     if (from->style->clipPath.url) to->style->clipPath.url = strdup(from->style->clipPath.url);
     if (from->style->mask.url) to->style->mask.url = strdup(from->style->mask.url);
 }

--- a/src/loaders/svg/tvgSvgCssStyle.h
+++ b/src/loaders/svg/tvgSvgCssStyle.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _TVG_SVG_CSS_STYLE_H_
+#define _TVG_SVG_CSS_STYLE_H_
+
+#include "tvgSvgLoaderCommon.h"
+
+void copyCssStyleAttr(SvgNode* to, const SvgNode* from);
+SvgNode* findCssStyleNode(const SvgNode* cssStyle, const char* title, SvgNodeType type);
+SvgNode* findCssStyleNode(const SvgNode* cssStyle, const char* title);
+void updateCssStyle(SvgNode* doc, SvgNode* cssStyle);
+void stylePostponedNodes(Array<SvgNodeIdPair>* nodesToStyle, SvgNode* cssStyle);
+
+#endif //_TVG_SVG_CSS_STYLE_H_

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -798,7 +798,7 @@ static bool _attrParseSvgNode(void* data, const char* key, const char* value)
     } else if (!strcmp(key, "preserveAspectRatio")) {
         if (!strcmp(value, "none")) doc->preserveAspect = false;
     } else if (!strcmp(key, "style")) {
-        return simpleXmlParseW3CAttribute(value, 0, _parseStyleAttr, loader);
+        return simpleXmlParseW3CAttribute(value, strlen(value), _parseStyleAttr, loader);
     }
 #ifdef THORVG_LOG_ENABLED
     else if ((!strcmp(key, "x") || !strcmp(key, "y")) && fabsf(svgUtilStrtof(value, nullptr)) > FLT_EPSILON) {
@@ -951,13 +951,13 @@ static void _handleDisplayAttr(TVG_UNUSED SvgLoaderData* loader, SvgNode* node, 
 }
 
 
-static SvgNode* _findCssStyleNode(const SvgNode* cssStyle, const char* title)
+static SvgNode* _findCssStyleNode(const SvgNode* cssStyle, const char* title, SvgNodeType type)
 {
     if (!cssStyle) return nullptr;
 
     auto child = cssStyle->child.data;
     for (uint32_t i = 0; i < cssStyle->child.count; ++i, ++child) {
-        if (((*child)->id) && !strcmp((*child)->id, title)) return (*child);
+        if ((*child)->type == type && ((*child)->id) && !strcmp((*child)->id, title)) return (*child);
     }
     return nullptr;
 
@@ -973,8 +973,8 @@ static void _handleCssClassAttr(SvgLoaderData* loader, SvgNode* node, const char
     *cssClass = _copyId(value);
 
     //TODO: works only if style was defined before it is used
-    if (auto cssNode = _findCssStyleNode(loader->cssStyle, *cssClass)) {
-        //TODO: check SVG2 stndard - should the geometric properties be copied?
+    if (auto cssNode = _findCssStyleNode(loader->cssStyle, *cssClass, node->type)) {
+        //TODO: check SVG2 standard - should the geometric properties be copied?
         _copyAttr(node, cssNode, false);
     }
 }
@@ -1054,7 +1054,7 @@ static bool _attrParseGNode(void* data, const char* key, const char* value)
     SvgNode* node = loader->svgParse->node;
 
     if (!strcmp(key, "style")) {
-        return simpleXmlParseW3CAttribute(value, 0, _parseStyleAttr, loader);
+        return simpleXmlParseW3CAttribute(value, strlen(value), _parseStyleAttr, loader);
     } else if (!strcmp(key, "transform")) {
         node->transform = _parseTransformationMatrix(value);
     } else if (!strcmp(key, "id")) {
@@ -1083,7 +1083,7 @@ static bool _attrParseClipPathNode(void* data, const char* key, const char* valu
     SvgClipNode* clip = &(node->node.clip);
 
     if (!strcmp(key, "style")) {
-        return simpleXmlParseW3CAttribute(value, 0, _parseStyleAttr, loader);
+        return simpleXmlParseW3CAttribute(value, strlen(value), _parseStyleAttr, loader);
     } else if (!strcmp(key, "transform")) {
         node->transform = _parseTransformationMatrix(value);
     } else if (!strcmp(key, "id")) {
@@ -1107,7 +1107,7 @@ static bool _attrParseMaskNode(void* data, const char* key, const char* value)
     SvgMaskNode* mask = &(node->node.mask);
 
     if (!strcmp(key, "style")) {
-        return simpleXmlParseW3CAttribute(value, 0, _parseStyleAttr, loader);
+        return simpleXmlParseW3CAttribute(value, strlen(value), _parseStyleAttr, loader);
     } else if (!strcmp(key, "transform")) {
         node->transform = _parseTransformationMatrix(value);
     } else if (!strcmp(key, "id")) {
@@ -1286,7 +1286,7 @@ static bool _attrParsePathNode(void* data, const char* key, const char* value)
         //Temporary: need to copy
         path->path = _copyId(value);
     } else if (!strcmp(key, "style")) {
-        return simpleXmlParseW3CAttribute(value, 0, _parseStyleAttr, loader);
+        return simpleXmlParseW3CAttribute(value, strlen(value), _parseStyleAttr, loader);
     } else if (!strcmp(key, "clip-path")) {
         _handleClipPathAttr(loader, node, value);
     } else if (!strcmp(key, "mask")) {
@@ -1348,7 +1348,7 @@ static bool _attrParseCircleNode(void* data, const char* key, const char* value)
     }
 
     if (!strcmp(key, "style")) {
-        return simpleXmlParseW3CAttribute(value, 0, _parseStyleAttr, loader);
+        return simpleXmlParseW3CAttribute(value, strlen(value), _parseStyleAttr, loader);
     } else if (!strcmp(key, "clip-path")) {
         _handleClipPathAttr(loader, node, value);
     } else if (!strcmp(key, "mask")) {
@@ -1415,7 +1415,7 @@ static bool _attrParseEllipseNode(void* data, const char* key, const char* value
     } else if (!strcmp(key, "class")) {
         _handleCssClassAttr(loader, node, value);
     } else if (!strcmp(key, "style")) {
-        return simpleXmlParseW3CAttribute(value, 0, _parseStyleAttr, loader);
+        return simpleXmlParseW3CAttribute(value, strlen(value), _parseStyleAttr, loader);
     } else if (!strcmp(key, "clip-path")) {
         _handleClipPathAttr(loader, node, value);
     } else if (!strcmp(key, "mask")) {
@@ -1489,7 +1489,7 @@ static bool _attrParsePolygonNode(void* data, const char* key, const char* value
     if (!strcmp(key, "points")) {
         return _attrParsePolygonPoints(value, &polygon->points, &polygon->pointsCount);
     } else if (!strcmp(key, "style")) {
-        return simpleXmlParseW3CAttribute(value, 0, _parseStyleAttr, loader);
+        return simpleXmlParseW3CAttribute(value, strlen(value), _parseStyleAttr, loader);
     } else if (!strcmp(key, "clip-path")) {
         _handleClipPathAttr(loader, node, value);
     } else if (!strcmp(key, "mask")) {
@@ -1576,7 +1576,7 @@ static bool _attrParseRectNode(void* data, const char* key, const char* value)
     } else if (!strcmp(key, "class")) {
         _handleCssClassAttr(loader, node, value);
     } else if (!strcmp(key, "style")) {
-        ret = simpleXmlParseW3CAttribute(value, 0, _parseStyleAttr, loader);
+        ret = simpleXmlParseW3CAttribute(value, strlen(value), _parseStyleAttr, loader);
     } else if (!strcmp(key, "clip-path")) {
         _handleClipPathAttr(loader, node, value);
     } else if (!strcmp(key, "mask")) {
@@ -1641,7 +1641,7 @@ static bool _attrParseLineNode(void* data, const char* key, const char* value)
     } else if (!strcmp(key, "class")) {
         _handleCssClassAttr(loader, node, value);
     } else if (!strcmp(key, "style")) {
-        return simpleXmlParseW3CAttribute(value, 0, _parseStyleAttr, loader);
+        return simpleXmlParseW3CAttribute(value, strlen(value), _parseStyleAttr, loader);
     } else if (!strcmp(key, "clip-path")) {
         _handleClipPathAttr(loader, node, value);
     } else if (!strcmp(key, "mask")) {
@@ -1714,7 +1714,7 @@ static bool _attrParseImageNode(void* data, const char* key, const char* value)
     } else if (!strcmp(key, "class")) {
         _handleCssClassAttr(loader, node, value);
     } else if (!strcmp(key, "style")) {
-        return simpleXmlParseW3CAttribute(value, 0, _parseStyleAttr, loader);
+        return simpleXmlParseW3CAttribute(value, strlen(value), _parseStyleAttr, loader);
     } else if (!strcmp(key, "clip-path")) {
         _handleClipPathAttr(loader, node, value);
     } else if (!strcmp(key, "mask")) {
@@ -2390,7 +2390,7 @@ static bool _attrParseStops(void* data, const char* key, const char* value)
             _toColor(value, &stop->r, &stop->g, &stop->b, nullptr);
         }
     } else if (!strcmp(key, "style")) {
-        simpleXmlParseW3CAttribute(value, 0, _attrParseStopsStyle, data);
+        simpleXmlParseW3CAttribute(value, strlen(value), _attrParseStopsStyle, data);
     } else {
         return false;
     }
@@ -2716,6 +2716,7 @@ static void _svgLoaderParserXmlStyle(SvgLoaderData* loader, const char* content,
 
         buflen -= next - buf;
         buf = next;
+
 
         free(tag);
         free(name);

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -2102,15 +2102,17 @@ static void _copyAttr(SvgNode* to, const SvgNode* from)
             break;
         }
         case SvgNodeType::Polygon: {
-            to->node.polygon.pointsCount = from->node.polygon.pointsCount;
-            to->node.polygon.points = (float*)malloc(to->node.polygon.pointsCount * sizeof(float));
-            memcpy(to->node.polygon.points, from->node.polygon.points, to->node.polygon.pointsCount * sizeof(float));
+            if ((to->node.polygon.pointsCount = from->node.polygon.pointsCount)) {
+                to->node.polygon.points = (float*)malloc(to->node.polygon.pointsCount * sizeof(float));
+                memcpy(to->node.polygon.points, from->node.polygon.points, to->node.polygon.pointsCount * sizeof(float));
+            }
             break;
         }
         case SvgNodeType::Polyline: {
-            to->node.polyline.pointsCount = from->node.polyline.pointsCount;
-            to->node.polyline.points = (float*)malloc(to->node.polyline.pointsCount * sizeof(float));
-            memcpy(to->node.polyline.points, from->node.polyline.points, to->node.polyline.pointsCount * sizeof(float));
+            if ((to->node.polyline.pointsCount = from->node.polyline.pointsCount)) {
+                to->node.polyline.points = (float*)malloc(to->node.polyline.pointsCount * sizeof(float));
+                memcpy(to->node.polyline.points, from->node.polyline.points, to->node.polyline.pointsCount * sizeof(float));
+            }
             break;
         }
         case SvgNodeType::Image: {

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -60,6 +60,7 @@
 #include "tvgSvgLoader.h"
 #include "tvgSvgSceneBuilder.h"
 #include "tvgSvgUtil.h"
+#include "tvgSvgCssStyle.h"
 
 /************************************************************************/
 /* Internal Class Implementation                                        */
@@ -949,130 +950,6 @@ static void _handleDisplayAttr(TVG_UNUSED SvgLoaderData* loader, SvgNode* node, 
 }
 
 
-static SvgNode* _findCssStyleNode(const SvgNode* cssStyle, const char* title, SvgNodeType type)
-{
-    if (!cssStyle) return nullptr;
-
-    auto child = cssStyle->child.data;
-    for (uint32_t i = 0; i < cssStyle->child.count; ++i, ++child) {
-        if ((*child)->type == type) {
-            if ((!title && !(*child)->id) || (title && (*child)->id && !strcmp((*child)->id, title))) return (*child);
-        }
-    }
-    return nullptr;
-}
-
-
-static SvgNode* _findCssStyleNode(const SvgNode* cssStyle, const char* title)
-{
-    if (!cssStyle) return nullptr;
-
-    auto child = cssStyle->child.data;
-    for (uint32_t i = 0; i < cssStyle->child.count; ++i, ++child) {
-        if ((*child)->type == SvgNodeType::CssStyle) {
-            if ((title && (*child)->id && !strcmp((*child)->id, title))) return (*child);
-        }
-    }
-    return nullptr;
-}
-
-
-static void _cssStyleCopy(SvgStyleProperty* to, const SvgStyleProperty* from)
-{
-    if (from == nullptr) return;
-    //Copy the properties of 'from' only if they were explicitly set (not the default ones).
-    if (from->curColorSet && !((int)to->flags & (int)SvgStyleFlags::Color)) {
-        to->color = from->color;
-        to->curColorSet = true;
-        to->flags = (SvgStyleFlags)((int)to->flags | (int)SvgStyleFlags::Color);
-    }
-    //Fill
-    if (((int)from->fill.flags & (int)SvgFillFlags::Paint) && !((int)to->flags & (int)SvgStyleFlags::Fill)) {
-        to->fill.paint.color = from->fill.paint.color;
-        to->fill.paint.none = from->fill.paint.none;
-        to->fill.paint.curColor = from->fill.paint.curColor;
-        if (from->fill.paint.url) to->fill.paint.url = _copyId(from->fill.paint.url);
-        to->fill.flags = (SvgFillFlags)((int)to->fill.flags | (int)SvgFillFlags::Paint);
-        to->flags = (SvgStyleFlags)((int)to->flags | (int)SvgStyleFlags::Fill);
-    }
-    if (((int)from->fill.flags & (int)SvgFillFlags::Opacity) && !((int)to->flags & (int)SvgStyleFlags::FillOpacity)) {
-        to->fill.opacity = from->fill.opacity;
-        to->fill.flags = (SvgFillFlags)((int)to->fill.flags | (int)SvgFillFlags::Opacity);
-        to->flags = (SvgStyleFlags)((int)to->flags | (int)SvgStyleFlags::FillOpacity);
-    }
-    if (((int)from->fill.flags & (int)SvgFillFlags::FillRule) && !((int)to->flags & (int)SvgStyleFlags::FillRule)) {
-        to->fill.fillRule = from->fill.fillRule;
-        to->fill.flags = (SvgFillFlags)((int)to->fill.flags | (int)SvgFillFlags::FillRule);
-        to->flags = (SvgStyleFlags)((int)to->flags | (int)SvgStyleFlags::FillRule);
-    }
-    //Stroke
-    if (((int)from->stroke.flags & (int)SvgStrokeFlags::Paint) && !((int)to->flags & (int)SvgStyleFlags::Stroke)) {
-        to->stroke.paint.color = from->stroke.paint.color;
-        to->stroke.paint.none = from->stroke.paint.none;
-        to->stroke.paint.curColor = from->stroke.paint.curColor;
-        to->stroke.paint.url = from->stroke.paint.url ? _copyId(from->stroke.paint.url) : nullptr;
-        to->stroke.flags = (SvgStrokeFlags)((int)to->stroke.flags | (int)SvgStrokeFlags::Paint);
-        to->flags = (SvgStyleFlags)((int)to->flags | (int)SvgStyleFlags::Stroke);
-    }
-    if (((int)from->stroke.flags & (int)SvgStrokeFlags::Opacity) && !((int)to->flags & (int)SvgStyleFlags::StrokeOpacity)) {
-        to->stroke.opacity = from->stroke.opacity;
-        to->stroke.flags = (SvgStrokeFlags)((int)to->stroke.flags | (int)SvgStrokeFlags::Opacity);
-        to->flags = (SvgStyleFlags)((int)to->flags | (int)SvgStyleFlags::StrokeOpacity);
-    }
-    if (((int)from->stroke.flags & (int)SvgStrokeFlags::Width) && !((int)to->flags & (int)SvgStyleFlags::StrokeWidth)) {
-        to->stroke.width = from->stroke.width;
-        to->stroke.flags = (SvgStrokeFlags)((int)to->stroke.flags | (int)SvgStrokeFlags::Width);
-        to->flags = (SvgStyleFlags)((int)to->flags | (int)SvgStyleFlags::StrokeWidth);
-    }
-    if (((int)from->stroke.flags & (int)SvgStrokeFlags::Dash) && !((int)to->flags & (int)SvgStyleFlags::StrokeDashArray)) {
-        if (from->stroke.dash.array.count > 0) {
-            to->stroke.dash.array.clear();
-            to->stroke.dash.array.reserve(from->stroke.dash.array.count);
-            for (uint32_t i = 0; i < from->stroke.dash.array.count; ++i) {
-                to->stroke.dash.array.push(from->stroke.dash.array.data[i]);
-            }
-            to->stroke.flags = (SvgStrokeFlags)((int)to->stroke.flags | (int)SvgStrokeFlags::Dash);
-            to->flags = (SvgStyleFlags)((int)to->flags | (int)SvgStyleFlags::StrokeDashArray);
-        }
-    }
-    if (((int)from->stroke.flags & (int)SvgStrokeFlags::Cap) && !((int)to->flags & (int)SvgStyleFlags::StrokeLineCap)) {
-        to->stroke.cap = from->stroke.cap;
-        to->stroke.flags = (SvgStrokeFlags)((int)to->stroke.flags | (int)SvgStrokeFlags::Cap);
-        to->flags = (SvgStyleFlags)((int)to->flags | (int)SvgStyleFlags::StrokeLineCap);
-    }
-    if (((int)from->stroke.flags & (int)SvgStrokeFlags::Join) && !((int)to->flags & (int)SvgStyleFlags::StrokeLineJoin)) {
-        to->stroke.join = from->stroke.join;
-        to->stroke.flags = (SvgStrokeFlags)((int)to->stroke.flags | (int)SvgStrokeFlags::Join);
-        to->flags = (SvgStyleFlags)((int)to->flags | (int)SvgStyleFlags::StrokeLineJoin);
-    }
-    //Opacity
-    //TODO: it can be set to be 255 and shouldn't be changed by attribute 'opacity'
-    if (from->opacity < 255 && !((int)to->flags & (int)SvgStyleFlags::Opacity)) {
-        to->opacity = from->opacity;
-        to->flags = (SvgStyleFlags)((int)to->flags | (int)SvgStyleFlags::Opacity);
-    }
-    //TODO: support clip-path, mask, mask-type, display
-}
-
-
-static void _copyCssStyleAttr(SvgNode* to, const SvgNode* from)
-{
-    //Copy matrix attribute
-    if (from->transform && !((int)to->style->flags & (int)SvgStyleFlags::Transform)) {
-        to->transform = (Matrix*)malloc(sizeof(Matrix));
-        if (to->transform) {
-            *to->transform = *from->transform;
-            to->style->flags = (SvgStyleFlags)((int)to->style->flags | (int)SvgStyleFlags::Transform);
-        }
-    }
-    //Copy style attribute
-    _cssStyleCopy(to->style, from->style);
-    //TODO: clips and masks are not supported yet in css style
-    if (from->style->clipPath.url) to->style->clipPath.url = strdup(from->style->clipPath.url);
-    if (from->style->mask.url) to->style->mask.url = strdup(from->style->mask.url);
-}
-
-
 static void _handleCssClassAttr(SvgLoaderData* loader, SvgNode* node, const char* value)
 {
     auto cssClass = &node->style->cssClass;
@@ -1083,13 +960,13 @@ static void _handleCssClassAttr(SvgLoaderData* loader, SvgNode* node, const char
     bool cssClassFound = false;
 
     //css styling: tag.name has higher priority than .name
-    if (auto cssNode = _findCssStyleNode(loader->cssStyle, *cssClass, node->type)) {
+    if (auto cssNode = findCssStyleNode(loader->cssStyle, *cssClass, node->type)) {
         cssClassFound = true;
-        _copyCssStyleAttr(node, cssNode);
+        copyCssStyleAttr(node, cssNode);
     }
-    if (auto cssNode = _findCssStyleNode(loader->cssStyle, *cssClass)) {
+    if (auto cssNode = findCssStyleNode(loader->cssStyle, *cssClass)) {
         cssClassFound = true;
-        _copyCssStyleAttr(node, cssNode);
+        copyCssStyleAttr(node, cssNode);
     }
 
     if (!cssClassFound) _postponeCloneNode(&loader->nodesToStyle, node, *cssClass);
@@ -3001,39 +2878,6 @@ static void _updateComposite(SvgNode* node, SvgNode* root)
 }
 
 
-static void _updateCssStyle(SvgNode* doc, SvgNode* cssStyle)
-{
-    if (doc->child.count > 0) {
-        auto child = doc->child.data;
-        for (uint32_t i = 0; i < doc->child.count; ++i, ++child) {
-            if (auto cssNode = _findCssStyleNode(cssStyle, nullptr, (*child)->type)) {
-                _copyCssStyleAttr(*child, cssNode);
-            }
-            if (auto cssNode = _findCssStyleNode(cssStyle, nullptr)) {
-                _copyCssStyleAttr(*child, cssNode);
-            }
-            _updateCssStyle(*child, cssStyle);
-        }
-    }
-}
-
-
-static void _stylePostponedNodes(Array<SvgNodeIdPair>* nodesToStyle, SvgNode* cssStyle)
-{
-    for (uint32_t i = 0; i < nodesToStyle->count; ++i) {
-        auto nodeIdPair = nodesToStyle->data[i];
-
-        //css styling: tag.name has higher priority than .name
-        if (auto cssNode = _findCssStyleNode(cssStyle, nodeIdPair.id, nodeIdPair.node->type)) {
-            _copyCssStyleAttr(nodeIdPair.node, cssNode);
-        }
-        if (auto cssNode = _findCssStyleNode(cssStyle, nodeIdPair.id)) {
-            _copyCssStyleAttr(nodeIdPair.node, cssNode);
-        }
-    }
-}
-
-
 static void _freeNodeStyle(SvgStyleProperty* style)
 {
     if (!style) return;
@@ -3210,8 +3054,8 @@ void SvgLoader::run(unsigned tid)
         if (loaderData.gradients.count > 0) _updateGradient(loaderData.doc, &loaderData.gradients);
         if (defs) _updateGradient(loaderData.doc, &defs->node.defs.gradients);
 
-        if (loaderData.nodesToStyle.count > 0) _stylePostponedNodes(&loaderData.nodesToStyle, loaderData.cssStyle);
-        if (loaderData.cssStyle) _updateCssStyle(loaderData.doc, loaderData.cssStyle);
+        if (loaderData.nodesToStyle.count > 0) stylePostponedNodes(&loaderData.nodesToStyle, loaderData.cssStyle);
+        if (loaderData.cssStyle) updateCssStyle(loaderData.doc, loaderData.cssStyle);
     }
     root = svgSceneBuild(loaderData.doc, vx, vy, vw, vh, w, h, preserveAspect, svgPath);
 }

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -1093,7 +1093,7 @@ static void _handleCssClassAttr(SvgLoaderData* loader, SvgNode* node, const char
         _copyCssStyleAttr(node, cssNode);
     }
 
-    if (!cssClassFound) _postponeCloneNode(&loader->cloneCssStyleNodes, node, *cssClass);
+    if (!cssClassFound) _postponeCloneNode(&loader->nodesToStyle, node, *cssClass);
 }
 
 
@@ -3022,10 +3022,10 @@ static void _updateCssStyle(SvgNode* doc, SvgNode* cssStyle)
 }
 
 
-static void _clonePostponedCssStyleNodes(Array<SvgNodeIdPair>* cloneCssStyleNodes, SvgNode* cssStyle)
+static void _stylePostponedNodes(Array<SvgNodeIdPair>* nodesToStyle, SvgNode* cssStyle)
 {
-    for (uint32_t i = 0; i < cloneCssStyleNodes->count; ++i) {
-        auto nodeIdPair = cloneCssStyleNodes->data[i];
+    for (uint32_t i = 0; i < nodesToStyle->count; ++i) {
+        auto nodeIdPair = nodesToStyle->data[i];
 
         //css styling: tag.name has higher priority than .name
         if (auto cssNode = _findCssStyleNode(cssStyle, nodeIdPair.id, nodeIdPair.node->type)) {
@@ -3214,7 +3214,7 @@ void SvgLoader::run(unsigned tid)
         if (loaderData.gradients.count > 0) _updateGradient(loaderData.doc, &loaderData.gradients);
         if (defs) _updateGradient(loaderData.doc, &defs->node.defs.gradients);
 
-        if (loaderData.cloneCssStyleNodes.count > 0) _clonePostponedCssStyleNodes(&loaderData.cloneCssStyleNodes, loaderData.cssStyle);
+        if (loaderData.nodesToStyle.count > 0) _stylePostponedNodes(&loaderData.nodesToStyle, loaderData.cssStyle);
         //TODO: defs should be updated as well?
         if (loaderData.cssStyle) _updateCssStyle(loaderData.doc, loaderData.cssStyle);
     }

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -2694,11 +2694,7 @@ static void _svgLoaderParserXmlStyle(SvgLoaderData* loader, const char* content,
     GradientFactoryMethod gradientMethod;
     SvgNode *node = nullptr;
 
-    const char *buf = content;
-    unsigned buflen = length;
-
-
-    while (auto next = simpleXmlParseCSSAttribute(buf, buflen, &tag, &name, &attrs, &attrsLength)) {
+    while (auto next = simpleXmlParseCSSAttribute(content, length, &tag, &name, &attrs, &attrsLength)) {
         if ((method = _findGroupFactory(tag))) {
             //TODO - node->id ??? add additional var for svgnode?
             if ((node = method(loader, loader->cssStyle, attrs, attrsLength, simpleXmlParseW3CAttribute))) node->id = _copyId(name);
@@ -2714,9 +2710,8 @@ static void _svgLoaderParserXmlStyle(SvgLoaderData* loader, const char* content,
             TVGLOG("SVG", "Unsupported elements used [Elements: %s]", tag);
         }
 
-        buflen -= next - buf;
-        buf = next;
-
+        length -= next - content;
+        content = next;
 
         free(tag);
         free(name);

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -2630,10 +2630,12 @@ static void _svgLoaderParserXmlOpen(SvgLoaderData* loader, const char* content, 
             if (!strcmp(tagName, "svg")) return; //Already loaded <svg>(SvgNodeType::Doc) tag
             if (loader->stack.count > 0) parent = loader->stack.data[loader->stack.count - 1];
             else parent = loader->doc;
-            node = method(loader, parent, attrs, attrsLength, simpleXmlParseAttributes);
             if (!strcmp(tagName, "style")) {
+                node = method(loader, nullptr, attrs, attrsLength, simpleXmlParseAttributes);
                 loader->cssStyle = node;
                 loader->style = true;
+            } else {
+                node = method(loader, parent, attrs, attrsLength, simpleXmlParseAttributes);
             }
         }
 

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -1102,6 +1102,21 @@ static bool _attrParseMaskNode(void* data, const char* key, const char* value)
 }
 
 
+static bool _attrParseCssStyleNode(void* data, const char* key, const char* value)
+{
+    SvgLoaderData* loader = (SvgLoaderData*)data;
+    SvgNode* node = loader->svgParse->node;
+
+    if (!strcmp(key, "id")) {
+        if (node->id && value) free(node->id);
+        node->id = _copyId(value);
+    } else {
+        return _parseStyleAttr(loader, key, value, false);
+    }
+    return true;
+}
+
+
 static SvgNode* _createNode(SvgNode* parent, SvgNodeType type)
 {
     SvgNode* node = (SvgNode*)calloc(1, sizeof(SvgNode));
@@ -1225,6 +1240,17 @@ static SvgNode* _createClipPathNode(SvgLoaderData* loader, SvgNode* parent, cons
 
     return loader->svgParse->node;
 }
+
+
+static SvgNode* _createCssStyleNode(SvgLoaderData* loader, SvgNode* parent, const char* buf, unsigned bufLength)
+{
+    loader->svgParse->node = _createNode(parent, SvgNodeType::CssStyle);
+    if (!loader->svgParse->node) return nullptr;
+
+    simpleXmlParseAttributes(buf, bufLength, _attrParseCssStyleNode, loader);
+    return loader->svgParse->node;
+}
+
 
 static bool _attrParsePathNode(void* data, const char* key, const char* value)
 {
@@ -2096,7 +2122,8 @@ static constexpr struct
     {"g", sizeof("g"), _createGNode},
     {"svg", sizeof("svg"), _createSvgNode},
     {"mask", sizeof("mask"), _createMaskNode},
-    {"clipPath", sizeof("clipPath"), _createClipPathNode}
+    {"clipPath", sizeof("clipPath"), _createClipPathNode},
+    {"style", sizeof("style"), _createCssStyleNode}
 };
 
 
@@ -2526,7 +2553,8 @@ static constexpr struct
     {"svg", sizeof("svg")},
     {"defs", sizeof("defs")},
     {"mask", sizeof("mask")},
-    {"clipPath", sizeof("clipPath")}
+    {"clipPath", sizeof("clipPath")},
+    {"style", sizeof("style")}
 };
 
 
@@ -2585,6 +2613,7 @@ static void _svgLoaderParserXmlOpen(SvgLoaderData* loader, const char* content, 
             if (loader->stack.count > 0) parent = loader->stack.data[loader->stack.count - 1];
             else parent = loader->doc;
             node = method(loader, parent, attrs, attrsLength);
+            if (!strcmp(tagName, "style")) loader->cssStyle = node;
         }
 
         if (!node) return;

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -947,6 +947,15 @@ static void _handleDisplayAttr(TVG_UNUSED SvgLoaderData* loader, SvgNode* node, 
 }
 
 
+static void _handleCssClassAttr(TVG_UNUSED SvgLoaderData* loader, SvgNode* node, const char* value)
+{
+    auto cssClass = &node->style->cssClass;
+
+    if (*cssClass && value) free(*cssClass);
+    *cssClass = _copyId(value);
+}
+
+
 typedef void (*styleMethod)(SvgLoaderData* loader, SvgNode* node, const char* value);
 
 #define STYLE_DEF(Name, Name1, Flag) { #Name, sizeof(#Name), _handle##Name1##Attr, Flag }
@@ -1027,6 +1036,8 @@ static bool _attrParseGNode(void* data, const char* key, const char* value)
     } else if (!strcmp(key, "id")) {
         if (node->id && value) free(node->id);
         node->id = _copyId(value);
+    } else if (!strcmp(key, "class")) {
+        _handleCssClassAttr(loader, node, value);
     } else if (!strcmp(key, "clip-path")) {
         _handleClipPathAttr(loader, node, value);
     } else if (!strcmp(key, "mask")) {
@@ -1054,6 +1065,8 @@ static bool _attrParseClipPathNode(void* data, const char* key, const char* valu
     } else if (!strcmp(key, "id")) {
         if (node->id && value) free(node->id);
         node->id = _copyId(value);
+    } else if (!strcmp(key, "class")) {
+        _handleCssClassAttr(loader, node, value);
     } else if (!strcmp(key, "clipPathUnits")) {
         if (!strcmp(value, "objectBoundingBox")) clip->userSpace = false;
     } else {
@@ -1076,6 +1089,8 @@ static bool _attrParseMaskNode(void* data, const char* key, const char* value)
     } else if (!strcmp(key, "id")) {
         if (node->id && value) free(node->id);
         node->id = _copyId(value);
+    } else if (!strcmp(key, "class")) {
+        _handleCssClassAttr(loader, node, value);
     } else if (!strcmp(key, "maskContentUnits")) {
         if (!strcmp(value, "objectBoundingBox")) mask->userSpace = false;
     } else if (!strcmp(key, "mask-type")) {
@@ -1229,6 +1244,8 @@ static bool _attrParsePathNode(void* data, const char* key, const char* value)
     } else if (!strcmp(key, "id")) {
         if (node->id && value) free(node->id);
         node->id = _copyId(value);
+    } else if (!strcmp(key, "class")) {
+        _handleCssClassAttr(loader, node, value);
     } else {
         return _parseStyleAttr(loader, key, value, false);
     }
@@ -1289,6 +1306,8 @@ static bool _attrParseCircleNode(void* data, const char* key, const char* value)
     } else if (!strcmp(key, "id")) {
         if (node->id && value) free(node->id);
         node->id = _copyId(value);
+    } else if (!strcmp(key, "class")) {
+        _handleCssClassAttr(loader, node, value);
     } else {
         return _parseStyleAttr(loader, key, value, false);
     }
@@ -1343,6 +1362,8 @@ static bool _attrParseEllipseNode(void* data, const char* key, const char* value
     if (!strcmp(key, "id")) {
         if (node->id && value) free(node->id);
         node->id = _copyId(value);
+    } else if (!strcmp(key, "class")) {
+        _handleCssClassAttr(loader, node, value);
     } else if (!strcmp(key, "style")) {
         return simpleXmlParseW3CAttribute(value, _parseStyleAttr, loader);
     } else if (!strcmp(key, "clip-path")) {
@@ -1426,6 +1447,8 @@ static bool _attrParsePolygonNode(void* data, const char* key, const char* value
     } else if (!strcmp(key, "id")) {
         if (node->id && value) free(node->id);
         node->id = _copyId(value);
+    } else if (!strcmp(key, "class")) {
+        _handleCssClassAttr(loader, node, value);
     } else {
         return _parseStyleAttr(loader, key, value, false);
     }
@@ -1500,6 +1523,8 @@ static bool _attrParseRectNode(void* data, const char* key, const char* value)
     if (!strcmp(key, "id")) {
         if (node->id && value) free(node->id);
         node->id = _copyId(value);
+    } else if (!strcmp(key, "class")) {
+        _handleCssClassAttr(loader, node, value);
     } else if (!strcmp(key, "style")) {
         ret = simpleXmlParseW3CAttribute(value, _parseStyleAttr, loader);
     } else if (!strcmp(key, "clip-path")) {
@@ -1563,6 +1588,8 @@ static bool _attrParseLineNode(void* data, const char* key, const char* value)
     if (!strcmp(key, "id")) {
         if (node->id && value) free(node->id);
         node->id = _copyId(value);
+    } else if (!strcmp(key, "class")) {
+        _handleCssClassAttr(loader, node, value);
     } else if (!strcmp(key, "style")) {
         return simpleXmlParseW3CAttribute(value, _parseStyleAttr, loader);
     } else if (!strcmp(key, "clip-path")) {
@@ -1634,6 +1661,8 @@ static bool _attrParseImageNode(void* data, const char* key, const char* value)
     } else if (!strcmp(key, "id")) {
         if (node->id && value) free(node->id);
         node->id = _copyId(value);
+    } else if (!strcmp(key, "class")) {
+        _handleCssClassAttr(loader, node, value);
     } else if (!strcmp(key, "style")) {
         return simpleXmlParseW3CAttribute(value, _parseStyleAttr, loader);
     } else if (!strcmp(key, "clip-path")) {
@@ -2767,6 +2796,7 @@ static void _freeNodeStyle(SvgStyleProperty* style)
     //style->clipPath.node and style->mask.node has only the addresses of node. Therefore, node is released from _freeNode.
     free(style->clipPath.url);
     free(style->mask.url);
+    free(style->cssClass);
 
     if (style->fill.paint.gradient) {
         style->fill.paint.gradient->clear();

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -2725,7 +2725,6 @@ static void _svgLoaderParserXmlOpen(SvgLoaderData* loader, const char* content, 
     GradientFactoryMethod gradientMethod;
     SvgNode *node = nullptr, *parent = nullptr;
     loader->level++;
-    loader->style = false;
     attrs = simpleXmlFindAttributesTag(content, length);
 
     if (!attrs) {
@@ -2835,6 +2834,7 @@ static void _svgLoaderParserXmlCssStyle(SvgLoaderData* loader, const char* conte
         free(tag);
         free(name);
     }
+    loader->style = false;
 }
 
 

--- a/src/loaders/svg/tvgSvgLoaderCommon.h
+++ b/src/loaders/svg/tvgSvgLoaderCommon.h
@@ -416,7 +416,7 @@ struct SvgLoaderData
     Array<SvgNodeIdPair> nodesToStyle;
     int level = 0;
     bool result = false;
-    bool style = false; //TODO: find a better sollution?
+    bool style = false;
 };
 
 /*

--- a/src/loaders/svg/tvgSvgLoaderCommon.h
+++ b/src/loaders/svg/tvgSvgLoaderCommon.h
@@ -413,7 +413,7 @@ struct SvgLoaderData
     SvgStyleGradient* latestGradient = nullptr; //For stops
     SvgParser* svgParse = nullptr;
     Array<SvgNodeIdPair> cloneNodes;
-    Array<SvgNodeIdPair> cloneCssStyleNodes;
+    Array<SvgNodeIdPair> nodesToStyle;
     int level = 0;
     bool result = false;
     bool style = false; //TODO: find a better sollution?

--- a/src/loaders/svg/tvgSvgLoaderCommon.h
+++ b/src/loaders/svg/tvgSvgLoaderCommon.h
@@ -415,6 +415,7 @@ struct SvgLoaderData
     Array<SvgNodeIdPair> cloneNodes;
     int level = 0;
     bool result = false;
+    bool style = false; //TODO: find a better sollution?
 };
 
 /*

--- a/src/loaders/svg/tvgSvgLoaderCommon.h
+++ b/src/loaders/svg/tvgSvgLoaderCommon.h
@@ -51,6 +51,7 @@ enum class SvgNodeType
     Video,
     ClipPath,
     Mask,
+    CssStyle,
     Unknown
 };
 
@@ -233,6 +234,10 @@ struct SvgMaskNode
     bool userSpace;
 };
 
+struct SvgCssStyleNode
+{
+};
+
 struct SvgLinearGradient
 {
     float x1;
@@ -368,6 +373,7 @@ struct SvgNode
         SvgImageNode image;
         SvgMaskNode mask;
         SvgClipNode clip;
+        SvgCssStyleNode cssStyle;
     } node;
     bool display;
     ~SvgNode();
@@ -402,6 +408,7 @@ struct SvgLoaderData
     Array<SvgNode *> stack = {nullptr, 0, 0};
     SvgNode* doc = nullptr;
     SvgNode* def = nullptr;
+    SvgNode* cssStyle = nullptr;
     Array<SvgStyleGradient*> gradients;
     SvgStyleGradient* latestGradient = nullptr; //For stops
     SvgParser* svgParse = nullptr;

--- a/src/loaders/svg/tvgSvgLoaderCommon.h
+++ b/src/loaders/svg/tvgSvgLoaderCommon.h
@@ -413,6 +413,7 @@ struct SvgLoaderData
     SvgStyleGradient* latestGradient = nullptr; //For stops
     SvgParser* svgParse = nullptr;
     Array<SvgNodeIdPair> cloneNodes;
+    Array<SvgNodeIdPair> cloneCssStyleNodes;
     int level = 0;
     bool result = false;
     bool style = false; //TODO: find a better sollution?

--- a/src/loaders/svg/tvgSvgLoaderCommon.h
+++ b/src/loaders/svg/tvgSvgLoaderCommon.h
@@ -341,6 +341,7 @@ struct SvgStyleProperty
     int opacity;
     SvgColor color;
     bool curColorSet;
+    char* cssClass;
     SvgStyleFlags flags;
 };
 

--- a/src/loaders/svg/tvgXmlParser.cpp
+++ b/src/loaders/svg/tvgXmlParser.cpp
@@ -509,6 +509,47 @@ bool simpleXmlParseW3CAttribute(const char* buf, simpleXMLAttributeCb func, cons
 }
 
 
+/*
+ * Supported formats:
+ * tag {}, .name {}, tag.name{}
+ */
+const char* simpleXmlParseCSSAttribute(const char* buf, unsigned bufLength, char** tag, char** name, const char** attrs, unsigned* attrsLength)
+{
+    if (!buf) return nullptr;
+
+    *tag = *name = nullptr;
+    *attrsLength = 0;
+
+    auto itr = _simpleXmlSkipWhiteSpace(buf, buf + bufLength);
+    auto itrEnd = (const char*)memchr(buf, '{', bufLength);
+
+    if (!itrEnd || itr == itrEnd) return nullptr;
+
+    auto nextElement = (const char*)memchr(itrEnd, '}', bufLength - (itrEnd - buf));
+    if (!nextElement) return nullptr;
+
+    *attrs = itrEnd + 1;
+    *attrsLength = nextElement - *attrs;
+
+    const char *p;
+
+    itrEnd = _simpleXmlUnskipWhiteSpace(itrEnd, itr);
+    if (*(itrEnd - 1) == '.') return nullptr;
+
+    for (p = itr; p < itrEnd; p++) {
+        if (*p == '.') break;
+    }
+
+    if (p == itr) *tag = strdup("all");
+    else *tag = strndup(itr, p - itr);
+
+    if (p == itrEnd) *name = nullptr;
+    else *name = strndup(p + 1, itrEnd - p - 1);
+
+    return (nextElement ? nextElement + 1 : nullptr);
+}
+
+
 const char* simpleXmlFindAttributesTag(const char* buf, unsigned bufLength)
 {
     const char *itr = buf, *itrEnd = buf + bufLength;

--- a/src/loaders/svg/tvgXmlParser.cpp
+++ b/src/loaders/svg/tvgXmlParser.cpp
@@ -236,6 +236,14 @@ static SimpleXMLType _getXMLType(const char* itr, const char* itrEnd, size_t &to
 }
 
 
+static char* _strndup(const char* src, unsigned len)
+{
+    auto ret = (char*)malloc(len + 1);
+    if (!ret) return nullptr;
+    ret[len] = '\0';
+    return (char*)memcpy(ret, src, len);
+}
+
 /************************************************************************/
 /* External Class Implementation                                        */
 /************************************************************************/
@@ -547,10 +555,10 @@ const char* simpleXmlParseCSSAttribute(const char* buf, unsigned bufLength, char
     }
 
     if (p == itr) *tag = strdup("all");
-    else *tag = strndup(itr, p - itr);
+    else *tag = _strndup(itr, p - itr);
 
     if (p == itrEnd) *name = nullptr;
-    else *name = strndup(p + 1, itrEnd - p - 1);
+    else *name = _strndup(p + 1, itrEnd - p - 1);
 
     return (nextElement ? nextElement + 1 : nullptr);
 }

--- a/src/loaders/svg/tvgXmlParser.cpp
+++ b/src/loaders/svg/tvgXmlParser.cpp
@@ -450,7 +450,7 @@ bool simpleXmlParse(const char* buf, unsigned bufLength, bool strip, simpleXMLCb
 }
 
 
-bool simpleXmlParseW3CAttribute(const char* buf, simpleXMLAttributeCb func, const void* data)
+bool simpleXmlParseW3CAttribute(const char* buf, TVG_UNUSED unsigned buflen, simpleXMLAttributeCb func, const void* data)
 {
     const char* end;
     char* key;

--- a/src/loaders/svg/tvgXmlParser.cpp
+++ b/src/loaders/svg/tvgXmlParser.cpp
@@ -458,7 +458,7 @@ bool simpleXmlParse(const char* buf, unsigned bufLength, bool strip, simpleXMLCb
 }
 
 
-bool simpleXmlParseW3CAttribute(const char* buf, unsigned buflen, simpleXMLAttributeCb func, const void* data)
+bool simpleXmlParseW3CAttribute(const char* buf, unsigned bufLength, simpleXMLAttributeCb func, const void* data)
 {
     const char* end;
     char* key;
@@ -467,7 +467,7 @@ bool simpleXmlParseW3CAttribute(const char* buf, unsigned buflen, simpleXMLAttri
 
     if (!buf) return false;
 
-    end = buf + buflen;
+    end = buf + bufLength;
     key = (char*)alloca(end - buf + 1);
     val = (char*)alloca(end - buf + 1);
 

--- a/src/loaders/svg/tvgXmlParser.cpp
+++ b/src/loaders/svg/tvgXmlParser.cpp
@@ -476,8 +476,7 @@ bool simpleXmlParseW3CAttribute(const char* buf, unsigned buflen, simpleXMLAttri
     do {
         char* sep = (char*)strchr(buf, ':');
         next = (char*)strchr(buf, ';');
-        if (sep >= end)
-        {
+        if (sep >= end) {
             next = nullptr;
             sep = nullptr;
         }

--- a/src/loaders/svg/tvgXmlParser.cpp
+++ b/src/loaders/svg/tvgXmlParser.cpp
@@ -468,6 +468,13 @@ bool simpleXmlParseW3CAttribute(const char* buf, TVG_UNUSED unsigned buflen, sim
     do {
         char* sep = (char*)strchr(buf, ':');
         next = (char*)strchr(buf, ';');
+        if (sep >= end)
+        {
+            next = nullptr;
+            sep = nullptr;
+        }
+        if (next >= end) next = nullptr;
+
 
         key[0] = '\0';
         val[0] = '\0';

--- a/src/loaders/svg/tvgXmlParser.cpp
+++ b/src/loaders/svg/tvgXmlParser.cpp
@@ -450,7 +450,7 @@ bool simpleXmlParse(const char* buf, unsigned bufLength, bool strip, simpleXMLCb
 }
 
 
-bool simpleXmlParseW3CAttribute(const char* buf, TVG_UNUSED unsigned buflen, simpleXMLAttributeCb func, const void* data)
+bool simpleXmlParseW3CAttribute(const char* buf, unsigned buflen, simpleXMLAttributeCb func, const void* data)
 {
     const char* end;
     char* key;
@@ -459,7 +459,7 @@ bool simpleXmlParseW3CAttribute(const char* buf, TVG_UNUSED unsigned buflen, sim
 
     if (!buf) return false;
 
-    end = buf + strlen(buf);
+    end = buf + buflen;
     key = (char*)alloca(end - buf + 1);
     val = (char*)alloca(end - buf + 1);
 
@@ -474,7 +474,6 @@ bool simpleXmlParseW3CAttribute(const char* buf, TVG_UNUSED unsigned buflen, sim
             sep = nullptr;
         }
         if (next >= end) next = nullptr;
-
 
         key[0] = '\0';
         val[0] = '\0';

--- a/src/loaders/svg/tvgXmlParser.h
+++ b/src/loaders/svg/tvgXmlParser.h
@@ -49,7 +49,7 @@ typedef bool (*simpleXMLAttributeCb)(void* data, const char* key, const char* va
 
 bool simpleXmlParseAttributes(const char* buf, unsigned buflen, simpleXMLAttributeCb func, const void* data);
 bool simpleXmlParse(const char* buf, unsigned buflen, bool strip, simpleXMLCb func, const void* data);
-bool simpleXmlParseW3CAttribute(const char* buf, TVG_UNUSED unsigned buflen, simpleXMLAttributeCb func, const void* data);
+bool simpleXmlParseW3CAttribute(const char* buf, unsigned buflen, simpleXMLAttributeCb func, const void* data);
 const char* simpleXmlParseCSSAttribute(const char* buf, unsigned bufLength, char** tag, char** name, const char** attrs, unsigned* attrsLength);
 const char* simpleXmlFindAttributesTag(const char* buf, unsigned buflen);
 bool isIgnoreUnsupportedLogElements(const char* tagName);

--- a/src/loaders/svg/tvgXmlParser.h
+++ b/src/loaders/svg/tvgXmlParser.h
@@ -49,7 +49,7 @@ typedef bool (*simpleXMLAttributeCb)(void* data, const char* key, const char* va
 
 bool simpleXmlParseAttributes(const char* buf, unsigned buflen, simpleXMLAttributeCb func, const void* data);
 bool simpleXmlParse(const char* buf, unsigned buflen, bool strip, simpleXMLCb func, const void* data);
-bool simpleXmlParseW3CAttribute(const char* buf, simpleXMLAttributeCb func, const void* data);
+bool simpleXmlParseW3CAttribute(const char* buf, TVG_UNUSED unsigned buflen, simpleXMLAttributeCb func, const void* data);
 const char* simpleXmlParseCSSAttribute(const char* buf, unsigned bufLength, char** tag, char** name, const char** attrs, unsigned* attrsLength);
 const char* simpleXmlFindAttributesTag(const char* buf, unsigned buflen);
 bool isIgnoreUnsupportedLogElements(const char* tagName);

--- a/src/loaders/svg/tvgXmlParser.h
+++ b/src/loaders/svg/tvgXmlParser.h
@@ -32,7 +32,7 @@ const int xmlEntityLength[] = {6, 6, 6, 5, 4, 4, 6, 6};
 enum class SimpleXMLType
 {
     Open = 0,     //!< \<tag attribute="value"\>
-    OpenEmpty,   //!< \<tag attribute="value" /\>
+    OpenEmpty,    //!< \<tag attribute="value" /\>
     Close,        //!< \</tag\>
     Data,         //!< tag text data
     CData,        //!< \<![cdata[something]]\>
@@ -41,7 +41,7 @@ enum class SimpleXMLType
     Doctype,      //!< \<!doctype html
     Comment,      //!< \<!-- something --\>
     Ignored,      //!< whatever is ignored by parser, like whitespace
-    DoctypeChild //!< \<!doctype_child
+    DoctypeChild  //!< \<!doctype_child
 };
 
 typedef bool (*simpleXMLCb)(void* data, SimpleXMLType type, const char* content, unsigned int length);
@@ -50,7 +50,8 @@ typedef bool (*simpleXMLAttributeCb)(void* data, const char* key, const char* va
 bool simpleXmlParseAttributes(const char* buf, unsigned buflen, simpleXMLAttributeCb func, const void* data);
 bool simpleXmlParse(const char* buf, unsigned buflen, bool strip, simpleXMLCb func, const void* data);
 bool simpleXmlParseW3CAttribute(const char* buf, simpleXMLAttributeCb func, const void* data);
-const char *simpleXmlFindAttributesTag(const char* buf, unsigned buflen);
+const char* simpleXmlParseCSSAttribute(const char* buf, unsigned bufLength, char** tag, char** name, const char** attrs, unsigned* attrsLength);
+const char* simpleXmlFindAttributesTag(const char* buf, unsigned buflen);
 bool isIgnoreUnsupportedLogElements(const char* tagName);
 const char* simpleXmlNodeTypeToString(SvgNodeType type);
 

--- a/src/loaders/svg/tvgXmlParser.h
+++ b/src/loaders/svg/tvgXmlParser.h
@@ -47,11 +47,11 @@ enum class SimpleXMLType
 typedef bool (*simpleXMLCb)(void* data, SimpleXMLType type, const char* content, unsigned int length);
 typedef bool (*simpleXMLAttributeCb)(void* data, const char* key, const char* value);
 
-bool simpleXmlParseAttributes(const char* buf, unsigned buflen, simpleXMLAttributeCb func, const void* data);
-bool simpleXmlParse(const char* buf, unsigned buflen, bool strip, simpleXMLCb func, const void* data);
-bool simpleXmlParseW3CAttribute(const char* buf, unsigned buflen, simpleXMLAttributeCb func, const void* data);
+bool simpleXmlParseAttributes(const char* buf, unsigned bufLength, simpleXMLAttributeCb func, const void* data);
+bool simpleXmlParse(const char* buf, unsigned bufLength, bool strip, simpleXMLCb func, const void* data);
+bool simpleXmlParseW3CAttribute(const char* buf, unsigned bufLength, simpleXMLAttributeCb func, const void* data);
 const char* simpleXmlParseCSSAttribute(const char* buf, unsigned bufLength, char** tag, char** name, const char** attrs, unsigned* attrsLength);
-const char* simpleXmlFindAttributesTag(const char* buf, unsigned buflen);
+const char* simpleXmlFindAttributesTag(const char* buf, unsigned bufLength);
 bool isIgnoreUnsupportedLogElements(const char* tagName);
 const char* simpleXmlNodeTypeToString(SvgNodeType type);
 


### PR DESCRIPTION
svg_loader: a basic implementation of the css internal style sheets

Support for class and type selectors (for the graphics elements) introduced.
The geometric attributes are not supported in the style attribute (feature added in SVG2 standard).

issue #702 
https://github.com/Samsung/thorvg/wiki/CSS-styling

---------
summary for a reviewer:
- tvgXmlParser.cpp - simpleXmlParseCSSAttribute() - parsing targets in formats: tag {}, tag.name {}, .name {}
- all methods _create...Node() has one additional arg - a pointer to a function. till now the simpleXmlParseAttributes() was used inside _create...Node() to determine the attributes values. Since the same functions (_create...Node()) are used to create the nodes with css style and the format of the data is different, I need to use there simpleXmlParseW3CAttribute() instead.
- proper precedence (from the highest):
  1. inline style (`style="fill: red; stroke: blue"`)
  2. css style for a proper target and with a name (`<circle ... class="name" />`)
  3. css style for all targets, with a name (class attribute used, but the type of the node is not checked) 
  4. css style for a proper target (`<circle .../>`   <- no class used, style applied to all circles)
  5. attributes (`fill="red" stroke="green"`)
- to apply the style defined at the end of the svg file, the postponed mechanism applied (similar to the one used for the 'use' nodes)

+ comments in issue #702 