### PR TITLE
svg_loader: memleak prevention

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -1628,6 +1628,7 @@ static bool _attrParseImageNode(void* data, const char* key, const char* value)
     }
 
     if (!strcmp(key, "href") || !strcmp(key, "xlink:href")) {
+        if (image->href && value) free(image->href);
         image->href = _idFromHref(value);
     } else if (!strcmp(key, "id")) {
         if (node->id && value) free(node->id);


### PR DESCRIPTION
If image href set more than once, the memory was not freed.