### PR TITLE
svg_loader: group tags misinterpreted as parent nodes

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -2538,6 +2538,7 @@ static void _svgLoaderParserXmlOpen(SvgLoaderData* loader, const char* content, 
 
     if ((method = _findGroupFactory(tagName))) {
         //Group
+        if (empty) return;
         if (!loader->doc) {
             if (strcmp(tagName, "svg")) return; //Not a valid svg document
             node = method(loader, nullptr, attrs, attrsLength);


### PR DESCRIPTION
Group tags in a format <tag .../> finds no application
to the rest of the svg file and should be skipped.

issue #1162 - the 90.svg file