### PR TITLE
sw_engine: Replace non-portable min/max with std version

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,3 +14,4 @@ Patryk Kaczmarek <patryk.k@partner.samsung.com>
 Michal Maciola <m.maciola@samsung.com>
 Peter Vullings <peter@projectitis.com>
 K. S. Ernest (iFire) Lee <ernest.lee@chibifire.com>
+Rémi Verschelde <rverschelde@gmail.com>

--- a/src/lib/sw_engine/tvgSwRenderer.cpp
+++ b/src/lib/sw_engine/tvgSwRenderer.cpp
@@ -23,6 +23,7 @@
 #include "tvgSwCommon.h"
 #include "tvgTaskScheduler.h"
 #include "tvgSwRenderer.h"
+#include "tvgMath.h"
 
 /************************************************************************/
 /* Internal Class Implementation                                        */
@@ -594,10 +595,10 @@ void* SwRenderer::prepareCommon(SwTask* task, const RenderTransform* transform, 
     task->surface = surface;
     task->mpool = mpool;
     task->flags = flags;
-    task->bbox.min.x = max(static_cast<SwCoord>(0), static_cast<SwCoord>(vport.x));
-    task->bbox.min.y = max(static_cast<SwCoord>(0), static_cast<SwCoord>(vport.y));
-    task->bbox.max.x = min(static_cast<SwCoord>(surface->w), static_cast<SwCoord>(vport.x + vport.w));
-    task->bbox.max.y = min(static_cast<SwCoord>(surface->h), static_cast<SwCoord>(vport.y + vport.h));
+    task->bbox.min.x = mathMax(static_cast<SwCoord>(0), static_cast<SwCoord>(vport.x));
+    task->bbox.min.y = mathMax(static_cast<SwCoord>(0), static_cast<SwCoord>(vport.y));
+    task->bbox.max.x = mathMin(static_cast<SwCoord>(surface->w), static_cast<SwCoord>(vport.x + vport.w));
+    task->bbox.max.y = mathMin(static_cast<SwCoord>(surface->h), static_cast<SwCoord>(vport.y + vport.h));
 
     if (!task->pushed) {
         task->pushed = true;

--- a/src/lib/tvgMath.h
+++ b/src/lib/tvgMath.h
@@ -29,6 +29,10 @@
 #include "tvgCommon.h"
 
 
+#define mathMin(x, y) (((x) < (y)) ? (x) : (y))
+#define mathMax(x, y) (((x) > (y)) ? (x) : (y))
+
+
 static inline bool mathZero(float a)
 {
     return (fabsf(a) < FLT_EPSILON) ? true : false;


### PR DESCRIPTION
This would fail building with Visual Studio 2017, at least downstream in Godot
where we undefine old Windows compilers' non-standard `min`/`max` macros (see
`minmax.h`/`NOMINMAX`).

**Note:** I didn't actually test this against VS 2017 nor VS 2019 - but it builds fine with GCC on Linux at least.
This aims at fixing the following bug report: https://github.com/godotengine/godot/issues/56894#issuecomment-1015956706

> I can't compile on MSVC2017 (14.1) because of the same library. I get the following error:
> ```
> tvgSwRenderer.cpp
> thirdparty\thorvg\src\lib\sw_engine\tvgSwRenderer.cpp(597): error C3861: 'max': identifier not found
> thirdparty\thorvg\src\lib\sw_engine\tvgSwRenderer.cpp(598): error C3861: 'max': identifier not found
> thirdparty\thorvg\src\lib\sw_engine\tvgSwRenderer.cpp(599): error C3861: 'min': identifier not found
> thirdparty\thorvg\src\lib\sw_engine\tvgSwRenderer.cpp(600): error C3861: 'min': identifier not found
> scons: *** [thirdparty\thorvg\src\lib\sw_engine\tvgSwRenderer.windows.tools.64.obj] Error 2
> scons: building terminated because of errors.
> [Time elapsed: 00:00:38.518]
> ```

This error might come from Godot's own undefinitions of the non-standard `min` and `max` in the Windows API: https://github.com/godotengine/godot/blob/master/core/typedefs.h#L74-L87

But I'm not sure those can be assumed to work without including `<windows.h>` or `<minmax.h>` and it's probably not a good idea to do this here. I'm not an expert on these but using `std::min`/`std::max` should be more portable (I've seen examples of using `#define NOMINMAX` *before* including `<algorithm>` - again I'm not very knowledgeable on this but happy to amend if you have suggestions).

Added myself to `AUTHORS` as asked in #1159 (though I consider these tiny include fixes as public domain work, but eventually I might make up for the added credits with some real work ;)).