### PR TITLE
loaders jpg: fix all memory leaks.

### DIFF
--- a/src/loaders/jpg/tvgJpgLoader.cpp
+++ b/src/loaders/jpg/tvgJpgLoader.cpp
@@ -47,6 +47,7 @@ JpgLoader::~JpgLoader()
 {
     jpgdDelete(decoder);
     if (freeData) free(data);
+    free(image);
 }
 
 
@@ -128,5 +129,9 @@ unique_ptr<Surface> JpgLoader::bitmap()
 
 void JpgLoader::run(unsigned tid)
 {
+    if (image) {
+        free(image);
+        image = nullptr;
+    }
     image = jpgdDecompress(decoder);
 }

--- a/src/loaders/jpg/tvgJpgd.cpp
+++ b/src/loaders/jpg/tvgJpgd.cpp
@@ -1080,7 +1080,9 @@ namespace DCT_Upsample
 // Unconditionally frees all allocated m_blocks.
 void jpeg_decoder::free_all_blocks()
 {
+    delete(m_pStream);
     m_pStream = nullptr;
+
     for (mem_block *b = m_pMem_blocks; b; ) {
         mem_block *n = b->m_pNext;
         free(b);
@@ -2815,7 +2817,6 @@ int jpeg_decoder::begin_decoding()
 jpeg_decoder::~jpeg_decoder()
 {
     free_all_blocks();
-    delete(m_pStream);
 }
 
 


### PR DESCRIPTION
These were detected by asan with PictureJpg example,

fixed them all.