### PR TITLE
svg_loader: fixing the used mask-type

### DIFF
--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -594,7 +594,10 @@ static unique_ptr<Scene> _sceneBuildHelper(const SvgNode* node, const Box& vBox,
                         if (isMaskWhite) {
                             uint8_t r, g, b;
                             shape->fillColor(&r, &g, &b, nullptr);
-                            if (shape->fill() || r < 255 || g < 255 || b < 255) *isMaskWhite = false;
+                            if (shape->fill() || r < 255 || g < 255 || b < 255 || shape->strokeFill() ||
+                                (shape->strokeColor(&r, &g, &b, nullptr) == Result::Success && (r < 255 || g < 255 || b < 255))) {
+                                *isMaskWhite = false;
+                            }
                         }
                         scene->push(move(shape));
                     }


### PR DESCRIPTION
For the performance reasons, regardless of the set/default
mask-type value, if the mask is white, the alpha masking is
used. To qualify a mask as white, not only its fill has to be
checked, but its stroke as well. The second was missing.