### PR TITLE
svg_loader: symbol tag implemented

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -1309,6 +1309,7 @@ static SvgNode* _createSymbolNode(SvgLoaderData* loader, SvgNode* parent, const 
 
     loader->svgParse->node->display = false;
     loader->svgParse->node->node.symbol.preserveAspect = true;
+    loader->svgParse->node->node.symbol.overflowVisible = false;
 
     func(buf, bufLength, _attrParseSymbolNode, loader);
 

--- a/src/loaders/svg/tvgSvgLoaderCommon.h
+++ b/src/loaders/svg/tvgSvgLoaderCommon.h
@@ -52,6 +52,7 @@ enum class SvgNodeType
     ClipPath,
     Mask,
     CssStyle,
+    Symbol,
     Unknown
 };
 
@@ -166,11 +167,19 @@ struct SvgDefsNode
     Array<SvgStyleGradient*> gradients;
 };
 
+struct SvgSymbolNode
+{
+    float w, h;
+    float vx, vy, vw, vh;
+    bool preserveAspect;
+    bool overflowVisible;
+};
+
 struct SvgUseNode
 {
     float x, y, w, h;
+    SvgNode* symbol;
 };
-
 
 struct SvgEllipseNode
 {
@@ -375,6 +384,7 @@ struct SvgNode
         SvgMaskNode mask;
         SvgClipNode clip;
         SvgCssStyleNode cssStyle;
+        SvgSymbolNode symbol;
     } node;
     bool display;
     ~SvgNode();

--- a/src/loaders/svg/tvgXmlParser.cpp
+++ b/src/loaders/svg/tvgXmlParser.cpp
@@ -272,6 +272,7 @@ const char* simpleXmlNodeTypeToString(TVG_UNUSED SvgNodeType type)
         "Video",
         "ClipPath",
         "Mask",
+        "Symbol",
         "Unknown",
     };
     return TYPE_NAMES[(int) type];


### PR DESCRIPTION
The 'symbol' tag introduced. It can be used to define graphical
template objects which can be instantiated by a 'use' tag.

issue #1177 

TODO:
- tested for 'preserveAspectRatio="none" since the issue #1181
- I need to work on the behavior in a case when no width/height/viewbox is set - issue #1183 - SOLVED