### PR TITLE
svg_loader: proper image transformation

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -1640,6 +1640,8 @@ static bool _attrParseImageNode(void* data, const char* key, const char* value)
         _handleClipPathAttr(loader, node, value);
     } else if (!strcmp(key, "mask")) {
         _handleMaskAttr(loader, node, value);
+    } else if (!strcmp(key, "transform")) {
+        node->transform = _parseTransformationMatrix(value);
     } else {
         return _parseStyleAttr(loader, key, value);
     }

--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -546,12 +546,14 @@ static unique_ptr<Picture> _imageBuildHelper(SvgNode* node, const Box& vBox, con
     }
 
     float w, h;
+    Matrix m = {1, 0, 0, 0, 1, 0, 0, 0, 1};
     if (picture->size(&w, &h) == Result::Success && w  > 0 && h > 0) {
         auto sx = node->node.image.w / w;
         auto sy = node->node.image.h / h;
-        Matrix m = {sx, 0, node->node.image.x, 0, sy, node->node.image.y, 0, 0, 1};
-        picture->transform(m);
+        m = {sx, 0, node->node.image.x, 0, sy, node->node.image.y, 0, 0, 1};
     }
+    if (node->transform) m = mathMultiply(node->transform, &m);
+    picture->transform(m);
 
     _applyComposition(picture.get(), node, vBox, svgPath);
     return picture;


### PR DESCRIPTION
One of the image's attributes can be a transformation matrix.
Now it's applied.

issue: #1177 