### PR TITLE
svg_loader: fixing memory leak

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -2632,6 +2632,7 @@ static void _svgLoaderParserXmlOpen(SvgLoaderData* loader, const char* content, 
             if (!strcmp(tagName, "style")) {
                 node = method(loader, nullptr, attrs, attrsLength, simpleXmlParseAttributes);
                 loader->cssStyle = node;
+                loader->doc->node.doc.style = node;
                 loader->style = true;
             } else {
                 node = method(loader, parent, attrs, attrsLength, simpleXmlParseAttributes);
@@ -2931,6 +2932,7 @@ static void _freeNode(SvgNode* node)
          }
          case SvgNodeType::Doc: {
              _freeNode(node->node.doc.defs);
+             _freeNode(node->node.doc.style);
              break;
          }
          case SvgNodeType::Defs: {

--- a/src/loaders/svg/tvgSvgLoaderCommon.h
+++ b/src/loaders/svg/tvgSvgLoaderCommon.h
@@ -153,6 +153,7 @@ struct SvgDocNode
     float vw;
     float vh;
     SvgNode* defs;
+    SvgNode* style;
     bool preserveAspect;
 };
 
@@ -405,7 +406,7 @@ struct SvgNodeIdPair
 
 struct SvgLoaderData
 {
-    Array<SvgNode *> stack = {nullptr, 0, 0};
+    Array<SvgNode*> stack = {nullptr, 0, 0};
     SvgNode* doc = nullptr;
     SvgNode* def = nullptr;
     SvgNode* cssStyle = nullptr;


### PR DESCRIPTION
The css style node was improperly freed.