### PR TITLE
infra: Disable unit test in window CI

### DIFF
--- a/.github/workflows/build_win.yml
+++ b/.github/workflows/build_win.yml
@@ -28,7 +28,7 @@ jobs:
         name: result
         path: build/src\thorvg*
 
-  unit_test:
+  build_loaders:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v2
@@ -39,7 +39,7 @@ jobs:
 
     - name: Build
       run: |
-        meson --backend=ninja build -Dloaders="svg, tvg, png, jpg" -Dsavers="tvg" -Dbindings="capi" -Dtests=true
+        meson --backend=ninja build -Dloaders="svg, tvg, png, jpg" -Dsavers="tvg" -Dbindings="capi"
         where link
-        ninja -C build test
+        ninja -C build install
 


### PR DESCRIPTION
Symbol file generation for compiling test code in CI fails.
It's not caused by recent patches.
We don't test until we know the exact cause.
However, loader test is added to check the safety of window build.

Error Log

[45/68] Generating symbol file src/thorvg-0.dll.p/thorvg-0.dll.symbols
FAILED: src/thorvg-0.dll.p/thorvg-0.dll.symbols
"C:\hostedtoolcache\windows\Python\3.7.9\x64\Scripts\meson" "--internal" "symbolextractor" "D:\a\thorvg\thorvg\build" src/thorvg-0.dll "src\thorvg.lib" src/thorvg-0.dll.p/thorvg-0.dll.symbols