### PR TITLE
svg_loader: handle the exception properly.

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -1143,13 +1143,8 @@ static bool _attrParseSymbolNode(void* data, const char* key, const char* value)
     SvgSymbolNode* symbol = &(node->node.symbol);
 
     if (!strcmp(key, "viewBox")) {
-        if (_parseNumber(&value, &symbol->vx)) {
-            if (_parseNumber(&value, &symbol->vy)) {
-                if (_parseNumber(&value, &symbol->vw)) {
-                    _parseNumber(&value, &symbol->vh);
-                }
-            }
-        }
+        if (!_parseNumber(&value, &symbol->vx) || !_parseNumber(&value, &symbol->vy)) return false;
+        if (!_parseNumber(&value, &symbol->vw) || !_parseNumber(&value, &symbol->vh)) return false;
     } else if (!strcmp(key, "width")) {
         symbol->w = _toFloat(loader->svgParse, value, SvgParserLengthType::Horizontal);
     } else if (!strcmp(key, "height")) {


### PR DESCRIPTION
viewBox doesn't expect the missing attributes,
it won't have any default values.

So we can decide the fault when the values are missed.