### PR TITLE
svg_loader: symbol preserveAspectRatio attribute fixed

### DIFF
--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -589,8 +589,8 @@ static unique_ptr<Scene> _useBuildHelper(const SvgNode* node, const Box& vBox, c
             auto tvy = symbol.vy * sy;
             auto tvw = symbol.vw * sx;
             auto tvh = symbol.vh * sy;
-            if (tvw > tvh) tvy -= (symbol.h - tvh) * 0.5f;
-            else tvx -= (symbol.w - tvw) * 0.5f;
+            tvy -= (symbol.h - tvh) * 0.5f;
+            tvx -= (symbol.w - tvw) * 0.5f;
             mViewBox = {sx, 0, -tvx, 0, sy, -tvy, 0, 0, 1};
         } else if (!mathZero(symbol.vx) || !mathZero(symbol.vy)) {
             mViewBox = {1, 0, -symbol.vx, 0, 1, -symbol.vy, 0, 0, 1};


### PR DESCRIPTION
The symbol node was properly scaled only for 'preserveAspectRatio=none'.
Now it works also for the default value of this attribute (xMidYMid).

in the [comment](https://github.com/Samsung/thorvg/pull/1184#issuecomment-1042456898) I pointed out that preserveAspectRatio="none" has to be set. now also the default value of the preserveAspectRatio works correctly 