### PR TITLE
svg_loader: use node fixed

### DIFF
--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -626,8 +626,8 @@ static unique_ptr<Scene> _useBuildHelper(const SvgNode* node, const Box& vBox, c
 
             finalScene = move(root);
         }
-    } else if (node->node.use.x != 0.0f || node->node.use.y != 0.0f) {
-        scene->transform(mUseTransform);
+    } else {
+        if (!mathIdentity((const Matrix*)(&mUseTransform))) scene->transform(mUseTransform);
         finalScene = move(scene);
     }
 


### PR DESCRIPTION
By mistake the use node was improperly transformed and/or displayed
for a reference node other than a symbol node.