### PR TITLE
svg_loader: symbol node without any viewbox/width/height info handled properly

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -1145,10 +1145,13 @@ static bool _attrParseSymbolNode(void* data, const char* key, const char* value)
     if (!strcmp(key, "viewBox")) {
         if (!_parseNumber(&value, &symbol->vx) || !_parseNumber(&value, &symbol->vy)) return false;
         if (!_parseNumber(&value, &symbol->vw) || !_parseNumber(&value, &symbol->vh)) return false;
+        symbol->hasViewBox = true;
     } else if (!strcmp(key, "width")) {
         symbol->w = _toFloat(loader->svgParse, value, SvgParserLengthType::Horizontal);
+        symbol->hasWidth = true;
     } else if (!strcmp(key, "height")) {
         symbol->h = _toFloat(loader->svgParse, value, SvgParserLengthType::Vertical);
+        symbol->hasHeight = true;
     } else if (!strcmp(key, "preserveAspectRatio")) {
         if (!strcmp(value, "none")) symbol->preserveAspect = false;
     } else if (!strcmp(key, "overflow")) {
@@ -1305,6 +1308,12 @@ static SvgNode* _createSymbolNode(SvgLoaderData* loader, SvgNode* parent, const 
     loader->svgParse->node->display = false;
     loader->svgParse->node->node.symbol.preserveAspect = true;
     loader->svgParse->node->node.symbol.overflowVisible = false;
+
+    loader->svgParse->node->node.symbol.hasViewBox = false;
+    loader->svgParse->node->node.symbol.hasWidth = false;
+    loader->svgParse->node->node.symbol.hasHeight = false;
+    loader->svgParse->node->node.symbol.vx = 0.0f;
+    loader->svgParse->node->node.symbol.vy = 0.0f;
 
     func(buf, bufLength, _attrParseSymbolNode, loader);
 

--- a/src/loaders/svg/tvgSvgLoaderCommon.h
+++ b/src/loaders/svg/tvgSvgLoaderCommon.h
@@ -173,6 +173,9 @@ struct SvgSymbolNode
     float vx, vy, vw, vh;
     bool preserveAspect;
     bool overflowVisible;
+    bool hasViewBox;
+    bool hasWidth;
+    bool hasHeight;
 };
 
 struct SvgUseNode

--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -576,15 +576,17 @@ static unique_ptr<Scene> _useBuildHelper(const SvgNode* node, const Box& vBox, c
     if (node->node.use.symbol) {
         auto symbol = node->node.use.symbol->node.symbol;
 
-        auto width = symbol.w;
+        auto width = (symbol.hasWidth ? symbol.w : vBox.w);
         if (node->node.use.isWidthSet) width = node->node.use.w;
-        auto height = symbol.h;
+        auto height = (symbol.hasHeight ? symbol.h : vBox.h);;
         if (node->node.use.isHeightSet) height = node->node.use.h;
+        auto vw = (symbol.hasViewBox ? symbol.vw : width);
+        auto vh = (symbol.hasViewBox ? symbol.vh : height);
 
         Matrix mViewBox = {1, 0, 0, 0, 1, 0, 0, 0, 1};
-        if ((!mathEqual(width, symbol.vw) || !mathEqual(height, symbol.vh)) && symbol.vw > 0 && symbol.vh > 0) {
-            auto sx = width / symbol.vw;
-            auto sy = height / symbol.vh;
+        if ((!mathEqual(width, vw) || !mathEqual(height, vh)) && vw > 0 && vh > 0) {
+            auto sx = width / vw;
+            auto sy = height / vh;
             if (symbol.preserveAspect) {
                 if (sx < sy) sy = sx;
                 else sx = sy;
@@ -592,8 +594,8 @@ static unique_ptr<Scene> _useBuildHelper(const SvgNode* node, const Box& vBox, c
 
             auto tvx = symbol.vx * sx;
             auto tvy = symbol.vy * sy;
-            auto tvw = symbol.vw * sx;
-            auto tvh = symbol.vh * sy;
+            auto tvw = vw * sx;
+            auto tvh = vh * sy;
             tvy -= (symbol.h - tvh) * 0.5f;
             tvx -= (symbol.w - tvw) * 0.5f;
             mViewBox = {sx, 0, -tvx, 0, sy, -tvy, 0, 0, 1};


### PR DESCRIPTION
issue #1183 
