### PR TITLE
common: viewport values improperly rounded

### DIFF
--- a/src/lib/tvgPaint.cpp
+++ b/src/lib/tvgPaint.cpp
@@ -79,8 +79,8 @@ static bool _compFastTrack(Paint* cmpTarget, const RenderTransform* pTransform, 
 
         viewport.x = static_cast<int32_t>(v1.x);
         viewport.y = static_cast<int32_t>(v1.y);
-        viewport.w = static_cast<int32_t>(v2.x - v1.x + 0.5f);
-        viewport.h = static_cast<int32_t>(v2.y - v1.y + 0.5f);
+        viewport.w = static_cast<int32_t>(ceil(v2.x - viewport.x));
+        viewport.h = static_cast<int32_t>(ceil(v2.y - viewport.y));
 
         if (viewport.w < 0) viewport.w = 0;
         if (viewport.h < 0) viewport.h = 0;


### PR DESCRIPTION
For a very specific scaling factors shapes were to much clipped
because of wrong rounding of the viewport.

example:
```
<svg viewBox="0 0 80 20" xmlns="http://www.w3.org/2000/svg">
  <clipPath id="myClip">
    <rect  width="12" height="12" x="4" y="4"/>
  </clipPath>

  <circle clip-path="url(#myClip)"  cx="10" cy="10" r="6" />
</svg>
```

before:
![viewBefore2](https://user-images.githubusercontent.com/67589014/155864662-749199ac-1b27-47b4-9f2f-dc8aa1f9642c.png)

after:
![viewAfter](https://user-images.githubusercontent.com/67589014/155864670-07dc8175-1fb4-48a5-8884-bb6705294afa.png)

