### PR TITLE
sw_engine: fixing oveflow

### DIFF
--- a/src/lib/sw_engine/tvgSwCommon.h
+++ b/src/lib/sw_engine/tvgSwCommon.h
@@ -99,9 +99,9 @@ struct SwSize
 struct SwOutline
 {
     SwPoint*      pts;              //the outline's points
-    uint16_t      ptsCnt;           //number of points in the glyph
-    uint16_t      reservedPtsCnt;
-    uint16_t*     cntrs;            //the contour end points
+    uint32_t      ptsCnt;           //number of points in the glyph
+    uint32_t      reservedPtsCnt;
+    uint32_t*     cntrs;            //the contour end points
     uint16_t      cntrsCnt;         //number of contours in glyph
     uint16_t      reservedCntrsCnt;
     uint8_t*      types;            //curve type

--- a/src/lib/sw_engine/tvgSwImage.cpp
+++ b/src/lib/sw_engine/tvgSwImage.cpp
@@ -46,7 +46,7 @@ static bool _genOutline(SwImage* image, const Matrix* transform, SwMpool* mpool,
 
     if (outline->reservedCntrsCnt < 1) {
         outline->reservedCntrsCnt = 1;
-        outline->cntrs = static_cast<uint16_t*>(realloc(outline->cntrs, outline->reservedCntrsCnt * sizeof(uint16_t)));
+        outline->cntrs = static_cast<uint32_t*>(realloc(outline->cntrs, outline->reservedCntrsCnt * sizeof(uint32_t)));
         outline->closed = static_cast<bool*>(realloc(outline->closed, outline->reservedCntrsCnt * sizeof(bool)));
         outline->closed[0] = true;
     }

--- a/src/lib/sw_engine/tvgSwShape.cpp
+++ b/src/lib/sw_engine/tvgSwShape.cpp
@@ -64,7 +64,7 @@ static bool _growOutlineContour(SwOutline& outline, uint32_t n)
 {
     if (outline.reservedCntrsCnt >= outline.cntrsCnt + n) return false;
     outline.reservedCntrsCnt = outline.cntrsCnt + n;
-    outline.cntrs = static_cast<uint16_t*>(realloc(outline.cntrs, outline.reservedCntrsCnt * sizeof(uint16_t)));
+    outline.cntrs = static_cast<uint32_t*>(realloc(outline.cntrs, outline.reservedCntrsCnt * sizeof(uint32_t)));
     return true;
 }
 

--- a/src/lib/sw_engine/tvgSwStroke.cpp
+++ b/src/lib/sw_engine/tvgSwStroke.cpp
@@ -780,7 +780,7 @@ static void _exportBorderOutline(const SwStroke& stroke, SwOutline* outline, uin
     auto src = border->tags;
     auto tags = outline->types + outline->ptsCnt;
     auto cntrs = outline->cntrs + outline->cntrsCnt;
-    uint16_t idx = outline->ptsCnt;
+    auto idx = outline->ptsCnt;
 
     while (cnt > 0) {
 
@@ -921,7 +921,7 @@ SwOutline* strokeExportOutline(SwStroke* stroke, SwMpool* mpool, unsigned tid)
         outline->reservedPtsCnt = ptsCnt;
     }
     if (outline->reservedCntrsCnt < cntrsCnt) {
-        outline->cntrs = static_cast<uint16_t*>(realloc(outline->cntrs, sizeof(uint16_t) * cntrsCnt));
+        outline->cntrs = static_cast<uint32_t*>(realloc(outline->cntrs, sizeof(uint32_t) * cntrsCnt));
         outline->reservedCntrsCnt = cntrsCnt;
     }
 


### PR DESCRIPTION
An overflow occurred for big shapes with a dashed stroke,
since a contour end points were stored as the uint16 type
(instead of the uint32 type).

example:
```
    if (!canvas) return;

    auto shape = tvg::Shape::gen();
    shape->appendCircle(400, 400, 200, 200);
    shape->appendCircle(400, 400, 198, 198);
    shape->appendCircle(400, 400, 196, 196);
    shape->appendCircle(400, 400, 194, 194);
    shape->appendCircle(400, 400, 192, 192);
    shape->appendCircle(400, 400, 190, 190);
    shape->appendCircle(400, 400, 188, 188);
    shape->appendCircle(400, 400, 186, 186);
    shape->appendCircle(400, 400, 184, 184);
    shape->appendCircle(400, 400, 182, 182);
    shape->appendCircle(400, 400, 180, 180);

    shape->stroke(0, 255, 0, 255);
    shape->stroke(1.0);
    float dashPattern[2] = {1.1, 1.1};
    shape->stroke(dashPattern, 2);

    if (canvas->push(move(shape)) != tvg::Result::Success) return;
```

before:
![before](https://user-images.githubusercontent.com/67589014/159589986-618fd927-3977-436b-925e-6d545b59a28f.png)

after:
![after](https://user-images.githubusercontent.com/67589014/159590011-c38b7f7d-f142-4b5d-afeb-1323fe4f0ce0.png)

