### PR TITLE
svg_loader: fixing segf when passing a nullptr to strcmp

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -2874,7 +2874,7 @@ static SvgStyleGradient* _gradientDup(Array<SvgStyleGradient*>* gradients, const
     auto gradList = gradients->data;
 
     for (uint32_t i = 0; i < gradients->count; ++i) {
-        if (!strcmp((*gradList)->id, id)) {
+        if ((*gradList)->id && !strcmp((*gradList)->id, id)) {
             result = _cloneGradient(*gradList);
             break;
         }
@@ -2884,7 +2884,7 @@ static SvgStyleGradient* _gradientDup(Array<SvgStyleGradient*>* gradients, const
     if (result && result->ref) {
         gradList = gradients->data;
         for (uint32_t i = 0; i < gradients->count; ++i) {
-            if (!strcmp((*gradList)->id, result->ref)) {
+            if ((*gradList)->id && !strcmp((*gradList)->id, result->ref)) {
                 if (result->stops.count == 0) _cloneGradStops(result->stops, (*gradList)->stops);
                 //TODO: Properly inherit other property
                 break;


### PR DESCRIPTION
This occurred when a gradient has no 'id' attribute.

issue #1211 