### PR TITLE
svg_loader: Fix invaild '<' nested check

### DIFF
--- a/src/loaders/svg/tvgXmlParser.cpp
+++ b/src/loaders/svg/tvgXmlParser.cpp
@@ -388,7 +388,7 @@ bool simpleXmlParse(const char* buf, unsigned bufLength, bool strip, simpleXMLCb
 
             if (p) {
                 //Invalid case: '<' nested
-                if (*p == '<') return false;
+                if (*p == '<' && type != SimpleXMLType::Doctype) return false;
                 const char *start, *end;
 
                 start = itr + 1 + toff;


### PR DESCRIPTION
When Type is DOCTYPE, Child Entities start with '<'.
This condition is valid when general Elements (svg, g, path etc) are used.
Add a Doctype check to if condition.
(There can be various cases related to '<' nested case.
But for now, I only add Doctype considering the side effect.)