### PR TITLE
Fix alloca on FreeBSD

### DIFF
--- a/src/loaders/svg/tvgXmlParser.cpp
+++ b/src/loaders/svg/tvgXmlParser.cpp
@@ -26,6 +26,8 @@
 
 #ifdef _WIN32
     #include <malloc.h>
+#elif __FreeBSD__
+    #include<stdlib.h>
 #else
     #include <alloca.h>
 #endif


### PR DESCRIPTION
Fix compile errors on FreeBSD.
- alloca is defined in stdlib.h on [freeBSD](https://www.freebsd.org/cgi/man.cgi?alloca)
Issue in [godot](https://cirrus-ci.com/task/5485473287110656?logs=build#L657)