### PR TITLE
fix FreeBSD compile issue.

### DIFF
--- a/src/lib/sw_engine/tvgSwRaster.cpp
+++ b/src/lib/sw_engine/tvgSwRaster.cpp
@@ -19,6 +19,15 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+
+#ifdef _WIN32
+    #include <malloc.h>
+#elif __FreeBSD__
+    #include<stdlib.h>
+#else
+    #include <alloca.h>
+#endif
+
 #include "tvgMath.h"
 #include "tvgRender.h"
 #include "tvgSwCommon.h"

--- a/src/loaders/tvg/tvgTvgBinInterpreter.cpp
+++ b/src/loaders/tvg/tvgTvgBinInterpreter.cpp
@@ -23,6 +23,8 @@
 
 #ifdef _WIN32
     #include <malloc.h>
+#elif __FreeBSD__
+    #include<stdlib.h>
 #else
     #include <alloca.h>
 #endif

--- a/src/savers/tvg/tvgTvgSaver.cpp
+++ b/src/savers/tvg/tvgTvgSaver.cpp
@@ -28,6 +28,8 @@
 
 #ifdef _WIN32
     #include <malloc.h>
+#elif __FreeBSD__
+    #include<stdlib.h>
 #else
     #include <alloca.h>
 #endif


### PR DESCRIPTION
alloca is defined in stdlib.h on [freeBSD](https://www.freebsd.org/cgi/man.cgi?alloca)

additional fix to 75c1314ab0297f59cc26b7876d7b60e751d4d85c