### PR TITLE
Cleanup FreeBSD preprocessor checks (if vs ifdef)

### DIFF
--- a/src/lib/sw_engine/tvgSwRaster.cpp
+++ b/src/lib/sw_engine/tvgSwRaster.cpp
@@ -22,8 +22,8 @@
 
 #ifdef _WIN32
     #include <malloc.h>
-#elif __FreeBSD__
-    #include<stdlib.h>
+#elif defined(__FreeBSD__)
+    #include <stdlib.h>
 #else
     #include <alloca.h>
 #endif

--- a/src/loaders/svg/tvgXmlParser.cpp
+++ b/src/loaders/svg/tvgXmlParser.cpp
@@ -26,8 +26,8 @@
 
 #ifdef _WIN32
     #include <malloc.h>
-#elif __FreeBSD__
-    #include<stdlib.h>
+#elif defined(__FreeBSD__)
+    #include <stdlib.h>
 #else
     #include <alloca.h>
 #endif

--- a/src/loaders/tvg/tvgTvgBinInterpreter.cpp
+++ b/src/loaders/tvg/tvgTvgBinInterpreter.cpp
@@ -23,8 +23,8 @@
 
 #ifdef _WIN32
     #include <malloc.h>
-#elif __FreeBSD__
-    #include<stdlib.h>
+#elif defined(__FreeBSD__)
+    #include <stdlib.h>
 #else
     #include <alloca.h>
 #endif

--- a/src/savers/tvg/tvgTvgSaver.cpp
+++ b/src/savers/tvg/tvgTvgSaver.cpp
@@ -28,8 +28,8 @@
 
 #ifdef _WIN32
     #include <malloc.h>
-#elif __FreeBSD__
-    #include<stdlib.h>
+#elif defined(__FreeBSD__)
+    #include <stdlib.h>
 #else
     #include <alloca.h>
 #endif


### PR DESCRIPTION
Should be equivalent but checking if the value is defined (`#ifdef`) is cleaner
than checking if it is set to something different from 0 (`#if`).