### PR TITLE
fix OpenBSD compile issue (alloca strikes again)

### DIFF
--- a/src/lib/sw_engine/tvgSwRaster.cpp
+++ b/src/lib/sw_engine/tvgSwRaster.cpp
@@ -22,10 +22,10 @@
 
 #ifdef _WIN32
     #include <malloc.h>
-#elif defined(__FreeBSD__)
-    #include <stdlib.h>
-#else
+#elif defined(__linux__)
     #include <alloca.h>
+#else
+    #include <stdlib.h>
 #endif
 
 #include "tvgMath.h"

--- a/src/loaders/svg/tvgXmlParser.cpp
+++ b/src/loaders/svg/tvgXmlParser.cpp
@@ -26,10 +26,10 @@
 
 #ifdef _WIN32
     #include <malloc.h>
-#elif defined(__FreeBSD__)
-    #include <stdlib.h>
-#else
+#elif defined(__linux__)
     #include <alloca.h>
+#else
+    #include <stdlib.h>
 #endif
 
 #include "tvgXmlParser.h"

--- a/src/loaders/tvg/tvgTvgBinInterpreter.cpp
+++ b/src/loaders/tvg/tvgTvgBinInterpreter.cpp
@@ -23,10 +23,10 @@
 
 #ifdef _WIN32
     #include <malloc.h>
-#elif defined(__FreeBSD__)
-    #include <stdlib.h>
-#else
+#elif defined(__linux__)
     #include <alloca.h>
+#else
+    #include <stdlib.h>
 #endif
 
 #include "tvgTvgCommon.h"

--- a/src/savers/tvg/tvgTvgSaver.cpp
+++ b/src/savers/tvg/tvgTvgSaver.cpp
@@ -28,10 +28,10 @@
 
 #ifdef _WIN32
     #include <malloc.h>
-#elif defined(__FreeBSD__)
-    #include <stdlib.h>
-#else
+#elif defined(__linux__)
     #include <alloca.h>
+#else
+    #include <stdlib.h>
 #endif
 
 static FILE* _fopen(const char* filename, const char* mode)


### PR DESCRIPTION
This is a similar, slightly more generic way to fix the issue (partially) fixed in #1223 and #1224.  I've found this issue trying to build Godot on OpenBSD.

Linux seems the only system AFAICS to provide `alloca.h`.  All the BSDs have the declaration in `stdlib.h`.

Truth be told, we could just as well use `stdlib.h` on linux too (at least when building on glibc) but [the alloca manpage for linux](https://man.voidlinux.org/alloca#Notes_on_the_GNU_version) lists some caveats that I don't know if apply in this case (and I don't have a linux machine at hand to properly test.)