### PR TITLE
sw_engine: Fix uninitialized variable

### DIFF
--- a/src/lib/sw_engine/tvgSwRasterTexmapInternal.h
+++ b/src/lib/sw_engine/tvgSwRasterTexmapInternal.h
@@ -30,7 +30,7 @@
     int32_t dw = surface->stride;
     int32_t x1, x2, x, y, ar, ab, iru, irv, px, ay;
     int32_t vv = 0, uu = 0;
-    int32_t minx, maxx;
+    int32_t minx = INT32_MAX, maxx = INT32_MIN;
     float dx, u, v, iptr;
     uint32_t* buf;
     SwSpan* span = nullptr;         //used only when rle based.


### PR DESCRIPTION
warning message
[35/42] Compiling C++ object src/libthorvg-0.dll.p/lib_sw_engine_tvgSwRaster.cpp.obj
In file included from ../src/lib/sw_engine/tvgSwRasterTexmap.h:96,
                 from ../src/lib/sw_engine/tvgSwRaster.cpp:83:
../src/lib/sw_engine/tvgSwRasterTexmapInternal.h: In function 'void _rasterPolygonImageSegment(SwSurface*, const SwImage*, const SwBBox*, int, int, uint32_t (*)(uint32_t), AASpans*)':
../src/lib/sw_engine/tvgSwRasterTexmapInternal.h:76:9: warning: 'maxx' may be used uninitialized [-Wmaybe-uninitialized]
   76 |         if (x2 > maxx) x2 = maxx;
      |         ^~
../src/lib/sw_engine/tvgSwRasterTexmapInternal.h:33:19: note: 'maxx' was declared here
   33 |     int32_t minx, maxx;
      |                   ^~~~
../src/lib/sw_engine/tvgSwRasterTexmapInternal.h:75:9: warning: 'minx' may be used uninitialized [-Wmaybe-uninitialized]
   75 |         if (x1 < minx) x1 = minx;
      |         ^~
../src/lib/sw_engine/tvgSwRasterTexmapInternal.h:33:13: note: 'minx' was declared here
   33 |     int32_t minx, maxx;
      |             ^~~~


related issue https://github.com/Samsung/thorvg/issues/1236