### PR TITLE
Fix compiler warnings on windows

### DIFF
--- a/src/loaders/jpg/tvgJpgLoader.cpp
+++ b/src/loaders/jpg/tvgJpgLoader.cpp
@@ -118,9 +118,9 @@ unique_ptr<Surface> JpgLoader::bitmap()
 
     auto surface = static_cast<Surface*>(malloc(sizeof(Surface)));
     surface->buffer = (uint32_t*)(image);
-    surface->stride = w;
-    surface->w = w;
-    surface->h = h;
+    surface->stride = static_cast<uint32_t>(w);
+    surface->w = static_cast<uint32_t>(w);
+    surface->h = static_cast<uint32_t>(h);
     surface->cs = SwCanvas::ARGB8888;
 
     return unique_ptr<Surface>(surface);

--- a/src/loaders/jpg/tvgJpgd.cpp
+++ b/src/loaders/jpg/tvgJpgd.cpp
@@ -808,7 +808,7 @@ inline int jpeg_decoder::huff_decode(huff_tables *pH, int& extra_bits)
 
 // Tables and macro used to fully decode the DPCM differences.
 static const int s_extend_test[16] = { 0, 0x0001, 0x0002, 0x0004, 0x0008, 0x0010, 0x0020, 0x0040, 0x0080, 0x0100, 0x0200, 0x0400, 0x0800, 0x1000, 0x2000, 0x4000 };
-static const unsigned int s_extend_offset[16] = { 0, ((-1u)<<1) + 1, ((-1u)<<2) + 1, ((-1u)<<3) + 1, ((-1u)<<4) + 1, ((-1u)<<5) + 1, ((-1u)<<6) + 1, ((-1u)<<7) + 1, ((-1u)<<8) + 1, ((-1u)<<9) + 1, ((-1u)<<10) + 1, ((-1u)<<11) + 1, ((-1u)<<12) + 1, ((-1u)<<13) + 1, ((-1u)<<14) + 1, ((-1u)<<15) + 1 };
+static const unsigned int s_extend_offset[16] = { 0, ((~0u)<<1) + 1, ((~0u)<<2) + 1, ((~0u)<<3) + 1, ((~0u)<<4) + 1, ((~0u)<<5) + 1, ((~0u)<<6) + 1, ((~0u)<<7) + 1, ((~0u)<<8) + 1, ((~0u)<<9) + 1, ((~0u)<<10) + 1, ((~0u)<<11) + 1, ((~0u)<<12) + 1, ((~0u)<<13) + 1, ((~0u)<<14) + 1, ((~0u)<<15) + 1 };
 
 // The logical AND's in this macro are to shut up static code analysis (aren't really necessary - couldn't find another way to do this)
 #define JPGD_HUFF_EXTEND(x, s) (((x) < s_extend_test[s & 15]) ? ((x) + s_extend_offset[s & 15]) : (x))

--- a/src/loaders/png/tvgPngLoader.cpp
+++ b/src/loaders/png/tvgPngLoader.cpp
@@ -170,9 +170,9 @@ unique_ptr<Surface> PngLoader::bitmap()
 
     auto surface = static_cast<Surface*>(malloc(sizeof(Surface)));
     surface->buffer = (uint32_t*)(image);
-    surface->stride = w;
-    surface->w = w;
-    surface->h = h;
+    surface->stride = static_cast<uint32_t>(w);
+    surface->w = static_cast<uint32_t>(w);
+    surface->h = static_cast<uint32_t>(h);
     surface->cs = SwCanvas::ARGB8888;
 
     return unique_ptr<Surface>(surface);

--- a/test/testScene.cpp
+++ b/test/testScene.cpp
@@ -41,9 +41,9 @@ TEST_CASE("Pushing Paints Into Scene", "[tvgScene]")
     REQUIRE(scene);
 
     //Pushing Paints
-    REQUIRE(scene->push(move(Shape::gen())) == Result::Success);
-    REQUIRE(scene->push(move(Picture::gen())) == Result::Success);
-    REQUIRE(scene->push(move(Scene::gen())) == Result::Success);
+    REQUIRE(scene->push(Shape::gen()) == Result::Success);
+    REQUIRE(scene->push(Picture::gen()) == Result::Success);
+    REQUIRE(scene->push(Scene::gen()) == Result::Success);
 
     //Pushing Null Pointer
     REQUIRE(scene->push(nullptr) == Result::MemoryCorruption);
@@ -70,7 +70,7 @@ TEST_CASE("Scene Clear", "[tvgScene]")
     auto scene = Scene::gen();
     REQUIRE(scene);
 
-    REQUIRE(scene->push(move(Shape::gen())) == Result::Success);
+    REQUIRE(scene->push(Shape::gen()) == Result::Success);
     REQUIRE(scene->clear() == Result::Success);
 }
 

--- a/test/testSwCanvas.cpp
+++ b/test/testSwCanvas.cpp
@@ -88,7 +88,7 @@ TEST_CASE("Memory Pool", "[tvgSwCanvas]")
     REQUIRE(canvas2->mempool(SwCanvas::MempoolPolicy::Shareable) == Result::Success);
     REQUIRE(canvas2->mempool(SwCanvas::MempoolPolicy::Shareable) == Result::Success);
 
-    REQUIRE(canvas2->push(move(Shape::gen())) == Result::Success);
+    REQUIRE(canvas2->push(Shape::gen()) == Result::Success);
     REQUIRE(canvas2->mempool(SwCanvas::MempoolPolicy::Individual) == Result::InsufficientCondition);
 
     REQUIRE(Initializer::term(CanvasEngine::Sw) == Result::Success);

--- a/test/testSwCanvasBase.cpp
+++ b/test/testSwCanvasBase.cpp
@@ -53,19 +53,19 @@ TEST_CASE("Pushing Paints", "[tvgSwCanvasBase]")
     REQUIRE(canvas->target(buffer, 100, 100, 100, SwCanvas::Colorspace::ARGB8888) == Result::Success);
 
     //Try all types of paints.
-    REQUIRE(canvas->push(move(Shape::gen())) == Result::Success);
-    REQUIRE(canvas->push(move(Picture::gen())) == Result::Success);
-    REQUIRE(canvas->push(move(Scene::gen())) == Result::Success);
+    REQUIRE(canvas->push(Shape::gen()) == Result::Success);
+    REQUIRE(canvas->push(Picture::gen()) == Result::Success);
+    REQUIRE(canvas->push(Scene::gen()) == Result::Success);
 
     //Cases by contexts.
     REQUIRE(canvas->update() == Result::Success);
 
-    REQUIRE(canvas->push(move(Shape::gen())) == Result::Success);
-    REQUIRE(canvas->push(move(Shape::gen())) == Result::Success);
+    REQUIRE(canvas->push(Shape::gen()) == Result::Success);
+    REQUIRE(canvas->push(Shape::gen()) == Result::Success);
 
     REQUIRE(canvas->clear() == Result::Success);
 
-    REQUIRE(canvas->push(move(Shape::gen())) == Result::Success);
+    REQUIRE(canvas->push(Shape::gen()) == Result::Success);
 
     //Negative case 1
     REQUIRE(canvas->push(nullptr) == Result::MemoryCorruption);
@@ -75,9 +75,9 @@ TEST_CASE("Pushing Paints", "[tvgSwCanvasBase]")
     REQUIRE(canvas->push(move(shape6)) == Result::MemoryCorruption);
 
     //Negative case 3
-    REQUIRE(canvas->push(move(Shape::gen())) == Result::Success);
+    REQUIRE(canvas->push(Shape::gen()) == Result::Success);
     REQUIRE(canvas->draw() == Result::Success);
-    REQUIRE(canvas->push(move(Shape::gen())) == Result::InsufficientCondition);
+    REQUIRE(canvas->push(Shape::gen()) == Result::InsufficientCondition);
 
     REQUIRE(Initializer::term(CanvasEngine::Sw) == Result::Success);
 }
@@ -104,7 +104,7 @@ TEST_CASE("Clear", "[tvgSwCanvasBase]")
 
     //Try 1: Push -> Clear
     for (int i = 0; i < 5; ++i) {
-        REQUIRE(canvas->push(move(Shape::gen())) == Result::Success);
+        REQUIRE(canvas->push(Shape::gen()) == Result::Success);
 
         auto shape2 = Shape::gen();
         REQUIRE(shape2);
@@ -123,7 +123,7 @@ TEST_CASE("Clear", "[tvgSwCanvasBase]")
 
     //Try 2: Push -> Update -> Clear
     for (int i = 0; i < 5; ++i) {
-        REQUIRE(canvas->push(move(Shape::gen())) == Result::Success);
+        REQUIRE(canvas->push(Shape::gen()) == Result::Success);
 
         auto shape2 = Shape::gen();
         REQUIRE(shape2);
@@ -157,7 +157,7 @@ TEST_CASE("Update", "[tvgSwCanvasBase]")
 
     REQUIRE(canvas->update() == Result::InsufficientCondition);
 
-    REQUIRE(canvas->push(move(Shape::gen())) == Result::Success);
+    REQUIRE(canvas->push(Shape::gen()) == Result::Success);
 
     //No pushed shape
     auto shape = Shape::gen();


### PR DESCRIPTION
Fixed compiler warnings that occur with MSVC (cl) and with LLVM (clang-cl) on windows.

- Conversion from float to uint32_t
- Negating an unsigned (tvgJpgd.cpp). Note that (-1u) and (~0u) are identical. They both set all bits of unsigned to 1 to give max unsigned, but `-1u` gives a compiler warning whereas `~0u` does not.
- Calling `scene->push(move(Shape::gen())` results in a `moving temporary variable prevents copy elision` warning. The move is not required here.