### PR TITLE
svg_loader: preserveAspectRatio attrib handled according to the svg standard

### DIFF
--- a/src/lib/tvgLoadModule.h
+++ b/src/lib/tvgLoadModule.h
@@ -36,7 +36,6 @@ public:
     float vw = 0;
     float vh = 0;
     float w = 0, h = 0;         //default image size
-    bool preserveAspect = true; //keep aspect ratio by default.
 
     virtual ~LoadModule() {}
 

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -115,8 +115,52 @@ static bool _parseNumber(const char** content, float* number)
     if ((*content) == end) return false;
     //Skip comma if any
     *content = _skipComma(end);
+
     return true;
 }
+
+
+static constexpr struct
+{
+    AspectRatioAlign align;
+    const char* tag;
+} alignTags[] = {
+    { AspectRatioAlign::XMinYMin, "xMinYMin" },
+    { AspectRatioAlign::XMidYMin, "xMidYMin" },
+    { AspectRatioAlign::XMaxYMin, "xMaxYMin" },
+    { AspectRatioAlign::XMinYMid, "xMinYMid" },
+    { AspectRatioAlign::XMidYMid, "xMidYMid" },
+    { AspectRatioAlign::XMaxYMid, "xMaxYMid" },
+    { AspectRatioAlign::XMinYMax, "xMinYMax" },
+    { AspectRatioAlign::XMidYMax, "xMidYMax" },
+    { AspectRatioAlign::XMaxYMax, "xMaxYMax" },
+};
+
+
+static bool _parseAspectRatio(const char** content, AspectRatioAlign* align, AspectRatioMeetOrSlice* meetOrSlice)
+{
+    if (!strcmp(*content, "none")) {
+        *align = AspectRatioAlign::None;
+        return true;
+    }
+
+    for (unsigned int i = 0; i < sizeof(alignTags) / sizeof(alignTags[0]); i++) {
+        if (!strncmp(*content, alignTags[i].tag, 8)) {
+            *align = alignTags[i].align;
+            *content += 8;
+            *content = _skipSpace(*content, nullptr);
+            break;
+        }
+    }
+
+    if (!strcmp(*content, "meet"))
+        *meetOrSlice = AspectRatioMeetOrSlice::Meet;
+    else if (!strcmp(*content, "slice"))
+        *meetOrSlice = AspectRatioMeetOrSlice::Slice;
+
+    return true;
+}
+
 
 /**
  * According to https://www.w3.org/TR/SVG/coords.html#Units
@@ -802,7 +846,7 @@ static bool _attrParseSvgNode(void* data, const char* key, const char* value)
         }
         loader->svgParse->global.x = (int)doc->vx;
     } else if (!strcmp(key, "preserveAspectRatio")) {
-        if (!strcmp(value, "none")) doc->preserveAspect = false;
+        _parseAspectRatio(&value, &doc->align, &doc->meetOrSlice);
     } else if (!strcmp(key, "style")) {
         return simpleXmlParseW3CAttribute(value, strlen(value), _parseStyleAttr, loader);
 #ifdef THORVG_LOG_ENABLED
@@ -1156,7 +1200,7 @@ static bool _attrParseSymbolNode(void* data, const char* key, const char* value)
         symbol->h = _toFloat(loader->svgParse, value, SvgParserLengthType::Vertical);
         symbol->hasHeight = true;
     } else if (!strcmp(key, "preserveAspectRatio")) {
-        if (!strcmp(value, "none")) symbol->preserveAspect = false;
+        _parseAspectRatio(&value, &symbol->align, &symbol->meetOrSlice);
     } else if (!strcmp(key, "overflow")) {
         if (!strcmp(value, "visible")) symbol->overflowVisible = true;
     } else {
@@ -1248,7 +1292,8 @@ static SvgNode* _createSvgNode(SvgLoaderData* loader, SvgNode* parent, const cha
     loader->svgParse->global.w = 0;
     loader->svgParse->global.h = 0;
 
-    doc->preserveAspect = true;
+    doc->align = AspectRatioAlign::XMidYMid;
+    doc->meetOrSlice = AspectRatioMeetOrSlice::Meet;
     func(buf, bufLength, _attrParseSvgNode, loader);
 
     if (loader->svgParse->global.w == 0) {
@@ -1309,7 +1354,8 @@ static SvgNode* _createSymbolNode(SvgLoaderData* loader, SvgNode* parent, const 
     if (!loader->svgParse->node) return nullptr;
 
     loader->svgParse->node->display = false;
-    loader->svgParse->node->node.symbol.preserveAspect = true;
+    loader->svgParse->node->node.symbol.align = AspectRatioAlign::XMidYMid;
+    loader->svgParse->node->node.symbol.meetOrSlice = AspectRatioMeetOrSlice::Meet;
     loader->svgParse->node->node.symbol.overflowVisible = false;
 
     loader->svgParse->node->node.symbol.hasViewBox = false;
@@ -3127,7 +3173,7 @@ void SvgLoader::run(unsigned tid)
 
         _updateStyle(loaderData.doc, nullptr);
     }
-    root = svgSceneBuild(loaderData.doc, vx, vy, vw, vh, w, h, preserveAspect, svgPath);
+    root = svgSceneBuild(loaderData.doc, vx, vy, vw, vh, w, h, align, meetOrSlice, svgPath);
 }
 
 
@@ -3160,7 +3206,8 @@ bool SvgLoader::header()
             if (vh < FLT_EPSILON) vh = h;
         }
 
-        preserveAspect = loaderData.doc->node.doc.preserveAspect;
+        align = loaderData.doc->node.doc.align;
+        meetOrSlice = loaderData.doc->node.doc.meetOrSlice;
     } else {
         TVGLOG("SVG", "No SVG File. There is no <svg/>");
         return false;
@@ -3216,30 +3263,19 @@ bool SvgLoader::resize(Paint* paint, float w, float h)
     auto sx = w / this->w;
     auto sy = h / this->h;
 
-    if (preserveAspect) {
-        //Scale
-        auto scale = sx < sy ? sx : sy;
-        paint->scale(scale);
-        //Align
-        auto tx = 0.0f;
-        auto ty = 0.0f;
-        auto tw = this->w * scale;
-        auto th = this->h * scale;
-        if (tw > th) ty -= (h - th) * 0.5f;
-        else tx -= (w - tw) * 0.5f;
-        paint->translate(-tx, -ty);
-    } else {
-        //Align
-        auto tx = 0.0f;
-        auto ty = 0.0f;
-        auto tw = this->w * sx;
-        auto th = this->h * sy;
-        if (tw > th) ty -= (h - th) * 0.5f;
-        else tx -= (w - tw) * 0.5f;
-
-        Matrix m = {sx, 0, -tx, 0, sy, -ty, 0, 0, 1};
+    if (align == AspectRatioAlign::None) {
+        Matrix m = {sx, 0, 0, 0, sy, 0, 0, 0, 1};
         paint->transform(m);
+    } else {
+        float scale;
+        if (meetOrSlice == AspectRatioMeetOrSlice::Meet)
+            scale = sx < sy ? sx : sy;
+        else
+            scale = sx < sy ? sy : sx;
+
+        paint->scale(scale);
     }
+
     return true;
 }
 

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -153,10 +153,11 @@ static bool _parseAspectRatio(const char** content, AspectRatioAlign* align, Asp
         }
     }
 
-    if (!strcmp(*content, "meet"))
+    if (!strcmp(*content, "meet")) {
         *meetOrSlice = AspectRatioMeetOrSlice::Meet;
-    else if (!strcmp(*content, "slice"))
+    } else if (!strcmp(*content, "slice")) {
         *meetOrSlice = AspectRatioMeetOrSlice::Slice;
+    }
 
     return true;
 }
@@ -3262,19 +3263,8 @@ bool SvgLoader::resize(Paint* paint, float w, float h)
 
     auto sx = w / this->w;
     auto sy = h / this->h;
-
-    if (align == AspectRatioAlign::None) {
-        Matrix m = {sx, 0, 0, 0, sy, 0, 0, 0, 1};
-        paint->transform(m);
-    } else {
-        float scale;
-        if (meetOrSlice == AspectRatioMeetOrSlice::Meet)
-            scale = sx < sy ? sx : sy;
-        else
-            scale = sx < sy ? sy : sx;
-
-        paint->scale(scale);
-    }
+    Matrix m = {sx, 0, 0, 0, sy, 0, 0, 0, 1};
+    paint->transform(m);
 
     return true;
 }

--- a/src/loaders/svg/tvgSvgLoader.h
+++ b/src/loaders/svg/tvgSvgLoader.h
@@ -32,8 +32,6 @@ public:
     string svgPath = "";
     const char* content = nullptr;
     uint32_t size = 0;
-    AspectRatioAlign align = AspectRatioAlign::XMidYMid;
-    AspectRatioMeetOrSlice meetOrSlice = AspectRatioMeetOrSlice::Meet;
 
     SvgLoaderData loaderData;
     unique_ptr<Scene> root;
@@ -52,6 +50,9 @@ public:
     unique_ptr<Paint> paint() override;
 
 private:
+    AspectRatioAlign align = AspectRatioAlign::XMidYMid;
+    AspectRatioMeetOrSlice meetOrSlice = AspectRatioMeetOrSlice::Meet;
+
     bool header();
     void clear();
     void run(unsigned tid) override;

--- a/src/loaders/svg/tvgSvgLoader.h
+++ b/src/loaders/svg/tvgSvgLoader.h
@@ -32,6 +32,8 @@ public:
     string svgPath = "";
     const char* content = nullptr;
     uint32_t size = 0;
+    AspectRatioAlign align;
+    AspectRatioMeetOrSlice meetOrSlice;
 
     SvgLoaderData loaderData;
     unique_ptr<Scene> root;

--- a/src/loaders/svg/tvgSvgLoader.h
+++ b/src/loaders/svg/tvgSvgLoader.h
@@ -32,8 +32,8 @@ public:
     string svgPath = "";
     const char* content = nullptr;
     uint32_t size = 0;
-    AspectRatioAlign align;
-    AspectRatioMeetOrSlice meetOrSlice;
+    AspectRatioAlign align = AspectRatioAlign::XMidYMid;
+    AspectRatioMeetOrSlice meetOrSlice = AspectRatioMeetOrSlice::Meet;
 
     SvgLoaderData loaderData;
     unique_ptr<Scene> root;

--- a/src/loaders/svg/tvgSvgLoaderCommon.h
+++ b/src/loaders/svg/tvgSvgLoaderCommon.h
@@ -145,6 +145,26 @@ enum class SvgParserLengthType
     Other
 };
 
+enum class AspectRatioAlign
+{
+    None,
+    XMinYMin,
+    XMidYMin,
+    XMaxYMin,
+    XMinYMid,
+    XMidYMid,
+    XMaxYMid,
+    XMinYMax,
+    XMidYMax,
+    XMaxYMax
+};
+
+enum class AspectRatioMeetOrSlice
+{
+    Meet,
+    Slice
+};
+
 struct SvgDocNode
 {
     float w;
@@ -155,7 +175,8 @@ struct SvgDocNode
     float vh;
     SvgNode* defs;
     SvgNode* style;
-    bool preserveAspect;
+    AspectRatioAlign align;
+    AspectRatioMeetOrSlice meetOrSlice;
 };
 
 struct SvgGNode
@@ -171,7 +192,8 @@ struct SvgSymbolNode
 {
     float w, h;
     float vx, vy, vw, vh;
-    bool preserveAspect;
+    AspectRatioAlign align;
+    AspectRatioMeetOrSlice meetOrSlice;
     bool overflowVisible;
     bool hasViewBox;
     bool hasWidth;

--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -560,6 +560,80 @@ static unique_ptr<Picture> _imageBuildHelper(SvgNode* node, const Box& vBox, con
 }
 
 
+static Matrix _calculateAspectRatioMatrix(AspectRatioAlign align, AspectRatioMeetOrSlice meetOrSlice, float width, float height, const Box& box)
+{
+    auto sx = width / box.w;
+    auto sy = height / box.h;
+    auto tvx = box.x * sx;
+    auto tvy = box.y * sy;
+
+    if (align == AspectRatioAlign::None)
+        return {sx, 0, -tvx, 0, sy, -tvy, 0, 0, 1};
+
+    //Scale
+    if (meetOrSlice == AspectRatioMeetOrSlice::Meet) {
+        if (sx < sy) sy = sx;
+        else sx = sy;
+    } else {
+        if (sx < sy) sx = sy;
+        else sy = sx;
+    }
+
+    //Align
+    tvx = box.x * sx;
+    tvy = box.y * sy;
+    auto tvw = box.w * sx;
+    auto tvh = box.h * sy;
+
+    switch (align) {
+        case AspectRatioAlign::XMinYMin: {
+            break;
+        }
+        case AspectRatioAlign::XMidYMin: {
+            tvx -= (width - tvw) * 0.5f;
+            break;
+        }
+        case AspectRatioAlign::XMaxYMin: {
+            tvx -= width - tvw;
+            break;
+        }
+        case AspectRatioAlign::XMinYMid: {
+            tvy -= (height - tvh) * 0.5f;
+            break;
+        }
+        case AspectRatioAlign::XMidYMid: {
+            tvx -= (width - tvw) * 0.5f;
+            tvy -= (height - tvh) * 0.5f;
+            break;
+        }
+        case AspectRatioAlign::XMaxYMid: {
+            tvx -= width - tvw;
+            tvy -= (height - tvh) * 0.5f;
+            break;
+        }
+        case AspectRatioAlign::XMinYMax: {
+            tvy -= height - tvh;
+            break;
+        }
+        case AspectRatioAlign::XMidYMax: {
+            tvx -= (width - tvw) * 0.5f;
+            tvy -= height - tvh;
+            break;
+        }
+        case AspectRatioAlign::XMaxYMax: {
+            tvx -= width - tvw;
+            tvy -= height - tvh;
+            break;
+        }
+        default: {
+            break;
+        }
+    }
+
+    return {sx, 0, -tvx, 0, sy, -tvy, 0, 0, 1};
+}
+
+
 static unique_ptr<Scene> _useBuildHelper(const SvgNode* node, const Box& vBox, const string& svgPath, bool* isMaskWhite)
 {
     unique_ptr<Scene> finalScene;
@@ -585,73 +659,8 @@ static unique_ptr<Scene> _useBuildHelper(const SvgNode* node, const Box& vBox, c
 
         Matrix mViewBox = {1, 0, 0, 0, 1, 0, 0, 0, 1};
         if ((!mathEqual(width, vw) || !mathEqual(height, vh)) && vw > 0 && vh > 0) {
-            auto sx = width / vw;
-            auto sy = height / vh;
-            auto tvx = symbol.vx * sx;
-            auto tvy = symbol.vy * sy;
-
-            if (symbol.align != AspectRatioAlign::None) {
-                //Scale
-                if (symbol.meetOrSlice == AspectRatioMeetOrSlice::Meet) {
-                    if (sx < sy) sy = sx;
-                    else sx = sy;
-                } else {
-                    if (sx < sy) sx = sy;
-                    else sy = sx;
-                }
-
-                tvx = symbol.vx * sx;
-                tvy = symbol.vy * sy;
-                auto tvw = vw * sx;
-                auto tvh = vh * sy;
-
-                switch (symbol.align) {
-                    case AspectRatioAlign::XMinYMin: {
-                        break;
-                    }
-                    case AspectRatioAlign::XMidYMin: {
-                        tvx -= (width - tvw) * 0.5f;
-                        break;
-                    }
-                    case AspectRatioAlign::XMaxYMin: {
-                        tvx -= width - tvw;
-                        break;
-                    }
-                    case AspectRatioAlign::XMinYMid: {
-                        tvy -= (height - tvh) * 0.5f;
-                        break;
-                    }
-                    case AspectRatioAlign::XMidYMid: {
-                        tvx -= (width - tvw) * 0.5f;
-                        tvy -= (height - tvh) * 0.5f;
-                        break;
-                    }
-                    case AspectRatioAlign::XMaxYMid: {
-                        tvx -= width - tvw;
-                        tvy -= (height - tvh) * 0.5f;
-                        break;
-                    }
-                    case AspectRatioAlign::XMinYMax: {
-                        tvy -= height - tvh;
-                        break;
-                    }
-                    case AspectRatioAlign::XMidYMax: {
-                        tvx -= (width - tvw) * 0.5f;
-                        tvy -= height - tvh;
-                        break;
-                    }
-                    case AspectRatioAlign::XMaxYMax: {
-                        tvx -= width - tvw;
-                        tvy -= height - tvh;
-                        break;
-                    }
-                    default: {
-                        break;
-                    }
-                }
-            }
-
-            mViewBox = {sx, 0, -tvx, 0, sy, -tvy, 0, 0, 1};
+            Box box = {symbol.vx, symbol.vy, vw, vh};
+            mViewBox = _calculateAspectRatioMatrix(symbol.align, symbol.meetOrSlice, width, height, box);
         } else if (!mathZero(symbol.vx) || !mathZero(symbol.vy)) {
             mViewBox = {1, 0, -symbol.vx, 0, 1, -symbol.vy, 0, 0, 1};
         }
@@ -751,77 +760,8 @@ unique_ptr<Scene> svgSceneBuild(SvgNode* node, float vx, float vy, float vw, flo
     auto docNode = _sceneBuildHelper(node, vBox, svgPath, false);
 
     if (!mathEqual(w, vw) || !mathEqual(h, vh)) {
-        auto sx = w / vw;
-        auto sy = h / vh;
-
-        if (align == AspectRatioAlign::None) {
-            //Align
-            auto tvx = vx * sx;
-            auto tvy = vy * sy;
-            Matrix m = {sx, 0, -tvx, 0, sy, -tvy, 0, 0, 1};
-            docNode->transform(m);
-        } else {
-            //Scale
-            float scale;
-            if (meetOrSlice == AspectRatioMeetOrSlice::Meet)
-                scale = sx < sy ? sx : sy;
-            else
-                scale = sx < sy ? sy : sx;
-            docNode->scale(scale);
-
-            //Align
-            auto tvx = vx * scale;
-            auto tvy = vy * scale;
-            auto tvw = vw * scale;
-            auto tvh = vh * scale;
-
-            switch (align) {
-                case AspectRatioAlign::XMinYMin: {
-                    break;
-                }
-                case AspectRatioAlign::XMidYMin: {
-                    tvx -= (w - tvw) * 0.5f;
-                    break;
-                }
-                case AspectRatioAlign::XMaxYMin: {
-                    tvx -= w - tvw;
-                    break;
-                }
-                case AspectRatioAlign::XMinYMid: {
-                    tvy -= (h - tvh) * 0.5f;
-                    break;
-                }
-                case AspectRatioAlign::XMidYMid: {
-                    tvx -= (w - tvw) * 0.5f;
-                    tvy -= (h - tvh) * 0.5f;
-                    break;
-                }
-                case AspectRatioAlign::XMaxYMid: {
-                    tvx -= w - tvw;
-                    tvy -= (h - tvh) * 0.5f;
-                    break;
-                }
-                case AspectRatioAlign::XMinYMax: {
-                    tvy -= h - tvh;
-                    break;
-                }
-                case AspectRatioAlign::XMidYMax: {
-                    tvx -= (w - tvw) * 0.5f;
-                    tvy -= h - tvh;
-                    break;
-                }
-                case AspectRatioAlign::XMaxYMax: {
-                    tvx -= w - tvw;
-                    tvy -= h - tvh;
-                    break;
-                }
-                default: {
-                    break;
-                }
-            }
-
-            docNode->translate(-tvx, -tvy);
-        }
+        Matrix m = _calculateAspectRatioMatrix(align, meetOrSlice, w, h, vBox);
+        docNode->transform(m);
     } else if (!mathZero(vx) || !mathZero(vy)) {
         docNode->translate(-vx, -vy);
     }

--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -610,39 +610,39 @@ static unique_ptr<Scene> _useBuildHelper(const SvgNode* node, const Box& vBox, c
                         break;
                     }
                     case AspectRatioAlign::XMidYMin: {
-                        tvx -= (symbol.w - tvw) * 0.5f;
+                        tvx -= (width - tvw) * 0.5f;
                         break;
                     }
                     case AspectRatioAlign::XMaxYMin: {
-                        tvx -= symbol.w - tvw;
+                        tvx -= width - tvw;
                         break;
                     }
                     case AspectRatioAlign::XMinYMid: {
-                        tvy -= (symbol.h - tvh) * 0.5f;
+                        tvy -= (height - tvh) * 0.5f;
                         break;
                     }
                     case AspectRatioAlign::XMidYMid: {
-                        tvx -= (symbol.w - tvw) * 0.5f;
-                        tvy -= (symbol.h - tvh) * 0.5f;
+                        tvx -= (width - tvw) * 0.5f;
+                        tvy -= (height - tvh) * 0.5f;
                         break;
                     }
                     case AspectRatioAlign::XMaxYMid: {
-                        tvx -= symbol.w - tvw;
-                        tvy -= (symbol.h - tvh) * 0.5f;
+                        tvx -= width - tvw;
+                        tvy -= (height - tvh) * 0.5f;
                         break;
                     }
                     case AspectRatioAlign::XMinYMax: {
-                        tvy -= symbol.h - tvh;
+                        tvy -= height - tvh;
                         break;
                     }
                     case AspectRatioAlign::XMidYMax: {
-                        tvx -= (symbol.w - tvw) * 0.5f;
-                        tvy -= symbol.h - tvh;
+                        tvx -= (width - tvw) * 0.5f;
+                        tvy -= height - tvh;
                         break;
                     }
                     case AspectRatioAlign::XMaxYMax: {
-                        tvx -= symbol.w - tvw;
-                        tvy -= symbol.h - tvh;
+                        tvx -= width - tvw;
+                        tvy -= height - tvh;
                         break;
                     }
                     default: {

--- a/src/loaders/svg/tvgSvgSceneBuilder.h
+++ b/src/loaders/svg/tvgSvgSceneBuilder.h
@@ -25,6 +25,6 @@
 
 #include "tvgCommon.h"
 
-unique_ptr<Scene> svgSceneBuild(SvgNode* node, float vx, float vy, float vw, float vh, float w, float h, bool preserveAspect, const string& svgPath);
+unique_ptr<Scene> svgSceneBuild(SvgNode* node, float vx, float vy, float vw, float vh, float w, float h, AspectRatioAlign align, AspectRatioMeetOrSlice meetOrSlice, const string& svgPath);
 
 #endif //_TVG_SVG_SCENE_BUILDER_H_


### PR DESCRIPTION
issue #1181 

sample file to test the bug:
```
<svg viewBox="0 0 15 15" xmlns="http://www.w3.org/2000/svg">
  <symbol id="myDot" width="10" height="5" viewBox="0.5 -1 4 4" preserveAspectRatio="none">
    <circle cx="0.1" cy="1" r="2" />
  </symbol>

  <use href="#myDot" x="0" y="5" height="4" style="opacity:0.8" />
  <use href="#myDot" x="5" y="5" width="5" style="opacity:0.6" />
</svg>
```

before:
![before](https://user-images.githubusercontent.com/67589014/185924160-67edfad7-bc23-4c27-bf01-9c69b95efe2f.PNG)

after:
![after](https://user-images.githubusercontent.com/67589014/185924179-b4c2c240-9c2f-4744-b7c9-dcde656f82c9.PNG)


to test the aspect ratio:
```
<svg id="svg1" width="200" height="100" viewBox="0 0 200 200" preserveAspectRatio="xMinYMin slice"
     xmlns="http://www.w3.org/2000/svg">
    <rect id="rect1" x="70" y="20" width="60" height="60" fill="green"/>
    <rect id="frame" x="1" y="1" width="198" height="98" fill="none" stroke="black"/>
</svg>

<svg id="svg1" width="200" height="100" viewBox="0 0 200 200" preserveAspectRatio="none"
     xmlns="http://www.w3.org/2000/svg">
    <rect id="rect1" x="70" y="20" width="60" height="60" fill="green"/>
    <rect id="frame" x="1" y="1" width="198" height="98" fill="none" stroke="black"/>
</svg>

<svg id="svg1" width="200" height="100" viewBox="0 0 200 200" preserveAspectRatio="xMinYMin"
     xmlns="http://www.w3.org/2000/svg">
    <rect id="rect1" x="70" y="20" width="60" height="60" fill="green"/>
    <rect id="frame" x="1" y="1" width="198" height="98" fill="none" stroke="black"/>
</svg>

<svg id="svg1" width="200" height="100" viewBox="0 0 200 200" preserveAspectRatio="xMidYMid  slice"
     xmlns="http://www.w3.org/2000/svg">
    <rect id="rect1" x="70" y="20" width="60" height="60" fill="green"/>
    <rect id="frame" x="1" y="1" width="198" height="98" fill="none" stroke="black"/>
</svg>

<svg id="svg1" width="200" height="100" viewBox="-20 -20 200 200" preserveAspectRatio="xMaxYMax slice"
     xmlns="http://www.w3.org/2000/svg">
    <rect id="rect1" x="70" y="20" width="60" height="60" fill="green"/>
    <rect id="frame" x="1" y="1" width="198" height="98" fill="none" stroke="black"/>
</svg>

<svg id="svg1" width="200" height="100" viewBox="0 0 200 200" preserveAspectRatio="xMidYMid"
     xmlns="http://www.w3.org/2000/svg">
    <rect id="rect1" x="70" y="20" width="60" height="60" fill="green"/>
    <rect id="frame" x="1" y="1" width="198" height="98" fill="none" stroke="black"/>
</svg>

<svg id="svg1" width="200" height="100" viewBox="-50 -100 200 200" preserveAspectRatio="xMinYMin"
     xmlns="http://www.w3.org/2000/svg">
    <rect id="rect1" x="70" y="20" width="60" height="60" fill="green"/>
    <rect id="frame" x="1" y="1" width="198" height="98" fill="none" stroke="black"/>
</svg>

<svg id="svg1" width="200" height="100" viewBox="0 0 200 200" preserveAspectRatio="xMaxYMax"
     xmlns="http://www.w3.org/2000/svg">
    <rect id="rect1" x="70" y="20" width="60" height="60" fill="green"/>
    <rect id="frame" x="1" y="1" width="198" height="98" fill="none" stroke="black"/>
</svg>

<svg id="svg1" width="200" height="100" viewBox="-10 -90 200 200" preserveAspectRatio="xMinYMin slice"
     xmlns="http://www.w3.org/2000/svg">
    <rect id="rect1" x="70" y="20" width="60" height="60" fill="green"/>
    <rect id="frame" x="1" y="1" width="198" height="98" fill="none" stroke="black"/>
</svg>
```

before:
![before_asp](https://user-images.githubusercontent.com/67589014/185926899-2cf58898-cefb-4338-a75e-d98e18b2827d.PNG)

after:
![after_asp](https://user-images.githubusercontent.com/67589014/185926924-d75a29b4-acb4-44ec-a1d3-a3cadbca51e2.PNG)

