### PR TITLE
Fix compilation error on Windows with clang toolchain: M_PI undeclared

### DIFF
--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -49,9 +49,9 @@
 */
 
 
+#include "tvgMath.h" /* to include math.h before cstring */
 #include <cstring>
 #include <string>
-#include "tvgMath.h"
 #include "tvgSvgLoaderCommon.h"
 #include "tvgSvgSceneBuilder.h"
 #include "tvgSvgPath.h"


### PR DESCRIPTION
Fix the error

```
../src/lib/tvgMath.h:52:56: error: use of undeclared identifier 'M_PI_2'
   if (radian < FLT_EPSILON || mathEqual(radian, float(M_PI_2)) || mathEqual(radian, float(M_PI))) return true;
                                                       ^
../src/lib/tvgMath.h:52:92: error: use of undeclared identifier 'M_PI'
   if (radian < FLT_EPSILON || mathEqual(radian, float(M_PI_2)) || mathEqual(radian, float(M_PI))) return true;
                                                                                           ^
../src/lib/tvgMath.h:122:37: error: use of undeclared identifier 'M_PI'
    auto radian = degree / 180.0f * M_PI;
                                    ^
```

Indeed:
* First, on Windows, one must define _USE_MATH_DEFINES before including math.h to get M_PI and other macros.
* tvgSvgSceneBuilder.cpp includes first cstring, which includes math.h, and after, it includes tvgMath.h. So _USE_MATH_DEFINES is not defined when math.h is included from cstring
* when tvgMath.h is included, _USE_MATH_DEFINES is defined, but math.h is not included anymore. Hence the problem.

Solution: in tvgSvgSceneBuilder.cpp, include tvgMath.h before string header files

Fix issue #1252 

