### PR TITLE
svg_loader: fill and stroke paiint url were copied twice

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -1992,8 +1992,6 @@ static void _copyAttr(SvgNode* to, const SvgNode* from)
     //Copy style attribute
     _styleCopy(to->style, from->style);
     to->style->flags = (SvgStyleFlags)((int)to->style->flags | (int)from->style->flags);
-    if (from->style->fill.paint.url) to->style->fill.paint.url = strdup(from->style->fill.paint.url);
-    if (from->style->stroke.paint.url) to->style->stroke.paint.url = strdup(from->style->stroke.paint.url);
     if (from->style->clipPath.url) to->style->clipPath.url = strdup(from->style->clipPath.url);
     if (from->style->mask.url) to->style->mask.url = strdup(from->style->mask.url);
 


### PR DESCRIPTION
The url were copied in the _copyAttr and in the _styleCopy
functions.

a memory leak could have been observed on the ex below:
```
<svg width="400" height="400">
  
<defs>
    <linearGradient id="myGradient">
      <stop offset="5%"  stop-color="gold" />
      <stop offset="95%" stop-color="red" />
    </linearGradient>
    <path fill="url(#myGradient)" id="path1" d="m 100 100 h 300 v 100 z"/>
</defs>

<use width="100%" x="0" y="0" height="100%" xlink:href="#path1"/>

</svg>
```

issue: #1257 