### PR TITLE
svg_loader: prevent mem leaks

### DIFF
--- a/src/loaders/svg/tvgSvgCssStyle.cpp
+++ b/src/loaders/svg/tvgSvgCssStyle.cpp
@@ -128,8 +128,14 @@ void cssCopyStyleAttr(SvgNode* to, const SvgNode* from)
     //Copy style attribute
     _copyStyle(to->style, from->style);
 
-    if (from->style->clipPath.url) to->style->clipPath.url = strdup(from->style->clipPath.url);
-    if (from->style->mask.url) to->style->mask.url = strdup(from->style->mask.url);
+    if (from->style->clipPath.url) {
+        if (to->style->clipPath.url) free(to->style->clipPath.url);
+        to->style->clipPath.url = strdup(from->style->clipPath.url);
+    }
+    if (from->style->mask.url) {
+        if (to->style->mask.url) free(to->style->mask.url);
+        to->style->mask.url = strdup(from->style->mask.url);
+    }
 }
 
 

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -1332,6 +1332,7 @@ static bool _attrParsePathNode(void* data, const char* key, const char* value)
     SvgPathNode* path = &(node->node.path);
 
     if (!strcmp(key, "d")) {
+        if (path->path) free(path->path);
         //Temporary: need to copy
         path->path = _copyId(value);
     } else if (!strcmp(key, "style")) {
@@ -2005,8 +2006,14 @@ static void _copyAttr(SvgNode* to, const SvgNode* from)
     //Copy style attribute
     _styleCopy(to->style, from->style);
     to->style->flags = (SvgStyleFlags)((int)to->style->flags | (int)from->style->flags);
-    if (from->style->clipPath.url) to->style->clipPath.url = strdup(from->style->clipPath.url);
-    if (from->style->mask.url) to->style->mask.url = strdup(from->style->mask.url);
+    if (from->style->clipPath.url) {
+        if (to->style->clipPath.url) free(to->style->clipPath.url);
+        to->style->clipPath.url = strdup(from->style->clipPath.url);
+    }
+    if (from->style->mask.url) {
+        if (to->style->mask.url) free(to->style->mask.url);
+        to->style->mask.url = strdup(from->style->mask.url);
+    }
 
     //Copy node attribute
     switch (from->type) {
@@ -2042,7 +2049,10 @@ static void _copyAttr(SvgNode* to, const SvgNode* from)
             break;
         }
         case SvgNodeType::Path: {
-            if (from->node.path.path) to->node.path.path = strdup(from->node.path.path);
+            if (from->node.path.path) {
+                if (to->node.path.path) free(to->node.path.path);
+                to->node.path.path = strdup(from->node.path.path);
+            }
             break;
         }
         case SvgNodeType::Polygon: {
@@ -2064,7 +2074,10 @@ static void _copyAttr(SvgNode* to, const SvgNode* from)
             to->node.image.y = from->node.image.y;
             to->node.image.w = from->node.image.w;
             to->node.image.h = from->node.image.h;
-            if (from->node.image.href) to->node.image.href = strdup(from->node.image.href);
+            if (from->node.image.href) {
+                if (to->node.image.href) free(to->node.image.href);
+                to->node.image.href = strdup(from->node.image.href);
+            }
             break;
         }
         default: {


### PR DESCRIPTION
A necessary check added before strdup function is called.

svgs with mem leaks:
```
<svg viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg"
     xmlns:xlink="http://www.w3.org/1999/xlink">
  <path d="M 0 0 h 100 v 100 z" fill="red" d="M 0 0 h 100 v 100 h -100 z"/>
</svg>
```

```
<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
  
  <clipPath id="myClip1">
    <circle cx="40" cy="35" r="75" />
  </clipPath>

  <clipPath id="myClip2">
    <circle cx="40" cy="35" r="55" />
  </clipPath>

 <rect x="5" y="90" width="50" height="50" class="mineStyle" clip-path="url(#myClip1)"/>


 <defs>
  <style>
    rect.mineStyle {
        fill: blue;
        stroke: #3399ff;
        clip-path: url(#myClip2);
    }
  </style>
 </defs>

</svg>
```
