### PR TITLE
svg_loader: No skip luma mask when composition node is image

### DIFF
--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -659,7 +659,10 @@ static unique_ptr<Scene> _sceneBuildHelper(const SvgNode* node, const Box& vBox,
                         scene->push(_sceneBuildHelper(*child, vBox, svgPath, false, isMaskWhite));
                 } else if ((*child)->type == SvgNodeType::Image) {
                     auto image = _imageBuildHelper(*child, vBox, svgPath);
-                    if (image) scene->push(move(image));
+                    if (image) {
+                        scene->push(move(image));
+                        if (isMaskWhite) *isMaskWhite = false;
+                    }
                 } else if ((*child)->type != SvgNodeType::Mask) {
                     auto shape = _shapeBuildHelper(*child, vBox, svgPath);
                     if (shape) {


### PR DESCRIPTION
Improved to skip Luma Mask when conditions are the same
as AlphaMask for optimization in e409bb29.
If the composition node is an image, it is not skipped because
it is not known for sure whether to skip it.

related issue : https://github.com/Samsung/thorvg/issues/1262