### PR TITLE
svg_loader: deeper search for postponed nodes

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -1803,19 +1803,10 @@ static SvgNode* _getDefsNode(SvgNode* node)
 }
 
 
-static SvgNode* _findChildById(const SvgNode* node, const char* id)
+static SvgNode* _findNodeById(SvgNode *node, const char* id)
 {
     if (!node) return nullptr;
 
-    auto child = node->child.data;
-    for (uint32_t i = 0; i < node->child.count; ++i, ++child) {
-        if (((*child)->id) && !strcmp((*child)->id, id)) return (*child);
-    }
-    return nullptr;
-}
-
-static SvgNode* _findNodeById(SvgNode *node, const char* id)
-{
     SvgNode* result = nullptr;
     if (node->id && !strcmp(node->id, id)) return node;
 
@@ -1828,6 +1819,7 @@ static SvgNode* _findNodeById(SvgNode *node, const char* id)
     }
     return result;
 }
+
 
 static void _cloneGradStops(Array<Fill::ColorStop>& dst, const Array<Fill::ColorStop>& src)
 {
@@ -2117,8 +2109,8 @@ static void _clonePostponedNodes(Array<SvgNodeIdPair>* cloneNodes, SvgNode* doc)
     for (uint32_t i = 0; i < cloneNodes->count; ++i) {
         auto nodeIdPair = cloneNodes->data[i];
         auto defs = _getDefsNode(nodeIdPair.node);
-        auto nodeFrom = _findChildById(defs, nodeIdPair.id);
-        if (!nodeFrom) nodeFrom = _findChildById(doc, nodeIdPair.id);
+        auto nodeFrom = _findNodeById(defs, nodeIdPair.id);
+        if (!nodeFrom) nodeFrom = _findNodeById(doc, nodeIdPair.id);
         _cloneNode(nodeFrom, nodeIdPair.node, 0);
         if (nodeFrom && nodeFrom->type == SvgNodeType::Symbol && nodeIdPair.node->type == SvgNodeType::Use) {
             nodeIdPair.node->node.use.symbol = nodeFrom;
@@ -2165,7 +2157,7 @@ static bool _attrParseUseNode(void* data, const char* key, const char* value)
     if (!strcmp(key, "href") || !strcmp(key, "xlink:href")) {
         id = _idFromHref(value);
         defs = _getDefsNode(node);
-        nodeFrom = _findChildById(defs, id);
+        nodeFrom = _findNodeById(defs, id);
         if (nodeFrom) {
             _cloneNode(nodeFrom, node, 0);
             if (nodeFrom->type == SvgNodeType::Symbol) use->symbol = nodeFrom;


### PR DESCRIPTION
Till now the proper node was searched only among children,
now all the nodes are checked.

sample svg (+ ABCD_297.svg from #1255):
```
<svg viewBox="0 0 50 50" xmlns="http://www.w3.org/2000/svg">
  <defs>
    <g stroke="blue" stroke-width="2" id="gID">
    <circle id="myCircle" cx="0" cy="0" r="5" />
    </g>
  </defs>

  <use x="5" y="5" href="#myCircle" fill="green" />
  <use x="5" y="15" href="#gID" fill="red" />
</svg>
```

before:
![bef](https://user-images.githubusercontent.com/67589014/187802241-5c24f60d-0191-4638-9b05-7d52cd380c2f.PNG)

after:
![aft](https://user-images.githubusercontent.com/67589014/187802248-233d0fb8-21c7-41de-85ed-5d32b2839f5e.PNG)

