### PR TITLE
wasm: add -flto option

### DIFF
--- a/wasm_cross.txt
+++ b/wasm_cross.txt
@@ -11,8 +11,8 @@ shared_module_suffix = 'js'
 exe_suffix = 'js'
 
 #[built-in options]
-cpp_args = ['-Wshift-negative-value', '--bind' , '-s' , 'WASM=1' , '-s' , 'ALLOW_MEMORY_GROWTH=1' , '-s' , 'FORCE_FILESYSTEM=1' , '-O2']
-cpp_link_args = ['-Wshift-negative-value', '--bind' , '-s' , 'WASM=1' , '-s' , 'ALLOW_MEMORY_GROWTH=1' , '-s' , 'FORCE_FILESYSTEM=1' , '-O2']
+cpp_args = ['-Wshift-negative-value', '--bind' , '-s' , 'WASM=1' , '-s' , 'ALLOW_MEMORY_GROWTH=1' , '-s' , 'FORCE_FILESYSTEM=1' , '-flto', '-O2']
+cpp_link_args = ['-Wshift-negative-value', '--bind' , '-s' , 'WASM=1' , '-s' , 'ALLOW_MEMORY_GROWTH=1' , '-s' , 'FORCE_FILESYSTEM=1' , '-flto', '-O2']
 
 [host_machine]
 system = 'emscripten'


### PR DESCRIPTION
Clang 16 of emsdk(Latest) does not support `-flto=0` option. so I temporarily add -flto option.

```
clang-16: error: unsupported argument '0' to option '-flto='

em++: error: '/home/junsu/dev/os/emsdk/upstream/bin/clang++ -target wasm32-unknown-emscripten -fignore-exceptions -fvisibility=default -I/home/junsu/dev/os/emsdk/upstream/emscripten/cache/sysroot/include/SDL --sysroot=/home/junsu/dev/os/emsdk/upstream/emscripten/cache/sysroot -Xclang -iwithsysroot/include/compat -O2 -Werror -fno-unroll-loops -g3 -flto=0 -c /home/junsu/dev/os/emsdk/upstream/emscripten/system/lib/embind/bind.cpp -o /home/junsu/dev/os/emsdk/upstream/emscripten/cache/build/libembind-rtti/bind.o' failed (returned 1)
```