### PR TITLE
wasm: Update size calculation logic

### DIFF
--- a/src/wasm/thorvgwasm.cpp
+++ b/src/wasm/thorvgwasm.cpp
@@ -181,14 +181,14 @@ public:
         const Paint* paint = findPaintById(mPicture, paintId, &parents);
         if (!paint) return val(typed_memory_view<float>(0, nullptr));
         paint->bounds(&mBounds[0], &mBounds[1], &mBounds[2], &mBounds[3]);
-        
+
         float points[8] = { //clockwise points
             mBounds[0], mBounds[1], //(x1, y1)
             mBounds[0] + mBounds[2], mBounds[1], //(x2, y1)
             mBounds[0] + mBounds[2], mBounds[1] + mBounds[3], //(x2, y2)
             mBounds[0], mBounds[1] + mBounds[3], //(x1, y2)
         };
-        
+
         for (auto paint = parents.data; paint < (parents.data + parents.count); ++paint) {
             auto m = const_cast<Paint*>(*paint)->transform();
             for (int i = 0; i<8; i += 2) {
@@ -197,7 +197,7 @@ public:
                 points[i] = x;
             }
         }
-        
+
         mBounds[0] = points[0];//x(p1)
         mBounds[1] = points[3];//y(p2)
         mBounds[2] = points[4] - mBounds[0];//x(p3)

--- a/src/wasm/thorvgwasm.cpp
+++ b/src/wasm/thorvgwasm.cpp
@@ -255,7 +255,19 @@ private:
         mBuffer = make_unique<uint8_t[]>(mWidth * mHeight * 4);
         mSwCanvas->target((uint32_t *)mBuffer.get(), mWidth, mWidth, mHeight, SwCanvas::ARGB8888);
 
-        if (mPicture) mPicture->size(width, height);
+        if (mPicture) {
+            float scale;
+            float shiftX = 0.0f, shiftY = 0.0f;
+            if (mOriginalSize[0] > mOriginalSize[1]) {
+                scale = width / mOriginalSize[0];
+                shiftY = (height - mOriginalSize[1] * scale) * 0.5f;
+            } else {
+                scale = height / mOriginalSize[1];
+                shiftX = (width - mOriginalSize[0] * scale) * 0.5f;
+            }
+            mPicture->scale(scale);
+            mPicture->translate(shiftX, shiftY);
+        }
     }
 
     struct Layer


### PR DESCRIPTION
revised the logic to align svg images in the center of the view.

this is the subsequent changes to 3939b61770c14602d7e349ba0baa21d9f4d97a44.