### PR TITLE
SwRaster: Prevent memory issue

### DIFF
--- a/src/lib/sw_engine/tvgSwRasterTexmapInternal.h
+++ b/src/lib/sw_engine/tvgSwRasterTexmapInternal.h
@@ -104,6 +104,12 @@
             ab = (int)(255 * (1 - modff(v, &iptr)));
             iru = uu + 1;
             irv = vv + 1;
+
+            //FIXME: If vv goes out of buffer, it can cause potential memory problems.
+            //Therefore, an `if condition` is added so that it does not exceed the height of the image.
+            //This is temporary fix.
+            if (vv >= sh) continue;
+
             px = *(sbuf + (vv * sw) + uu);
 
             /* horizontal interpolate */

--- a/src/lib/sw_engine/tvgSwRasterTexmapInternal.h
+++ b/src/lib/sw_engine/tvgSwRasterTexmapInternal.h
@@ -105,9 +105,6 @@
             iru = uu + 1;
             irv = vv + 1;
 
-            //FIXME: If vv goes out of buffer, it can cause potential memory problems.
-            //Therefore, an `if condition` is added so that it does not exceed the height of the image.
-            //This is temporary fix.
             if (vv >= sh) continue;
 
             px = *(sbuf + (vv * sw) + uu);


### PR DESCRIPTION
If vv goes out of buffer, it can cause potential memory problems.
Therefore, an `if condition` is added so that it does not exceed the height of the image.
This is temporary fix.

Test)
```
meson -Db_sanitize=address,undefined -Dexamples=true . build
$ ./build/src/examples/Texmap
```
```
==6298==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x7f37fd6c2180 at pc 0x7f380d884599 bp 0x7fffb02b2db0 sp 0x7fffb02b2da0 READ of size 4 at 0x7f37fd6c2180 thread T0
    #0 0x7f380d884598 in _rasterPolygonImageSegment ../src/lib/sw_engine/tvgSwRasterTexmapInternal.h:107
    #1 0x7f380d887694 in _rasterPolygonImage ../src/lib/sw_engine/tvgSwRasterTexmap.h:271
    #2 0x7f380d88a598 in _rasterTexmapPolygonMesh ../src/lib/sw_engine/tvgSwRasterTexmap.h:639
    #3 0x7f380d89828d in _transformedRGBAImageMesh ../src/lib/sw_engine/tvgSwRaster.cpp:701
    #4 0x7f380d89828d in rasterImageMesh(SwSurface*, SwImage*, tvg::Polygon const*, unsigned int, tvg::Matrix const*, SwBBox const&, unsigned int) ../src/lib/sw_engine/tvgSwRaster.cpp:1585
    #5 0x7f380d89bf16 in tvg::SwRenderer::renderImageMesh(void*) ../src/lib/sw_engine/tvgSwRenderer.cpp:369
    #6 0x7f380d830e7e in tvg::Paint::Impl::render(tvg::RenderMethod&) ../src/lib/tvgPaint.cpp:178
    #7 0x7f380d823bd2 in tvg::Canvas::Impl::draw() (/home/junsu/dev/os/thorvg/build/src/examples/../libthorvg.so.0+0x265bd2)
    #8 0x7f380d821e79 in tvg::Canvas::draw() ../src/lib/tvgCanvas.cpp:60
    #9 0x557d07b2d5b6 in drawSwView(void*, _Eo_Opaque*) ../src/examples/Texmap.cpp:103
    #10 0x7f380cb7d2aa in evas_process_dirty_pixels ../src/lib/evas/canvas/evas_object_image.c:1894
    #11 0x7f380cb7d2aa in _evas_image_pixels_get ../src/lib/evas/canvas/evas_object_image.c:2318
    #12 0x7f380cb7d85e in _evas_image_render ../src/lib/evas/canvas/evas_object_image.c:2468
    #13 0x7f380cb7ea0c in evas_object_image_render ../src/lib/evas/canvas/evas_object_image.c:2271
    #14 0x7f380cbe51db in evas_render_mapped ../src/lib/evas/canvas/evas_render.c:2290
    #15 0x7f380cbe6f15 in evas_render_updates_internal_loop ../src/lib/evas/canvas/evas_render.c:3158
    #16 0x7f380cbe9912 in evas_render_updates_internal ../src/lib/evas/canvas/evas_render.c:3631
    #17 0x7f380cbeb31c in _evas_canvas_render_async ../src/lib/evas/canvas/evas_render.c:4094
    #18 0x7f380cb6634a in evas_canvas_render_async ../src/lib/evas/canvas/evas_canvas_eo.c:168
    #19 0x7f380cb6fce5 in evas_render_async ../src/lib/evas/canvas/evas_canvas_eo.legacy.c:179
    #20 0x7f37f3a81555 in _ecore_evas_x_render ../src/modules/ecore_evas/engines/x/ecore_evas_x.c:761
    #21 0x7f3809677e42 in _ecore_evas_idle_enter ../src/lib/ecore_evas/ecore_evas.c:295
    #22 0x7f38098a89a4 in _ecore_call_task_cb ../src/lib/ecore/ecore_private.h:456
    #23 0x7f38098a89a4 in _ecore_factorized_idle_process ../src/lib/ecore/ecore_idler.c:35
    #24 0x7f3809b29081 in _event_callback_call ../src/lib/eo/eo_base_class.c:2114
    #25 0x7f3809b29081 in _efl_object_event_callback_call ../src/lib/eo/eo_base_class.c:2186
    #26 0x7f3809b22d22 in efl_event_callback_call ../src/lib/eo/eo_base_class.c:2189
    #27 0x7f38098aae44 in _ecore_main_loop_iterate_internal ../src/lib/ecore/ecore_main.c:2466
    #28 0x7f38098ab689 in _ecore_main_loop_begin ../src/lib/ecore/ecore_main.c:1231
    #29 0x7f38098b05e0 in _efl_loop_begin ../src/lib/ecore/efl_loop.c:57
    #30 0x7f38098af77c in efl_loop_begin src/lib/ecore/efl_loop.eo.c:28
    #31 0x7f38098ab755 in ecore_main_loop_begin ../src/lib/ecore/ecore_main.c:1316
    #32 0x7f380d14ba1f in elm_run ../src/lib/elementary/elm_main.c:1359
    #33 0x557d07b2d298 in main ../src/examples/Texmap.cpp:176
    #34 0x7f380b533c86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)
    #35 0x557d07b2d3c9 in _start (/home/junsu/dev/os/thorvg/build/src/examples/Texmap+0xb3c9)
```

related issue: https://github.com/Samsung/thorvg/issues/1272