### PR TITLE
gl_engine: fixed the signature of the prepare() method in GlRenderer

### DIFF
--- a/src/lib/gl_engine/tvgGlRenderer.cpp
+++ b/src/lib/gl_engine/tvgGlRenderer.cpp
@@ -190,7 +190,7 @@ bool GlRenderer::dispose(RenderData data)
 }
 
 
-RenderData GlRenderer::prepare(TVG_UNUSED Surface* image, TVG_UNUSED RenderData data, TVG_UNUSED const RenderTransform* transform, TVG_UNUSED uint32_t opacity, TVG_UNUSED Array<RenderData>& clips, TVG_UNUSED RenderUpdateFlag flags)
+RenderData GlRenderer::prepare(TVG_UNUSED Surface* image, TVG_UNUSED Polygon* triangles, TVG_UNUSED uint32_t triangleCnt, TVG_UNUSED RenderData data, TVG_UNUSED const RenderTransform* transform, TVG_UNUSED uint32_t opacity, TVG_UNUSED Array<RenderData>& clips, TVG_UNUSED RenderUpdateFlag flags)
 {
     //TODO:
     return nullptr;

--- a/src/lib/gl_engine/tvgGlRenderer.h
+++ b/src/lib/gl_engine/tvgGlRenderer.h
@@ -31,7 +31,7 @@ public:
     Surface surface = {nullptr, 0, 0, 0};
 
     RenderData prepare(const Shape& shape, RenderData data, const RenderTransform* transform, uint32_t opacity, Array<RenderData>& clips, RenderUpdateFlag flags) override;
-    RenderData prepare(Surface* image, RenderData data, const RenderTransform* transform, uint32_t opacity, Array<RenderData>& clips, RenderUpdateFlag flags) override;
+    RenderData prepare(Surface* image, Polygon* triangles, uint32_t triangleCnt, RenderData data, const RenderTransform* transform, uint32_t opacity, Array<RenderData>& clips, RenderUpdateFlag flags) override;
     bool preRender() override;
     bool renderShape(RenderData data) override;
     bool renderImage(RenderData data) override;


### PR DESCRIPTION
The implementation of the virtual prepare() method is different from that of RenderMethod, so the compilation fails. This modification solves the problem.