### PR TITLE
[svg2png] size limitation while converting the file

### DIFF
--- a/src/bin/svg2png/svg2png.cpp
+++ b/src/bin/svg2png/svg2png.cpp
@@ -37,6 +37,10 @@
     #include <sys/stat.h>
 #endif
 
+#define WIDTH_8K 7680
+#define HEIGHT_8K 4320
+#define SIZE_8K 33177600 //WIDTH_8K x HEIGHT_8K
+
 using namespace std;
 
 struct PngBuilder
@@ -94,6 +98,19 @@ public:
             picture->size(&fw, &fh);
             w = static_cast<uint32_t>(fw);
             h = static_cast<uint32_t>(fh);
+
+            if (w * h > SIZE_8K) {
+                float scale = fw / fh;
+                if (scale > 1) {
+                    w = WIDTH_8K;
+                    h = static_cast<uint32_t>(w / scale);
+                } else {
+                    h = HEIGHT_8K;
+                    w = static_cast<uint32_t>(h * scale);
+                }
+                cout << "Warning: The SVG width and/or height values exceed the 8k resolution. "
+                        "To avoid the heap overflow, the conversion to the PNG file made in " << WIDTH_8K << " x " << HEIGHT_8K << " resolution." << endl;
+            }
         } else {
             picture->size(w, h);
         }
@@ -272,7 +289,7 @@ private:
 private:
     int help()
     {
-        cout << "Usage:\n   svg2png [SVG files] [-r resolution] [-b bgColor]\n\nFlags:\n    -r set the output image resolution.\n    -b set the output image background color.\n\nExamples:\n    $ svg2png input.svg\n    $ svg2png input.svg -r 200x200\n    $ svg2png input.svg -r 200x200 -b ff00ff\n    $ svg2png input1.svg input2.svg -r 200x200 -b ff00ff\n    $ svg2png . -r 200x200\n\n";
+        cout << "Usage:\n   svg2png [SVG files] [-r resolution] [-b bgColor]\n\nFlags:\n    -r set the output image resolution.\n    -b set the output image background color.\n\nExamples:\n    $ svg2png input.svg\n    $ svg2png input.svg -r 200x200\n    $ svg2png input.svg -r 200x200 -b ff00ff\n    $ svg2png input1.svg input2.svg -r 200x200 -b ff00ff\n    $ svg2png . -r 200x200\n\nNote:\n    In the case, where the width and height in the SVG file determine the size of the image in resolution higher than 8k (7680 x 4320), limiting the resolution to this value is enforced.\n\n";
         return 1;
     }
 


### PR DESCRIPTION
In case the svg file size is too large, a heap overflow occurred when conversting to png. To prevent this a size limitation has been added - the resolution of the resulting png file cannot be higher than 8k (7680 x 4320).