### PR TITLE
common Accessor: Change parameter type of access api to std::funciton

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -14,6 +14,7 @@
 #ifndef _THORVG_H_
 #define _THORVG_H_
 
+#include <functional>
 #include <memory>
 #include <string>
 
@@ -1612,7 +1613,7 @@ public:
      *
      * @note The bitmap based picture might not have the scene-tree.
      */
-    std::unique_ptr<Picture> access(std::unique_ptr<Picture> picture, bool(*func)(const Paint* paint)) noexcept;
+    std::unique_ptr<Picture> access(std::unique_ptr<Picture> picture, std::function<bool(const Paint* paint)> func) noexcept;
 
     /**
      * @brief Creates a new Accessor object.

--- a/src/lib/tvgAccessor.cpp
+++ b/src/lib/tvgAccessor.cpp
@@ -23,7 +23,7 @@
 /* Internal Class Implementation                                        */
 /************************************************************************/
 
-static bool accessChildren(Iterator* it, bool(*func)(const Paint* paint), IteratorAccessor& itrAccessor)
+static bool accessChildren(Iterator* it, function<bool(const Paint* paint)> func, IteratorAccessor& itrAccessor)
 {
     while (auto child = it->next()) {
         //Access the child
@@ -41,12 +41,11 @@ static bool accessChildren(Iterator* it, bool(*func)(const Paint* paint), Iterat
     return true;
 }
 
-
 /************************************************************************/
 /* External Class Implementation                                        */
 /************************************************************************/
 
-unique_ptr<Picture> Accessor::access(unique_ptr<Picture> picture, bool(*func)(const Paint* paint)) noexcept
+unique_ptr<Picture> Accessor::access(unique_ptr<Picture> picture, function<bool(const Paint* paint)> func) noexcept
 {
     auto p = picture.get();
     if (!p || !func) return picture;


### PR DESCRIPTION
There are limited ways to pass user data to the func function.
So to support this we change parameter type to use std::function.