### PR TITLE
common Accessor: removed deprecated api.

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -1597,23 +1597,13 @@ public:
  * The Accessor helps you search specific nodes to read the property information, figure out the structure of the scene tree and its size.
  *
  * @warning We strongly warn you not to change the paints of a scene unless you really know the design-structure.
+ *
+ * @BETA_API
  */
 class TVG_EXPORT Accessor final
 {
 public:
     ~Accessor();
-
-    /**
-     * @brief Access the Picture scene tree nodes.
-     *
-     * @param[in] picture The picture node to traverse the internal scene-tree.
-     * @param[in] func The callback function calling for every paint nodes of the Picture.
-     *
-     * @return Return the given @p picture instance.
-     *
-     * @note The bitmap based picture might not have the scene-tree.
-     */
-    std::unique_ptr<Picture> access(std::unique_ptr<Picture> picture, bool(*func)(const Paint* paint)) noexcept;
 
     /**
      * @brief Set the access function for traversing the Picture scene tree nodes.
@@ -1633,6 +1623,8 @@ public:
      * @brief Creates a new Accessor object.
      *
      * @return A new Accessor object.
+     *
+     * @BETA_API
      */
     static std::unique_ptr<Accessor> gen() noexcept;
 

--- a/src/lib/tvgAccessor.cpp
+++ b/src/lib/tvgAccessor.cpp
@@ -45,26 +45,6 @@ static bool accessChildren(Iterator* it, IteratorAccessor& itrAccessor, function
 /* External Class Implementation                                        */
 /************************************************************************/
 
-unique_ptr<Picture> Accessor::access(unique_ptr<Picture> picture, bool(*func)(const Paint* paint)) noexcept
-{
-    auto p = picture.get();
-    if (!p || !func) return picture;
-
-    //Use the Preorder Tree-Search
-
-    //Root
-    if (!func(p)) return picture;
-
-    //Children
-    IteratorAccessor itrAccessor;
-    if (auto it = itrAccessor.iterator(p)) {
-        accessChildren(it, itrAccessor, func);
-        delete(it);
-    }
-    return picture;
-}
-
-
 unique_ptr<Picture> Accessor::set(unique_ptr<Picture> picture, function<bool(const Paint* paint)> func) noexcept
 {
     auto p = picture.get();


### PR DESCRIPTION
the old version of Accessor::access() is redundant, we replaced it with set().

It's still under the beta, we can remove it immediately. Note that we've planned to promote them official APIs in v0.9,
Newly changed, tagging beta again...