### PR TITLE
svg_loader: Change SVG viewbox variable type from int to float

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -178,9 +178,9 @@ static float _toFloat(const SvgParser* svgParse, const char* str, SvgParserLengt
         else if (type == SvgParserLengthType::Horizontal) parsedValue = (parsedValue / 100.0) * svgParse->global.w;
         else //if other then it's radius
         {
-            float max = (float)svgParse->global.w;
+            float max = svgParse->global.w;
             if (max < svgParse->global.h)
-                max = (float)svgParse->global.h;
+                max = svgParse->global.h;
             parsedValue = (parsedValue / 100.0) * max;
         }
     }
@@ -339,7 +339,7 @@ static void _parseDashArray(SvgLoaderData* loader, const char *str, SvgDash* das
             ++end;
             //Refers to the diagonal length of the viewport.
             //https://www.w3.org/TR/SVG2/coords.html#Units
-            parsedValue = (sqrtf(pow(loader->svgParse->global.w, 2) + pow(loader->svgParse->global.h, 2)) / sqrtf(2.0f)) * (parsedValue / 100.0f);
+            parsedValue = (sqrtf(powf(loader->svgParse->global.w, 2) + powf(loader->svgParse->global.h, 2)) / sqrtf(2.0f)) * (parsedValue / 100.0f);
         }
         (*dash).array.push(parsedValue);
         str = end;
@@ -838,13 +838,13 @@ static bool _attrParseSvgNode(void* data, const char* key, const char* value)
             if (_parseNumber(&value, &doc->vy)) {
                 if (_parseNumber(&value, &doc->vw)) {
                     _parseNumber(&value, &doc->vh);
-                    loader->svgParse->global.h = (uint32_t)doc->vh;
+                    loader->svgParse->global.h = doc->vh;
                 }
-                loader->svgParse->global.w = (uint32_t)doc->vw;
+                loader->svgParse->global.w = doc->vw;
             }
-            loader->svgParse->global.y = (int)doc->vy;
+            loader->svgParse->global.y = doc->vy;
         }
-        loader->svgParse->global.x = (int)doc->vx;
+        loader->svgParse->global.x = doc->vx;
     } else if (!strcmp(key, "preserveAspectRatio")) {
         _parseAspectRatio(&value, &doc->align, &doc->meetOrSlice);
     } else if (!strcmp(key, "style")) {
@@ -1298,11 +1298,11 @@ static SvgNode* _createSvgNode(SvgLoaderData* loader, SvgNode* parent, const cha
 
     if (loader->svgParse->global.w == 0) {
         if (doc->w < FLT_EPSILON) loader->svgParse->global.w = 1;
-        else loader->svgParse->global.w = (uint32_t)doc->w;
+        else loader->svgParse->global.w = doc->w;
     }
     if (loader->svgParse->global.h == 0) {
         if (doc->h < FLT_EPSILON) loader->svgParse->global.h = 1;
-        else loader->svgParse->global.h = (uint32_t)doc->h;
+        else loader->svgParse->global.h = doc->h;
     }
 
     return loader->svgParse->node;
@@ -2369,7 +2369,7 @@ static void _recalcRadialFyAttr(SvgLoaderData* loader, SvgRadialGradient* radial
 static void _recalcRadialRAttr(SvgLoaderData* loader, SvgRadialGradient* radial, bool userSpace)
 {
     // scaling factor based on the Units paragraph from : https://www.w3.org/TR/2015/WD-SVG2-20150915/coords.html
-    if (userSpace && !radial->isRPercentage) radial->r = radial->r / (sqrtf(pow(loader->svgParse->global.h, 2) + pow(loader->svgParse->global.w, 2)) / sqrtf(2.0));
+    if (userSpace && !radial->isRPercentage) radial->r = radial->r / (sqrtf(powf(loader->svgParse->global.h, 2) + powf(loader->svgParse->global.w, 2)) / sqrtf(2.0));
 }
 
 

--- a/src/loaders/svg/tvgSvgLoaderCommon.h
+++ b/src/loaders/svg/tvgSvgLoaderCommon.h
@@ -425,8 +425,7 @@ struct SvgParser
     SvgStopStyleFlags flags;
     struct
     {
-        int x, y;
-        uint32_t w, h;
+        float x, y, w, h;
     } global;
     struct
     {


### PR DESCRIPTION
The viewbox and size(width, height) defined in SVG can be float type.
This prevents matrix calculation errors caused by this.