### PR TITLE
common Util: Skip if there is a space after the dot

### DIFF
--- a/src/loaders/svg/tvgSvgUtil.cpp
+++ b/src/loaders/svg/tvgSvgUtil.cpp
@@ -137,11 +137,13 @@ float svgUtilStrtof(const char *nPtr, char **endPtr)
                     pow10 *= 10ULL;
                 }
             }
+        } else if (isspace(*iter)) { //skip if there is a space after the dot.
+            a = iter;
+            goto success;
         }
+
         val += static_cast<float>(decimalPart) / static_cast<float>(pow10);
         a = iter;
-        //skip if there is a space after the dot.
-        if (isspace(*a)) goto success;
     }
 
     //Optional: exponent

--- a/src/loaders/svg/tvgSvgUtil.cpp
+++ b/src/loaders/svg/tvgSvgUtil.cpp
@@ -140,6 +140,8 @@ float svgUtilStrtof(const char *nPtr, char **endPtr)
         }
         val += static_cast<float>(decimalPart) / static_cast<float>(pow10);
         a = iter;
+        //skip if there is a space after the dot.
+        if (isspace(*a)) goto success;
     }
 
     //Optional: exponent


### PR DESCRIPTION
Some SVG parsers allow parsing of "0."
If there is a space after the dot, skip to the next step.

[example]
```html
<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
  <defs id="defs3051">
    <style type="text/css" id="current-color-scheme">
      .ColorScheme-Text {
        color:#31363b;
      }
      .ColorScheme-Highlight {
        color:#3daee9;
      }
      </style>
  </defs>
 <path 
     style="fill:currentColor;fill-opacity:0.6;stroke:none" 
     d="m 15,12 v 3 h 1 v -3 z m -2,1 v 2 h 1 v -2 z m 4,0 v 2 h 1 v -2 z m -6,1 v 1 h 1 v -1 z m -1,2 v 4 c 0,1.813 1.01,3 3,3 h -2 v 1 h 8 v -1 h -2 c 1.572,0 2.507,-0.727 3,-2 h 1 c 1,0 1,-0. 1,-1.1 v -1.1 c 0,-1.8 0,-1.8 -1,-1.813 h -1 v -1 z m 1,1 h 8 v 3 c 0,1.5 -1.3,2 -3,2 h -2 c -1.662,0 -3,-0.489 -3,-2 z m 9,1 h 1 v 2 h -1 z"
     />
</svg>

```