### PR TITLE
common: ignoring color/alpha/opacity of a clip object

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -364,6 +364,20 @@ public:
     CompositeMethod composite(const Paint** target) const noexcept;
 
     /**
+     * @brief Gets the composition source object and the composition method.
+     *
+     * @param[out] source The paint of the composition source object.
+     * @param[out] method The method used to composite the source object with the target.
+     *
+     * @return Result::Success when the paint object used as a composition target, Result::InsufficientCondition otherwise.
+     *
+     * @warning Please do not use it, this API is not official one. It could be modified in the next version.
+     *
+     * @BETA_API
+     */
+    Result composite(const Paint** source, CompositeMethod* method) const noexcept;
+
+    /**
      * @brief Return the unique id value of the paint instance.
      *
      * This method can be called for checking the current concrete instance type.

--- a/src/examples/ClipPath.cpp
+++ b/src/examples/ClipPath.cpp
@@ -63,9 +63,9 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     //Move Star1
     star1->translate(-10, -10);
 
+    // color/alpha/opacity are ignored for a clip object - no need to set them
     auto clipStar = tvg::Shape::gen();
     clipStar->appendCircle(200, 230, 110, 110);
-    clipStar->fill(255, 255, 255, 255); // clip object must have alpha.
     clipStar->translate(10, 10);
 
     star1->composite(move(clipStar), tvg::CompositeMethod::ClipPath);
@@ -80,9 +80,9 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     //Move Star2
     star2->translate(10, 40);
 
+    // color/alpha/opacity are ignored for a clip object - no need to set them
     auto clip = tvg::Shape::gen();
     clip->appendCircle(200, 230, 130, 130);
-    clip->fill(255, 255, 255, 255); // clip object must have alpha.
     clip->translate(10, 10);
 
     scene->push(move(star1));
@@ -110,9 +110,9 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     star3->stroke(10);
     star3->translate(400, 0);
 
+    // color/alpha/opacity are ignored for a clip object - no need to set them
     auto clipRect = tvg::Shape::gen();
     clipRect->appendRect(500, 120, 200, 200, 0, 0);          //x, y, w, h, rx, ry
-    clipRect->fill(255, 255, 255, 255); // clip object must have alpha.
     clipRect->translate(20, 20);
 
     //Clipping scene to rect(shape)
@@ -127,10 +127,10 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     picture->scale(3);
     picture->translate(50, 400);
 
+    // color/alpha/opacity are ignored for a clip object - no need to set them
     auto clipPath = tvg::Shape::gen();
     clipPath->appendCircle(200, 510, 50, 50);          //x, y, w, h, rx, ry
     clipPath->appendCircle(200, 650, 50, 50);          //x, y, w, h, rx, ry
-    clipPath->fill(255, 255, 255, 255); // clip object must have alpha.
     clipPath->translate(20, 20);
 
     //Clipping picture to path
@@ -143,9 +143,9 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     shape1->appendRect(500, 420, 100, 100, 20, 20);
     shape1->fill(255, 0, 255, 160);
 
+    // color/alpha/opacity are ignored for a clip object - no need to set them
     auto clipShape = tvg::Shape::gen();
     clipShape->appendRect(600, 420, 100, 100, 0, 0);
-    clipShape->fill(255, 0, 255, 150);
 
     //Clipping shape1 to clipShape
     shape1->composite(move(clipShape), tvg::CompositeMethod::ClipPath);

--- a/src/lib/tvgPaint.cpp
+++ b/src/lib/tvgPaint.cpp
@@ -385,6 +385,19 @@ CompositeMethod Paint::composite(const Paint** target) const noexcept
 }
 
 
+Result Paint::composite(const Paint** source, CompositeMethod* method) const noexcept
+{
+    if (source) *source = pImpl->compSource;
+    auto met = (pImpl->compSource && pImpl->compSource->pImpl->compData ?
+                pImpl->compSource->pImpl->compData->method : CompositeMethod::None);
+    if (method) *method = met;
+
+    if (pImpl->compSource != nullptr && met != CompositeMethod::None)
+        return Result::Success;
+    return Result::InsufficientCondition;
+}
+
+
 Result Paint::opacity(uint8_t o) noexcept
 {
     if (pImpl->opacity == o) return Result::Success;

--- a/src/lib/tvgPaint.h
+++ b/src/lib/tvgPaint.h
@@ -63,6 +63,7 @@ namespace tvg
         StrategyMethod* smethod = nullptr;
         RenderTransform* rTransform = nullptr;
         Composite* compData = nullptr;
+        Paint* compSource = nullptr;
         uint32_t renderFlag = RenderUpdateFlag::None;
         uint32_t ctxFlag = ContextFlag::Invalid;
         uint32_t id;
@@ -137,6 +138,7 @@ namespace tvg
                 if (!target && method == CompositeMethod::None) return true;
                 compData = static_cast<Composite*>(calloc(1, sizeof(Composite)));
             }
+            target->pImpl->compSource = source;
             compData->target = target;
             compData->source = source;
             compData->method = method;


### PR DESCRIPTION
According to the svg specs clip's fill and opacity should be ignored. Till now setting the alpha/opacity value to zero resulted in the shape's rendering abort.

part of the #1192 issue