### PR TITLE
paint: fastTrack should return false for the skew transformations

### DIFF
--- a/src/lib/tvgMath.h
+++ b/src/lib/tvgMath.h
@@ -53,6 +53,12 @@ static inline bool mathRightAngle(const Matrix* m)
 }
 
 
+static inline bool mathSkewed(const Matrix* m)
+{
+    return (fabsf(m->e21 + m->e12) > FLT_EPSILON);
+}
+
+
 static inline bool mathIdentity(const Matrix* m)
 {
     if (!mathEqual(m->e11, 1.0f) || !mathZero(m->e12) || !mathZero(m->e13) ||

--- a/src/lib/tvgPaint.cpp
+++ b/src/lib/tvgPaint.cpp
@@ -38,9 +38,9 @@ static bool _compFastTrack(Paint* cmpTarget, const RenderTransform* pTransform, 
 
     if (rTransform) rTransform->update();
 
-    //No rotational.
-    if (pTransform && !mathRightAngle(&pTransform->m)) return false;
-    if (rTransform && !mathRightAngle(&rTransform->m)) return false;
+    //No rotation and no skewing
+    if (pTransform && (!mathRightAngle(&pTransform->m) || mathSkewed(&pTransform->m))) return false;
+    if (rTransform && (!mathRightAngle(&rTransform->m) || mathSkewed(&rTransform->m))) return false;
 
     //Perpendicular Rectangle?
     auto pt1 = pts + 0;


### PR DESCRIPTION
part of the #1192 issue

