### PR TITLE
examples: keep aspect ratio of svg images.

### DIFF
--- a/src/examples/MultiCanvas.cpp
+++ b/src/examples/MultiCanvas.cpp
@@ -55,7 +55,22 @@ void tvgDrawCmds(tvg::Canvas* canvas, const char* path, const char* name)
 
     if (picture->load(buf) != tvg::Result::Success) return;
 
-    picture->size(SIZE, SIZE);
+    //image scaling preserving its aspect ratio
+    float scale;
+    float shiftX = 0.0f, shiftY = 0.0f;
+    float w, h;
+    picture->size(&w, &h);
+
+    if (w > h) {
+        scale = SIZE / w;
+        shiftY = (SIZE - h * scale) * 0.5f;
+    } else {
+        scale = SIZE / h;
+        shiftX = (SIZE - w * scale) * 0.5f;
+    }
+
+    picture->scale(scale);
+    picture->translate(shiftX, shiftY);
 
     if (canvas->push(move(picture)) != tvg::Result::Success) return;
 

--- a/src/examples/Stress.cpp
+++ b/src/examples/Stress.cpp
@@ -52,14 +52,28 @@ void svgDirCallback(const char* name, const char* path, void* data)
 
     if (picture->load(buf) != tvg::Result::Success) return;
 
-    picture->size(SIZE, SIZE);
-    picture->translate((xCnt % NUM_PER_LINE) * SIZE, SIZE * (xCnt / NUM_PER_LINE));
+    //image scaling preserving its aspect ratio
+    float scale;
+    float shiftX = 0.0f, shiftY = 0.0f;
+    float w, h;
+    picture->size(&w, &h);
+
+    if (w > h) {
+        scale = SIZE / w;
+        shiftY = (SIZE - h * scale) * 0.5f;
+    } else {
+        scale = SIZE / h;
+        shiftX = (SIZE - w * scale) * 0.5f;
+    }
+
+    picture->scale(scale);
+    picture->translate((xCnt % NUM_PER_LINE) * SIZE + shiftX, SIZE * (xCnt / NUM_PER_LINE) + shiftY);
     ++xCnt;
 
     //Duplicates
     for (int i = 0; i < NUM_PER_LINE - 1; i++) {
         tvg::Picture* dup = static_cast<tvg::Picture*>(picture->duplicate());
-        dup->translate((xCnt % NUM_PER_LINE) * SIZE, SIZE * (xCnt / NUM_PER_LINE));
+        dup->translate((xCnt % NUM_PER_LINE) * SIZE + shiftX, SIZE * (xCnt / NUM_PER_LINE) + shiftY);
         pictures.push_back(dup);
         ++xCnt;
     }


### PR DESCRIPTION
changed by 3939b61770c14602d7e349ba0baa21d9f4d97a44