### PR TITLE
svg_loader: fixing crash for to big buffer

### DIFF
--- a/src/loaders/svg/tvgXmlParser.cpp
+++ b/src/loaders/svg/tvgXmlParser.cpp
@@ -304,38 +304,38 @@ bool isIgnoreUnsupportedLogElements(TVG_UNUSED const char* tagName)
 bool simpleXmlParseAttributes(const char* buf, unsigned bufLength, simpleXMLAttributeCb func, const void* data)
 {
     const char *itr = buf, *itrEnd = buf + bufLength;
-    char* tmpBuf = (char*)alloca(bufLength + 1);
+    char* tmpBuf = (char*)malloc(bufLength + 1);
 
-    if (!buf || !func) return false;
+    if (!buf || !func || !tmpBuf) goto error;
 
     while (itr < itrEnd) {
         const char* p = _skipWhiteSpacesAndXmlEntities(itr, itrEnd);
         const char *key, *keyEnd, *value, *valueEnd;
         char* tval;
 
-        if (p == itrEnd) return true;
+        if (p == itrEnd) goto success;
 
         key = p;
         for (keyEnd = key; keyEnd < itrEnd; keyEnd++) {
             if ((*keyEnd == '=') || (isspace((unsigned char)*keyEnd))) break;
         }
-        if (keyEnd == itrEnd) return false;
+        if (keyEnd == itrEnd) goto error;
         if (keyEnd == key) continue;
 
         if (*keyEnd == '=') value = keyEnd + 1;
         else {
             value = (const char*)memchr(keyEnd, '=', itrEnd - keyEnd);
-            if (!value) return false;
+            if (!value) goto error;
             value++;
         }
         keyEnd = _simpleXmlUnskipXmlEntities(keyEnd, key);
 
         value = _skipWhiteSpacesAndXmlEntities(value, itrEnd);
-        if (value == itrEnd) return false;
+        if (value == itrEnd) goto error;
 
         if ((*value == '"') || (*value == '\'')) {
             valueEnd = (const char*)memchr(value + 1, *value, itrEnd - value);
-            if (!valueEnd) return false;
+            if (!valueEnd) goto error;
             value++;
         } else {
             valueEnd = _simpleXmlFindWhiteSpace(value, itrEnd);
@@ -364,7 +364,14 @@ bool simpleXmlParseAttributes(const char* buf, unsigned bufLength, simpleXMLAttr
             }
         }
     }
+
+success:
+    free(tmpBuf);
     return true;
+
+error:
+    free(tmpBuf);
+    return false;
 }
 
 


### PR DESCRIPTION
Crash observed on macOS for the image-embeded-*.svg files. Since the alloca function was used the stack allocation failure could not be handled.