### PR TITLE
svg_loader: overwrite the clip's opacity/alpha

### DIFF
--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -255,7 +255,6 @@ static void _applyComposition(Paint* paint, const SvgNode* node, const Box& vBox
             node->style->clipPath.applying = true;
 
             auto comp = Shape::gen();
-            comp->fill(255, 255, 255, 255);
             if (node->transform) comp->transform(*node->transform);
 
             auto child = compNode->child.data;
@@ -265,8 +264,11 @@ static void _applyComposition(Paint* paint, const SvgNode* node, const Box& vBox
                 if (_appendChildShape(*child, comp.get(), vBox, svgPath)) valid = true;
             }
 
-            if (valid) paint->composite(move(comp), CompositeMethod::ClipPath);
-
+            if (valid) {
+                comp->fill(255, 255, 255, 255);
+                comp->opacity(255);
+                paint->composite(move(comp), CompositeMethod::ClipPath);
+            }
             node->style->clipPath.applying = false;
         }
     }


### PR DESCRIPTION
According to the svg standard the clips opacity
doesn't affect the final rendering. In order to
avoid any confusion the opacity values are
overwritten by the max possible value.

sample:
```
<svg viewBox="0 0 100 100">
  <g fill-opacity="0">
  <clipPath id="myClip">
    <circle cx="40" cy="35" r="35" opacity="0" fill-opacity="0.9"/>
    <circle cx="70" cy="35" r="15" fill-opacity="0"/>
  </clipPath>
 </g>
 <path d="M10,30 A20,20,0,0,1,50,30 A20,20,0,0,1,90,30 Q90,60,50,90 Q10,60,10,30 Z" clip-path="url(#myClip)" />
</svg>
```

before:
<img width="354" alt="Zrzut ekranu 2023-01-17 o 18 38 33" src="https://user-images.githubusercontent.com/67589014/212971971-73448371-bee3-42f3-b389-061b3bb054cf.png">

after:
<img width="354" alt="Zrzut ekranu 2023-01-17 o 18 37 57" src="https://user-images.githubusercontent.com/67589014/212972007-dee2160d-8771-4964-8431-d1185b81b223.png">
